### PR TITLE
feat: lot_id 타임스탬프 기반 고유성 보장 + history에 매도 손익 기록

### DIFF
--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -195,7 +195,8 @@ class MagicSplitEngine:
             if exe.action == OrderAction.BUY:
                 sig = signal_map.get((exe.ticker, OrderAction.BUY))
                 level = sig.level if sig else 1
-                lot_id = f"lot_{today.replace('-', '')}_{exe.ticker}_{level:03d}"
+                ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+                lot_id = f"lot_{ts}_{exe.ticker}_{level:03d}"
                 new_lot = PositionLot(
                     lot_id=lot_id,
                     ticker=exe.ticker,
@@ -246,7 +247,8 @@ class MagicSplitEngine:
         reason = self._build_reason(signals)
 
         self.repo.save_positions(positions)
-        self.repo.save_trade_history(executions, portfolio, reason, sim_date=sim_date)
+        self.repo.save_trade_history(executions, portfolio, reason,
+                                        signals=signals, sim_date=sim_date)
         self.repo.update_status(portfolio, positions, reason, sim_date=sim_date)
 
     # ── Private helpers ──────────────────────────────────────────

--- a/src/core/interfaces.py
+++ b/src/core/interfaces.py
@@ -1,7 +1,7 @@
 # src/core/interfaces.py
 from abc import ABC, abstractmethod
 from typing import List, Dict, Optional
-from src.core.models import Portfolio, Order, TradeExecution, PositionLot
+from src.core.models import Portfolio, Order, TradeExecution, PositionLot, SplitSignal
 
 
 class IBrokerAdapter(ABC):
@@ -43,6 +43,7 @@ class IRepository(ABC):
     @abstractmethod
     def save_trade_history(self, executions: List[TradeExecution],
                            portfolio: Portfolio, reason: str,
+                           signals: Optional[List[SplitSignal]] = None,
                            sim_date: Optional[str] = None) -> None:
         """매매 내역을 저장한다."""
         ...

--- a/src/core/logic/split_evaluator.py
+++ b/src/core/logic/split_evaluator.py
@@ -121,6 +121,7 @@ class SplitEvaluator:
                 reason=f"Lv{last_lot.level} {pct_change:+.1f}% → 익절",
                 pct_change=pct_change,
                 level=last_lot.level,
+                buy_price=last_lot.buy_price,
             )
         return None
 

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -90,6 +90,7 @@ class SplitSignal:
     reason: str             # 판단 사유 (예: "Lv3 +12.3% → 익절")
     pct_change: float       # 매수가 대비 변동률
     level: int = 0          # 대상 차수 (매도: 해당 lot 차수, 매수: 새로운 차수)
+    buy_price: float = 0.0  # 매도 시 원래 매수 단가 (손익 계산용)
 
 
 @dataclass

--- a/src/infra/repo.py
+++ b/src/infra/repo.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 from dataclasses import asdict
 from datetime import datetime
 
-from src.core.models import PositionLot, Portfolio, TradeExecution
+from src.core.models import PositionLot, Portfolio, TradeExecution, SplitSignal, OrderAction
 from src.core.interfaces import IRepository
 
 
@@ -84,6 +84,7 @@ class JsonRepository(IRepository):
 
     def save_trade_history(self, executions: List[TradeExecution],
                            portfolio: Portfolio, reason: str,
+                           signals: Optional[List[SplitSignal]] = None,
                            sim_date: Optional[str] = None) -> None:
         """매매 내역 저장 (Append 방식)"""
         if not executions:
@@ -98,13 +99,33 @@ class JsonRepository(IRepository):
             date_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             tx_id = f"tx_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
 
+        # 신호 매핑: (ticker, action) → signal (손익 정보 enrichment용)
+        signal_map: dict = {}
+        if signals:
+            for sig in signals:
+                signal_map[(sig.ticker, sig.action)] = sig
+
+        enriched_execs = []
+        for e in executions:
+            rec = asdict(e)
+            sig = signal_map.get((e.ticker, OrderAction(e.action)))
+            if sig:
+                rec["lot_id"] = sig.lot_id
+                rec["level"] = sig.level
+                if sig.action == OrderAction.SELL and sig.buy_price > 0:
+                    rec["buy_price"] = sig.buy_price
+                    rec["realized_pnl"] = round(
+                        (e.price - sig.buy_price) * e.quantity - e.fee, 2
+                    )
+            enriched_execs.append(rec)
+
         record = {
             "id": tx_id,
             "date": date_str,
             "portfolio_value": portfolio.total_value,
             "total_trade_amount": trade_amt,
             "reason": reason,
-            "executions": [asdict(e) for e in executions],
+            "executions": enriched_execs,
         }
 
         data = self._load_json(self.history_file, default=[])


### PR DESCRIPTION
- lot_id 생성을 날짜 기반(YYYYMMDD)에서 타임스탬프 기반(YYYYMMDD_HHMMSS)으로
  변경하여 같은 날 동일 레벨 재진입 시 충돌 방지
- SplitSignal에 buy_price 필드 추가 (매도 시 원래 매수가 보존)
- history.json execution 레코드에 lot_id, level, buy_price, realized_pnl 추가
  → 종목별 실현 손익 추적 가능

https://claude.ai/code/session_01QxGtCoraAc6qb4hooZ6uMv