### PR TITLE
feat: MagicSplit 백테스트 시스템 구현

### DIFF
--- a/.github/workflows/run-backtest.yml
+++ b/.github/workflows/run-backtest.yml
@@ -1,0 +1,72 @@
+name: Run MagicSplit Backtest
+
+on:
+  workflow_dispatch:
+    inputs:
+      start:
+        description: '시작 날짜 (예: 2023-01-01)'
+        required: true
+        type: string
+      end:
+        description: '종료 날짜 (예: 2024-12-31)'
+        required: true
+        type: string
+      initial_cash:
+        description: '초기 자본 (기본값: 10000)'
+        required: false
+        type: string
+        default: '10000'
+      config_path:
+        description: 'config.json 경로 (기본값: config_overseas.json)'
+        required: false
+        type: string
+        default: 'config_overseas.json'
+      market_type:
+        description: '마켓 타입 (overseas 또는 domestic)'
+        required: false
+        type: string
+        default: 'overseas'
+
+permissions:
+  contents: write
+
+jobs:
+  backtest:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run backtest
+      run: |
+        python -c "
+        from src.backtest.runner import run_backtest
+        result = run_backtest(
+            config_path='${{ inputs.config_path }}',
+            start_date='${{ inputs.start }}',
+            end_date='${{ inputs.end }}',
+            initial_cash=float('${{ inputs.initial_cash }}'),
+            market_type='${{ inputs.market_type }}',
+        )
+        if result:
+            pf = result.final_portfolio
+            print(f'Final: Cash=\${pf.total_cash:,.0f}, Value=\${pf.total_value:,.0f}')
+        else:
+            print('Backtest returned no result.')
+        "
+
+    - name: Commit and Push Results
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: "backtest result update (${{ inputs.start }} ~ ${{ inputs.end }}) [skip ci]"
+        file_pattern: "docs/data/backtest/** logs/backtest/*"

--- a/logs/backtest/2026-04-13.log
+++ b/logs/backtest/2026-04-13.log
@@ -1,0 +1,534 @@
+2026-04-13 15:09:28,984 [INFO] --- 데이터 다운로드: ['AAPL'] (2024-01-02 ~ 2024-01-15) ---
+2026-04-13 15:09:28,985 [INFO] --- 백테스트 시작 (10 거래일) ---
+2026-04-13 15:09:28,987 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:28,988 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:28,988 [INFO] Portfolio: Cash=$10,000, Value=$10,000
+2026-04-13 15:09:28,988 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:28,989 [INFO] Loaded 0 position lot(s)
+2026-04-13 15:09:28,989 [INFO] >>> Processing AAPL
+2026-04-13 15:09:28,989 [INFO] [AAPL] 보유 lot 없음 → 초기 매수 Lv1 5주 @$100.00
+2026-04-13 15:09:28,989 [INFO] Executing 1 order(s)...
+2026-04-13 15:09:28,989 [INFO] [FILLED] BUY AAPL: 5 @ $100.10 (Fee: $1.25)
+2026-04-13 15:09:28,990 [INFO] [Position] New lot: lot_20260413_150928_AAPL_001 Lv1 AAPL 5주 @$100.10
+2026-04-13 15:09:28,990 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:28,993 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:28,993 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:28,993 [INFO] Portfolio: Cash=$9,498, Value=$9,988
+2026-04-13 15:09:28,993 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:28,994 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:09:28,994 [INFO] >>> Processing AAPL
+2026-04-13 15:09:28,994 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:28,994 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:28,997 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:28,997 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:28,997 [INFO] Portfolio: Cash=$9,498, Value=$9,978
+2026-04-13 15:09:28,997 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:28,998 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:09:28,998 [INFO] >>> Processing AAPL
+2026-04-13 15:09:28,998 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:28,998 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,000 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,000 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,001 [INFO] Portfolio: Cash=$9,498, Value=$9,968
+2026-04-13 15:09:29,001 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,001 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:09:29,001 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,001 [INFO] [AAPL] Lv1 매수가 $100.10 대비 -6.1% → 추가 매수 Lv2 5주 @$94.00
+2026-04-13 15:09:29,002 [INFO] Executing 1 order(s)...
+2026-04-13 15:09:29,002 [INFO] [FILLED] BUY AAPL: 5 @ $94.09 (Fee: $1.18)
+2026-04-13 15:09:29,002 [INFO] [Position] New lot: lot_20260413_150929_AAPL_002 Lv2 AAPL 5주 @$94.09
+2026-04-13 15:09:29,002 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,005 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,005 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,006 [INFO] Portfolio: Cash=$9,027, Value=$9,947
+2026-04-13 15:09:29,006 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,006 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:09:29,006 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,007 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:29,007 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,009 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,009 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,009 [INFO] Portfolio: Cash=$9,027, Value=$9,927
+2026-04-13 15:09:29,009 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,010 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:09:29,010 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,010 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:29,010 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,012 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,013 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,013 [INFO] Portfolio: Cash=$9,027, Value=$9,907
+2026-04-13 15:09:29,013 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,014 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:09:29,014 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,014 [INFO] [AAPL] Lv2 매수가 $94.09 대비 -6.5% → 추가 매수 Lv3 5주 @$88.00
+2026-04-13 15:09:29,014 [INFO] Executing 1 order(s)...
+2026-04-13 15:09:29,015 [INFO] [FILLED] BUY AAPL: 5 @ $88.09 (Fee: $1.10)
+2026-04-13 15:09:29,015 [INFO] [Position] New lot: lot_20260413_150929_AAPL_003 Lv3 AAPL 5주 @$88.09
+2026-04-13 15:09:29,015 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,018 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,018 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,018 [INFO] Portfolio: Cash=$8,585, Value=$9,875
+2026-04-13 15:09:29,018 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,019 [INFO] Loaded 3 position lot(s)
+2026-04-13 15:09:29,019 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,020 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:29,020 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,022 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,023 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,023 [INFO] Portfolio: Cash=$8,585, Value=$9,845
+2026-04-13 15:09:29,023 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,024 [INFO] Loaded 3 position lot(s)
+2026-04-13 15:09:29,024 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,024 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:29,024 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,026 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,026 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,026 [INFO] Portfolio: Cash=$8,585, Value=$9,815
+2026-04-13 15:09:29,026 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,027 [INFO] Loaded 3 position lot(s)
+2026-04-13 15:09:29,027 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,028 [INFO] [AAPL] Lv3 매수가 $88.09 대비 -6.9% → 추가 매수 Lv4 6주 @$82.00
+2026-04-13 15:09:29,028 [INFO] Executing 1 order(s)...
+2026-04-13 15:09:29,028 [INFO] [FILLED] BUY AAPL: 6 @ $82.08 (Fee: $1.23)
+2026-04-13 15:09:29,029 [INFO] [Position] New lot: lot_20260413_150929_AAPL_004 Lv4 AAPL 6주 @$82.08
+2026-04-13 15:09:29,029 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,032 [INFO] --- 백테스트 완료 ---
+2026-04-13 15:09:29,032 [INFO] 최종: Cash=$8,091, Value=$9,813
+2026-04-13 15:09:29,040 [INFO] --- 데이터 다운로드: ['AAPL'] (2024-01-02 ~ 2024-01-08) ---
+2026-04-13 15:09:29,041 [INFO] --- 백테스트 시작 (5 거래일) ---
+2026-04-13 15:09:29,042 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,042 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,042 [INFO] Portfolio: Cash=$10,000, Value=$10,000
+2026-04-13 15:09:29,042 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,043 [INFO] Loaded 0 position lot(s)
+2026-04-13 15:09:29,044 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,044 [INFO] [AAPL] 보유 lot 없음 → 초기 매수 Lv1 5주 @$100.00
+2026-04-13 15:09:29,044 [INFO] Executing 1 order(s)...
+2026-04-13 15:09:29,044 [INFO] [FILLED] BUY AAPL: 5 @ $100.10 (Fee: $1.25)
+2026-04-13 15:09:29,044 [INFO] [Position] New lot: lot_20260413_150929_AAPL_001 Lv1 AAPL 5주 @$100.10
+2026-04-13 15:09:29,044 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,047 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,047 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,047 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-13 15:09:29,048 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,048 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:09:29,048 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,048 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:29,048 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,050 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,050 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,050 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-13 15:09:29,050 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,051 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:09:29,051 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,051 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:29,051 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,053 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,054 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,054 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-13 15:09:29,054 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,055 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:09:29,055 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,056 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:29,056 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,058 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,058 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,058 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-13 15:09:29,058 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,059 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:09:29,059 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,059 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:29,059 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,061 [INFO] --- 백테스트 완료 ---
+2026-04-13 15:09:29,061 [INFO] 최종: Cash=$9,498, Value=$9,998
+2026-04-13 15:09:29,069 [WARNING] 'overseas' 마켓에 해당하는 종목이 없습니다.
+2026-04-13 15:09:29,076 [INFO] --- 데이터 다운로드: ['AAPL', 'MSFT'] (2024-01-02 ~ 2024-01-15) ---
+2026-04-13 15:09:29,078 [INFO] --- 백테스트 시작 (10 거래일) ---
+2026-04-13 15:09:29,079 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,079 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,080 [INFO] Portfolio: Cash=$10,000, Value=$10,000
+2026-04-13 15:09:29,080 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,080 [INFO] Loaded 0 position lot(s)
+2026-04-13 15:09:29,080 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,080 [INFO] [AAPL] 보유 lot 없음 → 초기 매수 Lv1 3주 @$100.00
+2026-04-13 15:09:29,080 [INFO] Executing 1 order(s)...
+2026-04-13 15:09:29,081 [INFO] [FILLED] BUY AAPL: 3 @ $100.10 (Fee: $0.75)
+2026-04-13 15:09:29,081 [INFO] [Position] New lot: lot_20260413_150929_AAPL_001 Lv1 AAPL 3주 @$100.10
+2026-04-13 15:09:29,081 [INFO] >>> Processing MSFT
+2026-04-13 15:09:29,081 [INFO] [MSFT] 보유 lot 없음 → 초기 매수 Lv1 3주 @$100.00
+2026-04-13 15:09:29,082 [INFO] Executing 1 order(s)...
+2026-04-13 15:09:29,082 [INFO] [FILLED] BUY MSFT: 3 @ $100.10 (Fee: $0.75)
+2026-04-13 15:09:29,082 [INFO] [Position] New lot: lot_20260413_150929_MSFT_001 Lv1 MSFT 3주 @$100.10
+2026-04-13 15:09:29,082 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,085 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,086 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,086 [INFO] Portfolio: Cash=$9,398, Value=$9,992
+2026-04-13 15:09:29,086 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,087 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:09:29,087 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,087 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:29,087 [INFO] >>> Processing MSFT
+2026-04-13 15:09:29,087 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:09:29,087 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,090 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,090 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,091 [INFO] Portfolio: Cash=$9,398, Value=$9,986
+2026-04-13 15:09:29,091 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,091 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:09:29,091 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,091 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:29,092 [INFO] >>> Processing MSFT
+2026-04-13 15:09:29,092 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:09:29,092 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,094 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,094 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,095 [INFO] Portfolio: Cash=$9,398, Value=$9,980
+2026-04-13 15:09:29,095 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,095 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:09:29,096 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,096 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:29,096 [INFO] >>> Processing MSFT
+2026-04-13 15:09:29,096 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:09:29,096 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,099 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,099 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,099 [INFO] Portfolio: Cash=$9,398, Value=$9,974
+2026-04-13 15:09:29,099 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,100 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:09:29,100 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,100 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:29,100 [INFO] >>> Processing MSFT
+2026-04-13 15:09:29,100 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:09:29,100 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,103 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,103 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,103 [INFO] Portfolio: Cash=$9,398, Value=$9,968
+2026-04-13 15:09:29,103 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,103 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:09:29,104 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,104 [INFO] [AAPL] Lv1 매수가 $100.10 대비 -5.1% → 추가 매수 Lv2 3주 @$95.00
+2026-04-13 15:09:29,105 [INFO] Executing 1 order(s)...
+2026-04-13 15:09:29,105 [INFO] [FILLED] BUY AAPL: 3 @ $95.09 (Fee: $0.71)
+2026-04-13 15:09:29,105 [INFO] [Position] New lot: lot_20260413_150929_AAPL_002 Lv2 AAPL 3주 @$95.09
+2026-04-13 15:09:29,105 [INFO] >>> Processing MSFT
+2026-04-13 15:09:29,105 [INFO] [MSFT] Lv1 매수가 $100.10 대비 -5.1% → 추가 매수 Lv2 3주 @$95.00
+2026-04-13 15:09:29,105 [INFO] Executing 1 order(s)...
+2026-04-13 15:09:29,105 [INFO] [FILLED] BUY MSFT: 3 @ $95.09 (Fee: $0.71)
+2026-04-13 15:09:29,105 [INFO] [Position] New lot: lot_20260413_150929_MSFT_002 Lv2 MSFT 3주 @$95.09
+2026-04-13 15:09:29,105 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,110 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,110 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,110 [INFO] Portfolio: Cash=$8,826, Value=$9,954
+2026-04-13 15:09:29,111 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,111 [INFO] Loaded 4 position lot(s)
+2026-04-13 15:09:29,111 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,111 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:29,111 [INFO] >>> Processing MSFT
+2026-04-13 15:09:29,112 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:09:29,112 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,114 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,115 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,115 [INFO] Portfolio: Cash=$8,826, Value=$9,942
+2026-04-13 15:09:29,116 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,116 [INFO] Loaded 4 position lot(s)
+2026-04-13 15:09:29,116 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,116 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:29,116 [INFO] >>> Processing MSFT
+2026-04-13 15:09:29,117 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:09:29,117 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,119 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,119 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,120 [INFO] Portfolio: Cash=$8,826, Value=$9,930
+2026-04-13 15:09:29,120 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,120 [INFO] Loaded 4 position lot(s)
+2026-04-13 15:09:29,121 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,121 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:29,121 [INFO] >>> Processing MSFT
+2026-04-13 15:09:29,121 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:09:29,121 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,124 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:29,124 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:29,124 [INFO] Portfolio: Cash=$8,826, Value=$9,918
+2026-04-13 15:09:29,124 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:29,125 [INFO] Loaded 4 position lot(s)
+2026-04-13 15:09:29,125 [INFO] >>> Processing AAPL
+2026-04-13 15:09:29,125 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:29,125 [INFO] >>> Processing MSFT
+2026-04-13 15:09:29,125 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:09:29,125 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:29,127 [INFO] --- 백테스트 완료 ---
+2026-04-13 15:09:29,127 [INFO] 최종: Cash=$8,826, Value=$9,918
+2026-04-13 15:09:29,136 [INFO] --- 데이터 다운로드: ['AAPL'] (2024-01-02 ~ 2024-01-08) ---
+2026-04-13 15:09:29,137 [WARNING] 데이터 미수신 티커 ['AAPL'] — 백테스트를 중단합니다.
+2026-04-13 15:09:43,131 [INFO] --- 데이터 다운로드: ['AAPL'] (2024-01-02 ~ 2024-01-15) ---
+2026-04-13 15:09:43,134 [INFO] --- 백테스트 시작 (10 거래일) ---
+2026-04-13 15:09:43,135 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,135 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,135 [INFO] Portfolio: Cash=$10,000, Value=$10,000
+2026-04-13 15:09:43,136 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,136 [INFO] Loaded 0 position lot(s)
+2026-04-13 15:09:43,136 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,137 [INFO] [AAPL] 보유 lot 없음 → 초기 매수 Lv1 5주 @$100.00
+2026-04-13 15:09:43,137 [INFO] Executing 1 order(s)...
+2026-04-13 15:09:43,137 [INFO] [FILLED] BUY AAPL: 5 @ $100.10 (Fee: $1.25)
+2026-04-13 15:09:43,138 [INFO] [Position] New lot: lot_20260413_150943_AAPL_001 Lv1 AAPL 5주 @$100.10
+2026-04-13 15:09:43,138 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,142 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,143 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,144 [INFO] Portfolio: Cash=$9,498, Value=$9,988
+2026-04-13 15:09:43,144 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,145 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:09:43,145 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,146 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:43,146 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,149 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,150 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,150 [INFO] Portfolio: Cash=$9,498, Value=$9,978
+2026-04-13 15:09:43,150 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,151 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:09:43,151 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,151 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:43,151 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,154 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,155 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,155 [INFO] Portfolio: Cash=$9,498, Value=$9,968
+2026-04-13 15:09:43,155 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,158 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:09:43,160 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,161 [INFO] [AAPL] Lv1 매수가 $100.10 대비 -6.1% → 추가 매수 Lv2 5주 @$94.00
+2026-04-13 15:09:43,162 [INFO] Executing 1 order(s)...
+2026-04-13 15:09:43,163 [INFO] [FILLED] BUY AAPL: 5 @ $94.09 (Fee: $1.18)
+2026-04-13 15:09:43,164 [INFO] [Position] New lot: lot_20260413_150943_AAPL_002 Lv2 AAPL 5주 @$94.09
+2026-04-13 15:09:43,164 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,172 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,172 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,173 [INFO] Portfolio: Cash=$9,027, Value=$9,947
+2026-04-13 15:09:43,174 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,175 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:09:43,175 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,175 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:43,175 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,179 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,179 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,180 [INFO] Portfolio: Cash=$9,027, Value=$9,927
+2026-04-13 15:09:43,180 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,181 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:09:43,181 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,181 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:43,182 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,185 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,186 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,186 [INFO] Portfolio: Cash=$9,027, Value=$9,907
+2026-04-13 15:09:43,187 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,188 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:09:43,188 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,189 [INFO] [AAPL] Lv2 매수가 $94.09 대비 -6.5% → 추가 매수 Lv3 5주 @$88.00
+2026-04-13 15:09:43,189 [INFO] Executing 1 order(s)...
+2026-04-13 15:09:43,189 [INFO] [FILLED] BUY AAPL: 5 @ $88.09 (Fee: $1.10)
+2026-04-13 15:09:43,189 [INFO] [Position] New lot: lot_20260413_150943_AAPL_003 Lv3 AAPL 5주 @$88.09
+2026-04-13 15:09:43,190 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,194 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,194 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,194 [INFO] Portfolio: Cash=$8,585, Value=$9,875
+2026-04-13 15:09:43,195 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,195 [INFO] Loaded 3 position lot(s)
+2026-04-13 15:09:43,196 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,196 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:43,196 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,199 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,200 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,201 [INFO] Portfolio: Cash=$8,585, Value=$9,845
+2026-04-13 15:09:43,202 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,203 [INFO] Loaded 3 position lot(s)
+2026-04-13 15:09:43,203 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,203 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:43,203 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,206 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,206 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,206 [INFO] Portfolio: Cash=$8,585, Value=$9,815
+2026-04-13 15:09:43,207 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,207 [INFO] Loaded 3 position lot(s)
+2026-04-13 15:09:43,207 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,208 [INFO] [AAPL] Lv3 매수가 $88.09 대비 -6.9% → 추가 매수 Lv4 6주 @$82.00
+2026-04-13 15:09:43,208 [INFO] Executing 1 order(s)...
+2026-04-13 15:09:43,208 [INFO] [FILLED] BUY AAPL: 6 @ $82.08 (Fee: $1.23)
+2026-04-13 15:09:43,208 [INFO] [Position] New lot: lot_20260413_150943_AAPL_004 Lv4 AAPL 6주 @$82.08
+2026-04-13 15:09:43,208 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,213 [INFO] --- 백테스트 완료 ---
+2026-04-13 15:09:43,214 [INFO] 최종: Cash=$8,091, Value=$9,813
+2026-04-13 15:09:43,225 [INFO] --- 데이터 다운로드: ['AAPL'] (2024-01-02 ~ 2024-01-08) ---
+2026-04-13 15:09:43,226 [INFO] --- 백테스트 시작 (5 거래일) ---
+2026-04-13 15:09:43,227 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,227 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,227 [INFO] Portfolio: Cash=$10,000, Value=$10,000
+2026-04-13 15:09:43,227 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,228 [INFO] Loaded 0 position lot(s)
+2026-04-13 15:09:43,228 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,228 [INFO] [AAPL] 보유 lot 없음 → 초기 매수 Lv1 5주 @$100.00
+2026-04-13 15:09:43,228 [INFO] Executing 1 order(s)...
+2026-04-13 15:09:43,228 [INFO] [FILLED] BUY AAPL: 5 @ $100.10 (Fee: $1.25)
+2026-04-13 15:09:43,229 [INFO] [Position] New lot: lot_20260413_150943_AAPL_001 Lv1 AAPL 5주 @$100.10
+2026-04-13 15:09:43,229 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,232 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,233 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,233 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-13 15:09:43,233 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,234 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:09:43,234 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,234 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:43,234 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,237 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,237 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,237 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-13 15:09:43,237 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,238 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:09:43,239 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,239 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:43,239 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,242 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,242 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,243 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-13 15:09:43,243 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,244 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:09:43,244 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,244 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:43,244 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,247 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,247 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,247 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-13 15:09:43,247 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,248 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:09:43,248 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,248 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:43,249 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,250 [INFO] --- 백테스트 완료 ---
+2026-04-13 15:09:43,250 [INFO] 최종: Cash=$9,498, Value=$9,998
+2026-04-13 15:09:43,258 [WARNING] 'overseas' 마켓에 해당하는 종목이 없습니다.
+2026-04-13 15:09:43,266 [INFO] --- 데이터 다운로드: ['AAPL', 'MSFT'] (2024-01-02 ~ 2024-01-15) ---
+2026-04-13 15:09:43,268 [INFO] --- 백테스트 시작 (10 거래일) ---
+2026-04-13 15:09:43,269 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,270 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,270 [INFO] Portfolio: Cash=$10,000, Value=$10,000
+2026-04-13 15:09:43,270 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,271 [INFO] Loaded 0 position lot(s)
+2026-04-13 15:09:43,271 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,271 [INFO] [AAPL] 보유 lot 없음 → 초기 매수 Lv1 3주 @$100.00
+2026-04-13 15:09:43,271 [INFO] Executing 1 order(s)...
+2026-04-13 15:09:43,272 [INFO] [FILLED] BUY AAPL: 3 @ $100.10 (Fee: $0.75)
+2026-04-13 15:09:43,272 [INFO] [Position] New lot: lot_20260413_150943_AAPL_001 Lv1 AAPL 3주 @$100.10
+2026-04-13 15:09:43,272 [INFO] >>> Processing MSFT
+2026-04-13 15:09:43,272 [INFO] [MSFT] 보유 lot 없음 → 초기 매수 Lv1 3주 @$100.00
+2026-04-13 15:09:43,272 [INFO] Executing 1 order(s)...
+2026-04-13 15:09:43,272 [INFO] [FILLED] BUY MSFT: 3 @ $100.10 (Fee: $0.75)
+2026-04-13 15:09:43,272 [INFO] [Position] New lot: lot_20260413_150943_MSFT_001 Lv1 MSFT 3주 @$100.10
+2026-04-13 15:09:43,273 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,278 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,278 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,279 [INFO] Portfolio: Cash=$9,398, Value=$9,992
+2026-04-13 15:09:43,279 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,280 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:09:43,281 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,281 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:43,282 [INFO] >>> Processing MSFT
+2026-04-13 15:09:43,282 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:09:43,282 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,285 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,286 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,286 [INFO] Portfolio: Cash=$9,398, Value=$9,986
+2026-04-13 15:09:43,286 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,287 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:09:43,287 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,287 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:43,287 [INFO] >>> Processing MSFT
+2026-04-13 15:09:43,287 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:09:43,288 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,291 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,291 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,291 [INFO] Portfolio: Cash=$9,398, Value=$9,980
+2026-04-13 15:09:43,291 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,292 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:09:43,292 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,292 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:43,292 [INFO] >>> Processing MSFT
+2026-04-13 15:09:43,292 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:09:43,292 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,295 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,295 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,295 [INFO] Portfolio: Cash=$9,398, Value=$9,974
+2026-04-13 15:09:43,295 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,296 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:09:43,296 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,297 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:43,297 [INFO] >>> Processing MSFT
+2026-04-13 15:09:43,298 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:09:43,298 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,301 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,301 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,301 [INFO] Portfolio: Cash=$9,398, Value=$9,968
+2026-04-13 15:09:43,301 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,302 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:09:43,302 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,303 [INFO] [AAPL] Lv1 매수가 $100.10 대비 -5.1% → 추가 매수 Lv2 3주 @$95.00
+2026-04-13 15:09:43,303 [INFO] Executing 1 order(s)...
+2026-04-13 15:09:43,303 [INFO] [FILLED] BUY AAPL: 3 @ $95.09 (Fee: $0.71)
+2026-04-13 15:09:43,303 [INFO] [Position] New lot: lot_20260413_150943_AAPL_002 Lv2 AAPL 3주 @$95.09
+2026-04-13 15:09:43,303 [INFO] >>> Processing MSFT
+2026-04-13 15:09:43,303 [INFO] [MSFT] Lv1 매수가 $100.10 대비 -5.1% → 추가 매수 Lv2 3주 @$95.00
+2026-04-13 15:09:43,304 [INFO] Executing 1 order(s)...
+2026-04-13 15:09:43,304 [INFO] [FILLED] BUY MSFT: 3 @ $95.09 (Fee: $0.71)
+2026-04-13 15:09:43,304 [INFO] [Position] New lot: lot_20260413_150943_MSFT_002 Lv2 MSFT 3주 @$95.09
+2026-04-13 15:09:43,304 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,308 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,308 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,309 [INFO] Portfolio: Cash=$8,826, Value=$9,954
+2026-04-13 15:09:43,309 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,310 [INFO] Loaded 4 position lot(s)
+2026-04-13 15:09:43,310 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,310 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:43,310 [INFO] >>> Processing MSFT
+2026-04-13 15:09:43,310 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:09:43,310 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,314 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,314 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,314 [INFO] Portfolio: Cash=$8,826, Value=$9,942
+2026-04-13 15:09:43,314 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,315 [INFO] Loaded 4 position lot(s)
+2026-04-13 15:09:43,316 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,316 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:43,316 [INFO] >>> Processing MSFT
+2026-04-13 15:09:43,316 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:09:43,316 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,319 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,319 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,320 [INFO] Portfolio: Cash=$8,826, Value=$9,930
+2026-04-13 15:09:43,322 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,324 [INFO] Loaded 4 position lot(s)
+2026-04-13 15:09:43,325 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,325 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:43,326 [INFO] >>> Processing MSFT
+2026-04-13 15:09:43,326 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:09:43,326 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,330 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:09:43,330 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:09:43,330 [INFO] Portfolio: Cash=$8,826, Value=$9,918
+2026-04-13 15:09:43,331 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:09:43,331 [INFO] Loaded 4 position lot(s)
+2026-04-13 15:09:43,332 [INFO] >>> Processing AAPL
+2026-04-13 15:09:43,332 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:09:43,332 [INFO] >>> Processing MSFT
+2026-04-13 15:09:43,332 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:09:43,332 [INFO] >>> Step 6: Persist
+2026-04-13 15:09:43,335 [INFO] --- 백테스트 완료 ---
+2026-04-13 15:09:43,335 [INFO] 최종: Cash=$8,826, Value=$9,918
+2026-04-13 15:09:43,348 [INFO] --- 데이터 다운로드: ['AAPL'] (2024-01-02 ~ 2024-01-08) ---
+2026-04-13 15:09:43,349 [WARNING] 데이터 미수신 티커 ['AAPL'] — 백테스트를 중단합니다.
+2026-04-13 15:09:43,707 [INFO] === Initializing MagicSplit Bot (single account) ===
+2026-04-13 15:09:43,708 [INFO] Loaded 1 stock rule(s) from /tmp/pytest-of-root/pytest-1/test_init_and_run0/config.json
+2026-04-13 15:09:43,708 [INFO] [overseas] 1 rule(s), mode=PAPER
+2026-04-13 15:09:43,709 [INFO] === Running overseas engine ===
+2026-04-13 15:09:43,721 [INFO] === Initializing MagicSplit Bot (single account) ===
+2026-04-13 15:09:43,722 [INFO] Loaded 1 stock rule(s) from /tmp/pytest-of-root/pytest-1/test_run_engine_failure_raises0/config.json
+2026-04-13 15:09:43,722 [INFO] [overseas] 1 rule(s), mode=PAPER
+2026-04-13 15:09:43,725 [INFO] === Running overseas engine ===
+2026-04-13 15:09:43,740 [INFO] === Initializing MagicSplit Bot (single account) ===
+2026-04-13 15:09:43,741 [INFO] Loaded 1 stock rule(s) from /tmp/pytest-of-root/pytest-1/test_no_active_stocks_raises0/config.json

--- a/logs/backtest/2026-04-13.log
+++ b/logs/backtest/2026-04-13.log
@@ -532,3 +532,275 @@
 2026-04-13 15:09:43,725 [INFO] === Running overseas engine ===
 2026-04-13 15:09:43,740 [INFO] === Initializing MagicSplit Bot (single account) ===
 2026-04-13 15:09:43,741 [INFO] Loaded 1 stock rule(s) from /tmp/pytest-of-root/pytest-1/test_no_active_stocks_raises0/config.json
+2026-04-13 15:28:43,250 [INFO] --- 데이터 다운로드: ['AAPL'] (2024-01-02 ~ 2024-01-15) ---
+2026-04-13 15:28:43,253 [INFO] --- 백테스트 시작 (10 거래일) ---
+2026-04-13 15:28:43,255 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,255 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,255 [INFO] Portfolio: Cash=$10,000, Value=$10,000
+2026-04-13 15:28:43,255 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,256 [INFO] Loaded 0 position lot(s)
+2026-04-13 15:28:43,256 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,256 [INFO] [AAPL] 보유 lot 없음 → 초기 매수 Lv1 5주 @$100.00
+2026-04-13 15:28:43,256 [INFO] Executing 1 order(s)...
+2026-04-13 15:28:43,257 [INFO] [FILLED] BUY AAPL: 5 @ $100.10 (Fee: $1.25)
+2026-04-13 15:28:43,257 [INFO] [Position] New lot: lot_20260413_152843_AAPL_001 Lv1 AAPL 5주 @$100.10
+2026-04-13 15:28:43,258 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,262 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,262 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,262 [INFO] Portfolio: Cash=$9,498, Value=$9,988
+2026-04-13 15:28:43,263 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,263 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:28:43,263 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,263 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:28:43,264 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,266 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,266 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,266 [INFO] Portfolio: Cash=$9,498, Value=$9,978
+2026-04-13 15:28:43,266 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,267 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:28:43,267 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,267 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:28:43,268 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,270 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,270 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,270 [INFO] Portfolio: Cash=$9,498, Value=$9,968
+2026-04-13 15:28:43,270 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,271 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:28:43,271 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,271 [INFO] [AAPL] Lv1 매수가 $100.10 대비 -6.1% → 추가 매수 Lv2 5주 @$94.00
+2026-04-13 15:28:43,271 [INFO] Executing 1 order(s)...
+2026-04-13 15:28:43,272 [INFO] [FILLED] BUY AAPL: 5 @ $94.09 (Fee: $1.18)
+2026-04-13 15:28:43,272 [INFO] [Position] New lot: lot_20260413_152843_AAPL_002 Lv2 AAPL 5주 @$94.09
+2026-04-13 15:28:43,272 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,275 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,275 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,275 [INFO] Portfolio: Cash=$9,027, Value=$9,947
+2026-04-13 15:28:43,276 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,276 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:28:43,277 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,277 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:28:43,277 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,279 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,280 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,280 [INFO] Portfolio: Cash=$9,027, Value=$9,927
+2026-04-13 15:28:43,280 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,281 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:28:43,281 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,281 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:28:43,281 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,284 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,287 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,288 [INFO] Portfolio: Cash=$9,027, Value=$9,907
+2026-04-13 15:28:43,289 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,291 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:28:43,291 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,291 [INFO] [AAPL] Lv2 매수가 $94.09 대비 -6.5% → 추가 매수 Lv3 5주 @$88.00
+2026-04-13 15:28:43,291 [INFO] Executing 1 order(s)...
+2026-04-13 15:28:43,292 [INFO] [FILLED] BUY AAPL: 5 @ $88.09 (Fee: $1.10)
+2026-04-13 15:28:43,292 [INFO] [Position] New lot: lot_20260413_152843_AAPL_003 Lv3 AAPL 5주 @$88.09
+2026-04-13 15:28:43,293 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,298 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,298 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,298 [INFO] Portfolio: Cash=$8,585, Value=$9,875
+2026-04-13 15:28:43,298 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,299 [INFO] Loaded 3 position lot(s)
+2026-04-13 15:28:43,299 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,300 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:28:43,300 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,303 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,303 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,303 [INFO] Portfolio: Cash=$8,585, Value=$9,845
+2026-04-13 15:28:43,303 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,304 [INFO] Loaded 3 position lot(s)
+2026-04-13 15:28:43,304 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,304 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:28:43,305 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,307 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,308 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,308 [INFO] Portfolio: Cash=$8,585, Value=$9,815
+2026-04-13 15:28:43,308 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,309 [INFO] Loaded 3 position lot(s)
+2026-04-13 15:28:43,309 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,309 [INFO] [AAPL] Lv3 매수가 $88.09 대비 -6.9% → 추가 매수 Lv4 6주 @$82.00
+2026-04-13 15:28:43,310 [INFO] Executing 1 order(s)...
+2026-04-13 15:28:43,310 [INFO] [FILLED] BUY AAPL: 6 @ $82.08 (Fee: $1.23)
+2026-04-13 15:28:43,310 [INFO] [Position] New lot: lot_20260413_152843_AAPL_004 Lv4 AAPL 6주 @$82.08
+2026-04-13 15:28:43,310 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,313 [INFO] --- 백테스트 완료 ---
+2026-04-13 15:28:43,314 [INFO] 최종: Cash=$8,091, Value=$9,813
+2026-04-13 15:28:43,324 [INFO] --- 데이터 다운로드: ['AAPL'] (2024-01-02 ~ 2024-01-08) ---
+2026-04-13 15:28:43,326 [INFO] --- 백테스트 시작 (5 거래일) ---
+2026-04-13 15:28:43,326 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,327 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,327 [INFO] Portfolio: Cash=$10,000, Value=$10,000
+2026-04-13 15:28:43,327 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,327 [INFO] Loaded 0 position lot(s)
+2026-04-13 15:28:43,327 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,328 [INFO] [AAPL] 보유 lot 없음 → 초기 매수 Lv1 5주 @$100.00
+2026-04-13 15:28:43,328 [INFO] Executing 1 order(s)...
+2026-04-13 15:28:43,328 [INFO] [FILLED] BUY AAPL: 5 @ $100.10 (Fee: $1.25)
+2026-04-13 15:28:43,328 [INFO] [Position] New lot: lot_20260413_152843_AAPL_001 Lv1 AAPL 5주 @$100.10
+2026-04-13 15:28:43,328 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,332 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,332 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,332 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-13 15:28:43,333 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,333 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:28:43,334 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,334 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:28:43,334 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,336 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,337 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,337 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-13 15:28:43,337 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,337 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:28:43,338 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,338 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:28:43,338 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,340 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,340 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,340 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-13 15:28:43,340 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,341 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:28:43,341 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,341 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:28:43,341 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,344 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,344 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,344 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-13 15:28:43,344 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,345 [INFO] Loaded 1 position lot(s)
+2026-04-13 15:28:43,345 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,346 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:28:43,346 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,347 [INFO] --- 백테스트 완료 ---
+2026-04-13 15:28:43,348 [INFO] 최종: Cash=$9,498, Value=$9,998
+2026-04-13 15:28:43,355 [WARNING] 'overseas' 마켓에 해당하는 종목이 없습니다.
+2026-04-13 15:28:43,364 [INFO] --- 데이터 다운로드: ['AAPL', 'MSFT'] (2024-01-02 ~ 2024-01-15) ---
+2026-04-13 15:28:43,366 [INFO] --- 백테스트 시작 (10 거래일) ---
+2026-04-13 15:28:43,367 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,367 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,367 [INFO] Portfolio: Cash=$10,000, Value=$10,000
+2026-04-13 15:28:43,367 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,368 [INFO] Loaded 0 position lot(s)
+2026-04-13 15:28:43,368 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,368 [INFO] [AAPL] 보유 lot 없음 → 초기 매수 Lv1 3주 @$100.00
+2026-04-13 15:28:43,368 [INFO] Executing 1 order(s)...
+2026-04-13 15:28:43,369 [INFO] [FILLED] BUY AAPL: 3 @ $100.10 (Fee: $0.75)
+2026-04-13 15:28:43,369 [INFO] [Position] New lot: lot_20260413_152843_AAPL_001 Lv1 AAPL 3주 @$100.10
+2026-04-13 15:28:43,369 [INFO] >>> Processing MSFT
+2026-04-13 15:28:43,369 [INFO] [MSFT] 보유 lot 없음 → 초기 매수 Lv1 3주 @$100.00
+2026-04-13 15:28:43,369 [INFO] Executing 1 order(s)...
+2026-04-13 15:28:43,369 [INFO] [FILLED] BUY MSFT: 3 @ $100.10 (Fee: $0.75)
+2026-04-13 15:28:43,369 [INFO] [Position] New lot: lot_20260413_152843_MSFT_001 Lv1 MSFT 3주 @$100.10
+2026-04-13 15:28:43,370 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,373 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,373 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,373 [INFO] Portfolio: Cash=$9,398, Value=$9,992
+2026-04-13 15:28:43,374 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,374 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:28:43,375 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,375 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:28:43,375 [INFO] >>> Processing MSFT
+2026-04-13 15:28:43,375 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:28:43,375 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,378 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,378 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,378 [INFO] Portfolio: Cash=$9,398, Value=$9,986
+2026-04-13 15:28:43,378 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,379 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:28:43,379 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,379 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:28:43,379 [INFO] >>> Processing MSFT
+2026-04-13 15:28:43,379 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:28:43,379 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,382 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,382 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,382 [INFO] Portfolio: Cash=$9,398, Value=$9,980
+2026-04-13 15:28:43,382 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,383 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:28:43,383 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,383 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:28:43,383 [INFO] >>> Processing MSFT
+2026-04-13 15:28:43,383 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:28:43,384 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,386 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,386 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,386 [INFO] Portfolio: Cash=$9,398, Value=$9,974
+2026-04-13 15:28:43,386 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,387 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:28:43,387 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,388 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:28:43,388 [INFO] >>> Processing MSFT
+2026-04-13 15:28:43,388 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:28:43,388 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,390 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,390 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,391 [INFO] Portfolio: Cash=$9,398, Value=$9,968
+2026-04-13 15:28:43,391 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,391 [INFO] Loaded 2 position lot(s)
+2026-04-13 15:28:43,391 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,392 [INFO] [AAPL] Lv1 매수가 $100.10 대비 -5.1% → 추가 매수 Lv2 3주 @$95.00
+2026-04-13 15:28:43,392 [INFO] Executing 1 order(s)...
+2026-04-13 15:28:43,392 [INFO] [FILLED] BUY AAPL: 3 @ $95.09 (Fee: $0.71)
+2026-04-13 15:28:43,392 [INFO] [Position] New lot: lot_20260413_152843_AAPL_002 Lv2 AAPL 3주 @$95.09
+2026-04-13 15:28:43,392 [INFO] >>> Processing MSFT
+2026-04-13 15:28:43,392 [INFO] [MSFT] Lv1 매수가 $100.10 대비 -5.1% → 추가 매수 Lv2 3주 @$95.00
+2026-04-13 15:28:43,393 [INFO] Executing 1 order(s)...
+2026-04-13 15:28:43,393 [INFO] [FILLED] BUY MSFT: 3 @ $95.09 (Fee: $0.71)
+2026-04-13 15:28:43,393 [INFO] [Position] New lot: lot_20260413_152843_MSFT_002 Lv2 MSFT 3주 @$95.09
+2026-04-13 15:28:43,393 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,397 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,397 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,398 [INFO] Portfolio: Cash=$8,826, Value=$9,954
+2026-04-13 15:28:43,398 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,398 [INFO] Loaded 4 position lot(s)
+2026-04-13 15:28:43,399 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,399 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:28:43,399 [INFO] >>> Processing MSFT
+2026-04-13 15:28:43,399 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:28:43,399 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,402 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,402 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,403 [INFO] Portfolio: Cash=$8,826, Value=$9,942
+2026-04-13 15:28:43,403 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,404 [INFO] Loaded 4 position lot(s)
+2026-04-13 15:28:43,404 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,404 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:28:43,404 [INFO] >>> Processing MSFT
+2026-04-13 15:28:43,404 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:28:43,405 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,407 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,408 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,408 [INFO] Portfolio: Cash=$8,826, Value=$9,930
+2026-04-13 15:28:43,408 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,408 [INFO] Loaded 4 position lot(s)
+2026-04-13 15:28:43,409 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,409 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:28:43,409 [INFO] >>> Processing MSFT
+2026-04-13 15:28:43,409 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:28:43,409 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,412 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-13 15:28:43,412 [INFO] Fetching real-time prices from Broker...
+2026-04-13 15:28:43,413 [INFO] Portfolio: Cash=$8,826, Value=$9,918
+2026-04-13 15:28:43,413 [INFO] >>> Step 2: Load Positions
+2026-04-13 15:28:43,414 [INFO] Loaded 4 position lot(s)
+2026-04-13 15:28:43,414 [INFO] >>> Processing AAPL
+2026-04-13 15:28:43,414 [INFO]   [AAPL] 신호 없음. 스킵.
+2026-04-13 15:28:43,414 [INFO] >>> Processing MSFT
+2026-04-13 15:28:43,414 [INFO]   [MSFT] 신호 없음. 스킵.
+2026-04-13 15:28:43,415 [INFO] >>> Step 6: Persist
+2026-04-13 15:28:43,417 [INFO] --- 백테스트 완료 ---
+2026-04-13 15:28:43,417 [INFO] 최종: Cash=$8,826, Value=$9,918
+2026-04-13 15:28:43,427 [INFO] --- 데이터 다운로드: ['AAPL'] (2024-01-02 ~ 2024-01-08) ---
+2026-04-13 15:28:43,427 [WARNING] 데이터 미수신 티커 ['AAPL'] — 백테스트를 중단합니다.
+2026-04-13 15:28:43,693 [INFO] === Initializing MagicSplit Bot (single account) ===
+2026-04-13 15:28:43,694 [INFO] Loaded 1 stock rule(s) from /tmp/pytest-of-root/pytest-2/test_init_and_run0/config.json
+2026-04-13 15:28:43,694 [INFO] [overseas] 1 rule(s), mode=PAPER
+2026-04-13 15:28:43,695 [INFO] === Running overseas engine ===
+2026-04-13 15:28:43,705 [INFO] === Initializing MagicSplit Bot (single account) ===
+2026-04-13 15:28:43,706 [INFO] Loaded 1 stock rule(s) from /tmp/pytest-of-root/pytest-2/test_run_engine_failure_raises0/config.json
+2026-04-13 15:28:43,706 [INFO] [overseas] 1 rule(s), mode=PAPER
+2026-04-13 15:28:43,708 [INFO] === Running overseas engine ===
+2026-04-13 15:28:43,716 [INFO] === Initializing MagicSplit Bot (single account) ===
+2026-04-13 15:28:43,716 [INFO] Loaded 1 stock rule(s) from /tmp/pytest-of-root/pytest-2/test_no_active_stocks_raises0/config.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ requests
 python-dotenv
 pytest-cov
 PyYAML
+yfinance
+pyarrow

--- a/src/backtest/cache.py
+++ b/src/backtest/cache.py
@@ -1,0 +1,119 @@
+# src/backtest/cache.py
+import pandas as pd
+import yfinance as yf
+from pathlib import Path
+from typing import List, Optional
+from src.core.interfaces import ILogger
+
+CACHE_DIR = Path(__file__).parent / "cache"
+
+
+class _NullLogger:
+    """로거가 없을 때 사용하는 아무것도 하지 않는 로거"""
+    def info(self, msg: str) -> None: pass
+    def warning(self, msg: str) -> None: pass
+    def error(self, msg: str) -> None: pass
+
+
+class BacktestDataCache:
+    """
+    yfinance로 종가 데이터를 다운로드하고 Parquet으로 캐시한다.
+
+    요청할 때마다 기존 캐시를 삭제하고 전체 재다운로드한다.
+    증분 merge 없이 항상 깨끗한 데이터를 보장한다.
+
+    저장 위치: src/backtest/cache/close.parquet
+    """
+
+    def __init__(self, cache_dir: Path = CACHE_DIR, logger: Optional[ILogger] = None):
+        self.cache_dir = Path(cache_dir)
+        self.close_path = self.cache_dir / "close.parquet"
+        self._logger: ILogger = logger if logger is not None else _NullLogger()
+
+    def get_data(
+        self, tickers: List[str], start_date: str, end_date: str
+    ) -> pd.DataFrame:
+        """
+        기존 캐시를 삭제하고 전체 티커를 새로 다운로드한다.
+
+        1. 기존 캐시 삭제
+        2. 전 티커 일괄 다운로드 (auto_adjust=False)
+        3. Close 컬럼만 추출
+        4. NaN을 이전 값으로 채움 (ffill)
+        5. 저장 후 반환
+
+        Returns:
+            Close 가격 DataFrame (index=DatetimeIndex, columns=tickers)
+        """
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+        # 1. 기존 캐시 삭제
+        self.clear()
+
+        # 2. 전체 다운로드
+        self._logger.info(f"종가 다운로드 시작: {tickers} ({start_date} ~ {end_date})")
+        close_df = self._download_close(tickers, start_date, end_date)
+
+        if close_df is None or close_df.empty:
+            raise ValueError(f"종가 다운로드 실패: {tickers} ({start_date} ~ {end_date})")
+
+        # 3. NaN → 이전 값으로 채움
+        nan_before = int(close_df.isna().sum().sum())
+        if nan_before > 0:
+            close_df = close_df.ffill()
+            nan_after = int(close_df.isna().sum().sum())
+            filled = nan_before - nan_after
+            self._logger.info(f"NaN ffill 처리: {filled}개 채움, 잔여 {nan_after}개")
+
+        # 4. 저장
+        self._save_parquet(close_df, self.close_path)
+
+        return close_df
+
+    def _download_close(
+        self, tickers: List[str], start_date: str, end_date: str
+    ) -> Optional[pd.DataFrame]:
+        """yfinance로 종가를 다운로드한다."""
+        try:
+            df = yf.download(
+                tickers, start=start_date, end=end_date,
+                auto_adjust=False, progress=False,
+            )
+            if df is None or df.empty:
+                return None
+
+            # 단일 티커 + SingleIndex → 정규화
+            if not isinstance(df.columns, pd.MultiIndex) and len(tickers) == 1:
+                # SingleIndex DataFrame: 컬럼이 [Open, High, Low, Close, ...]
+                if "Close" in df.columns:
+                    close_df = df[["Close"]].copy()
+                    close_df.columns = tickers
+                    return close_df
+                return None
+
+            # MultiIndex DataFrame: ('Close', ticker) 형태
+            if "Close" not in df.columns.get_level_values(0):
+                return None
+            close_df = df["Close"]
+
+            # Series → DataFrame 변환 (단일 티커의 경우)
+            if isinstance(close_df, pd.Series):
+                close_df = close_df.to_frame(name=tickers[0])
+
+            return close_df
+        except Exception as e:
+            self._logger.warning(f"종가 다운로드 실패: {e}")
+            return None
+
+    def _save_parquet(self, df: pd.DataFrame, path: Path):
+        if df is not None and not df.empty:
+            try:
+                df.to_parquet(path)
+            except Exception as e:
+                self._logger.warning(f"캐시 저장 실패 ({path.name}): {e}")
+
+    def clear(self):
+        """캐시 파일 삭제"""
+        if self.close_path.exists():
+            self.close_path.unlink()
+            self._logger.info("기존 캐시 삭제 완료")

--- a/src/backtest/components.py
+++ b/src/backtest/components.py
@@ -1,0 +1,58 @@
+# src/backtest/components.py
+from dataclasses import replace
+from typing import List, Dict, Optional
+
+from src.core.interfaces import ILogger
+from src.core.models import Portfolio, Order, TradeExecution
+from src.infra.broker.mock import MockBroker
+
+
+class BacktestBroker(MockBroker):
+    """
+    MockBroker를 상속받되, '현재가'를 API가 아닌
+    백테스터가 주입해준 가격(simulation_prices)으로 처리한다.
+    """
+
+    def __init__(self, initial_cash: float, logger: Optional[ILogger] = None):
+        super().__init__(initial_cash=initial_cash, logger=logger)
+        self.simulation_prices: Dict[str, float] = {}
+        self.current_date = None  # 시뮬레이션 상의 '오늘'
+
+    def set_date(self, date):
+        """시뮬레이션 날짜를 설정한다. runner가 매 거래일마다 호출해야 한다."""
+        self.current_date = date
+
+    def set_prices(self, prices: Dict[str, float]):
+        """시뮬레이션 종가를 설정한다."""
+        self.simulation_prices = prices
+
+    def fetch_current_prices(self, tickers: List[str]) -> Dict[str, float]:
+        """백테스터가 설정해준 시뮬레이션 가격을 반환한다."""
+        return {t: self.simulation_prices.get(t, 0.0) for t in tickers}
+
+    def get_portfolio(self) -> Portfolio:
+        """simulation_prices를 current_prices로 반영한 Portfolio를 반환한다."""
+        return Portfolio(
+            total_cash=self.cash,
+            holdings=dict(self.holdings),
+            current_prices=dict(self.simulation_prices),
+        )
+
+    def execute_orders(self, orders: List[Order]) -> List[TradeExecution]:
+        """주문 가격을 simulation_prices로 교체한 뒤 부모 클래스에 위임한다."""
+        updated_orders = [
+            replace(order, price=self.simulation_prices.get(order.ticker, order.price))
+            for order in orders
+        ]
+        return super().execute_orders(updated_orders)
+
+    def _process_order(self, order: Order) -> TradeExecution:
+        """체결 날짜를 실제 현재 시각이 아닌 시뮬레이션 날짜로 기록한다."""
+        result = super()._process_order(order)
+        if self.current_date is not None:
+            if hasattr(self.current_date, 'strftime'):
+                sim_date = self.current_date.strftime("%Y-%m-%d")
+            else:
+                sim_date = str(self.current_date)
+            return replace(result, date=sim_date)
+        return result

--- a/src/backtest/fetcher.py
+++ b/src/backtest/fetcher.py
@@ -1,0 +1,27 @@
+# src/backtest/fetcher.py
+import pandas as pd
+from src.backtest.cache import BacktestDataCache
+
+
+def download_historical_data(
+    tickers: list,
+    start_date: str,
+    end_date: str,
+    cache: BacktestDataCache = None,
+) -> pd.DataFrame:
+    """
+    백테스트용 종가 데이터 다운로드 (캐시 활용).
+
+    Args:
+        tickers: 종목 코드 리스트
+        start_date: 시작일 'YYYY-MM-DD'
+        end_date: 종료일 'YYYY-MM-DD'
+        cache: BacktestDataCache 인스턴스. None이면 기본 인스턴스를 생성한다.
+
+    Returns:
+        Close 가격 DataFrame (index=DatetimeIndex, columns=tickers)
+    """
+    if cache is None:
+        cache = BacktestDataCache()
+
+    return cache.get_data(tickers, start_date, end_date)

--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -1,0 +1,136 @@
+# src/backtest/runner.py
+import shutil
+import pandas as pd
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from src.core.models import DayResult
+from src.core.engine.base import MagicSplitEngine
+from src.infra.repo import JsonRepository
+from src.utils.logger import TradeLogger
+from src.strategy_config import StrategyConfig
+from src.backtest.fetcher import download_historical_data
+from src.backtest.components import BacktestBroker
+
+
+def _validate_tickers(
+    close_df: pd.DataFrame, required: List[str], logger: TradeLogger,
+) -> List[str]:
+    """close_df에 실제로 수신된 티커와 required를 비교해 누락된 티커를 반환한다."""
+    available = set(close_df.columns)
+    missing = [t for t in required if t not in available]
+    if missing:
+        logger.warning(f"데이터 미수신 티커 {missing} — 백테스트를 중단합니다.")
+    return missing
+
+
+def run_backtest(
+    config_path: str,
+    start_date: str,
+    end_date: str,
+    initial_cash: float = 10000.0,
+    market_type: str = "overseas",
+    output_dir: str = "docs/data/backtest",
+    run_number: Optional[str] = None,
+) -> Optional[DayResult]:
+    """MagicSplit 전략 백테스트를 실행한다.
+
+    Args:
+        config_path: config.json 경로
+        start_date: 시작일 'YYYY-MM-DD'
+        end_date: 종료일 'YYYY-MM-DD'
+        initial_cash: 초기 자금 (USD 또는 KRW)
+        market_type: 'overseas' 또는 'domestic'
+        output_dir: 결과 저장 디렉토리
+        run_number: 실행 번호 (로그 구분용)
+
+    Returns:
+        마지막 거래일의 DayResult, 또는 데이터가 없으면 None
+    """
+    logger = TradeLogger(log_dir="logs/backtest", run_number=run_number)
+
+    # 1. 설정 로드
+    strategy = StrategyConfig(config_path=config_path)
+    rules = strategy.get_rules_by_market(market_type)
+    if not rules:
+        logger.warning(f"'{market_type}' 마켓에 해당하는 종목이 없습니다.")
+        return None
+
+    tickers = [r.ticker for r in rules if r.enabled]
+    if not tickers:
+        logger.warning("활성화된 종목이 없습니다.")
+        return None
+
+    # 2. 데이터 다운로드
+    logger.info(f"--- 데이터 다운로드: {tickers} ({start_date} ~ {end_date}) ---")
+    close_df = download_historical_data(tickers, start_date, end_date)
+
+    if _validate_tickers(close_df, tickers, logger):
+        return None
+
+    # 3. 거래일 산출
+    trading_days = close_df.index
+    sim_days = [d for d in trading_days
+                if start_date <= d.strftime("%Y-%m-%d") <= end_date]
+
+    if not sim_days:
+        logger.warning("시뮬레이션 기간에 거래일이 없습니다.")
+        return None
+
+    # 4. 컴포넌트 생성
+    out_path = Path(output_dir)
+    if out_path.exists():
+        shutil.rmtree(out_path)
+
+    broker = BacktestBroker(initial_cash=initial_cash, logger=logger)
+    repo = JsonRepository(root_path=output_dir)
+    engine = MagicSplitEngine(
+        broker=broker,
+        repo=repo,
+        logger=logger,
+        stock_rules=rules,
+        notifier=None,
+        is_live_trading=False,
+    )
+
+    # 5. 시뮬레이션 루프
+    logger.info(f"--- 백테스트 시작 ({len(sim_days)} 거래일) ---")
+
+    prev_prices: Dict[str, float] = {}
+    last_result: Optional[DayResult] = None
+
+    for today in sim_days:
+        # 종가 추출
+        try:
+            row = close_df.loc[today]
+            current_prices = row.to_dict()
+            # NaN → 전일 가격으로 대체 (forward-fill)
+            current_prices = {
+                t: (p if not pd.isna(p) else prev_prices.get(t))
+                for t, p in current_prices.items()
+                if not pd.isna(p) or prev_prices.get(t) is not None
+            }
+            prev_prices = current_prices
+        except Exception as e:
+            logger.warning(f"[{today.date()}] 종가 추출 실패, 건너뜀: {e}")
+            continue
+
+        sim_date = today.strftime("%Y-%m-%d")
+
+        broker.set_date(today)
+        broker.set_prices(current_prices)
+
+        try:
+            last_result = engine.run_one_cycle(sim_date=sim_date)
+        except Exception as e:
+            logger.error(f"[{sim_date}] 사이클 실행 실패: {e}")
+
+    logger.info("--- 백테스트 완료 ---")
+    if last_result:
+        pf = last_result.final_portfolio
+        logger.info(
+            f"최종: Cash=${pf.total_cash:,.0f}, "
+            f"Value=${pf.total_value:,.0f}"
+        )
+
+    return last_result

--- a/tests/test_backtest_cache.py
+++ b/tests/test_backtest_cache.py
@@ -1,0 +1,125 @@
+# tests/test_backtest_cache.py
+import pandas as pd
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from src.backtest.cache import BacktestDataCache
+
+
+@pytest.fixture
+def tmp_cache_dir(tmp_path):
+    """임시 캐시 디렉토리"""
+    return tmp_path / "cache"
+
+
+@pytest.fixture
+def cache(tmp_cache_dir):
+    """테스트용 BacktestDataCache 인스턴스"""
+    return BacktestDataCache(cache_dir=tmp_cache_dir)
+
+
+def _make_yf_response(tickers, days=5):
+    """yfinance 응답을 시뮬레이션하는 DataFrame 생성"""
+    dates = pd.bdate_range("2024-01-02", periods=days)
+    if len(tickers) == 1:
+        # 단일 티커: SingleIndex
+        data = {
+            "Open": range(100, 100 + days),
+            "High": range(101, 101 + days),
+            "Low": range(99, 99 + days),
+            "Close": range(100, 100 + days),
+            "Volume": [1000] * days,
+        }
+        return pd.DataFrame(data, index=dates)
+    else:
+        # 멀티 티커: MultiIndex
+        cols = pd.MultiIndex.from_product(
+            [["Open", "High", "Low", "Close", "Volume"], tickers]
+        )
+        data = {}
+        for field in ["Open", "High", "Low", "Close"]:
+            for t in tickers:
+                data[(field, t)] = range(100, 100 + days)
+        for t in tickers:
+            data[("Volume", t)] = [1000] * days
+        df = pd.DataFrame(data, index=dates)
+        df.columns = cols
+        return df
+
+
+class TestBacktestDataCache:
+    def test_get_data_single_ticker(self, cache, tmp_cache_dir):
+        """단일 티커 다운로드 및 캐시 저장"""
+        mock_df = _make_yf_response(["AAPL"], days=5)
+
+        with patch("src.backtest.cache.yf.download", return_value=mock_df):
+            result = cache.get_data(["AAPL"], "2024-01-01", "2024-01-10")
+
+        assert isinstance(result, pd.DataFrame)
+        assert "AAPL" in result.columns
+        assert len(result) == 5
+        assert (tmp_cache_dir / "close.parquet").exists()
+
+    def test_get_data_multi_ticker(self, cache, tmp_cache_dir):
+        """멀티 티커 다운로드 및 캐시 저장"""
+        mock_df = _make_yf_response(["AAPL", "MSFT"], days=5)
+
+        with patch("src.backtest.cache.yf.download", return_value=mock_df):
+            result = cache.get_data(["AAPL", "MSFT"], "2024-01-01", "2024-01-10")
+
+        assert "AAPL" in result.columns
+        assert "MSFT" in result.columns
+        assert len(result) == 5
+
+    def test_get_data_ffill_nan(self, cache):
+        """NaN 값이 ffill로 처리되는지 확인"""
+        dates = pd.bdate_range("2024-01-02", periods=3)
+        cols = pd.MultiIndex.from_product([["Close"], ["AAPL"]])
+        data = {("Close", "AAPL"): [100.0, float("nan"), 102.0]}
+        mock_df = pd.DataFrame(data, index=dates)
+        mock_df.columns = cols
+
+        # Open, High 등을 추가하여 yfinance 응답처럼 만듦
+        for field in ["Open", "High", "Low", "Volume"]:
+            mock_df[(field, "AAPL")] = 100.0
+        mock_df.columns = pd.MultiIndex.from_tuples(mock_df.columns)
+
+        with patch("src.backtest.cache.yf.download", return_value=mock_df):
+            result = cache.get_data(["AAPL"], "2024-01-01", "2024-01-10")
+
+        # NaN이 ffill로 100.0이 되어야 함
+        assert result["AAPL"].iloc[1] == 100.0
+
+    def test_get_data_raises_on_empty(self, cache):
+        """빈 데이터 다운로드 시 ValueError 발생"""
+        with patch("src.backtest.cache.yf.download", return_value=pd.DataFrame()):
+            with pytest.raises(ValueError, match="종가 다운로드 실패"):
+                cache.get_data(["AAPL"], "2024-01-01", "2024-01-10")
+
+    def test_clear(self, cache, tmp_cache_dir):
+        """캐시 삭제"""
+        tmp_cache_dir.mkdir(parents=True, exist_ok=True)
+        parquet_path = tmp_cache_dir / "close.parquet"
+        parquet_path.write_text("dummy")
+
+        cache.clear()
+        assert not parquet_path.exists()
+
+    def test_clear_no_file(self, cache):
+        """파일이 없을 때 clear가 오류 없이 동작"""
+        cache.clear()  # 예외 없이 완료
+
+    def test_get_data_deletes_existing_cache(self, cache, tmp_cache_dir):
+        """get_data 호출 시 기존 캐시가 삭제되는지 확인"""
+        tmp_cache_dir.mkdir(parents=True, exist_ok=True)
+        parquet_path = tmp_cache_dir / "close.parquet"
+        parquet_path.write_text("old data")
+
+        mock_df = _make_yf_response(["AAPL"], days=3)
+        with patch("src.backtest.cache.yf.download", return_value=mock_df):
+            cache.get_data(["AAPL"], "2024-01-01", "2024-01-05")
+
+        # 파일이 새로 생성됨 (parquet 형식)
+        assert parquet_path.exists()
+        content = parquet_path.read_bytes()
+        assert content != b"old data"

--- a/tests/test_backtest_components.py
+++ b/tests/test_backtest_components.py
@@ -1,0 +1,123 @@
+# tests/test_backtest_components.py
+import pandas as pd
+import pytest
+from src.core.models import Order, OrderAction, ExecutionStatus
+from src.backtest.components import BacktestBroker
+
+
+@pytest.fixture
+def broker():
+    """초기 자금 10000의 BacktestBroker"""
+    return BacktestBroker(initial_cash=10000.0)
+
+
+class TestBacktestBrokerPriceInjection:
+    def test_set_prices_and_fetch(self, broker):
+        """set_prices 후 fetch_current_prices가 주입된 가격을 반환"""
+        broker.set_prices({"AAPL": 150.0, "MSFT": 300.0})
+        prices = broker.fetch_current_prices(["AAPL", "MSFT"])
+        assert prices == {"AAPL": 150.0, "MSFT": 300.0}
+
+    def test_fetch_missing_ticker_returns_zero(self, broker):
+        """주입되지 않은 티커는 0.0 반환"""
+        broker.set_prices({"AAPL": 150.0})
+        prices = broker.fetch_current_prices(["AAPL", "GOOG"])
+        assert prices["GOOG"] == 0.0
+
+    def test_get_portfolio_uses_simulation_prices(self, broker):
+        """get_portfolio가 simulation_prices를 current_prices로 반영"""
+        broker.set_prices({"AAPL": 150.0})
+        portfolio = broker.get_portfolio()
+        assert portfolio.current_prices == {"AAPL": 150.0}
+        assert portfolio.total_cash == 10000.0
+
+
+class TestBacktestBrokerDateInjection:
+    def test_execution_date_uses_simulation_date(self, broker):
+        """체결 날짜가 시뮬레이션 날짜로 기록됨"""
+        broker.set_date(pd.Timestamp("2024-03-15"))
+        broker.set_prices({"AAPL": 150.0})
+
+        orders = [Order(ticker="AAPL", action=OrderAction.BUY, quantity=2, price=150.0)]
+        executions = broker.execute_orders(orders)
+
+        assert len(executions) == 1
+        assert executions[0].date == "2024-03-15"
+
+    def test_execution_date_with_string_date(self, broker):
+        """문자열 날짜도 정상 처리"""
+        broker.set_date("2024-03-15")
+        broker.set_prices({"AAPL": 150.0})
+
+        orders = [Order(ticker="AAPL", action=OrderAction.BUY, quantity=1, price=150.0)]
+        executions = broker.execute_orders(orders)
+
+        assert executions[0].date == "2024-03-15"
+
+
+class TestBacktestBrokerOrderExecution:
+    def test_execute_buy_uses_simulation_price(self, broker):
+        """매수 시 simulation_prices 가격이 사용됨 (order.price 무시)"""
+        broker.set_prices({"AAPL": 200.0})
+        broker.set_date(pd.Timestamp("2024-01-02"))
+
+        # order.price=100 이지만 simulation_prices=200으로 체결되어야 함
+        orders = [Order(ticker="AAPL", action=OrderAction.BUY, quantity=3, price=100.0)]
+        executions = broker.execute_orders(orders)
+
+        assert len(executions) == 1
+        # 슬리피지 포함: 200 * 1.001 = 200.2
+        assert abs(executions[0].price - 200.2) < 0.1
+
+    def test_execute_sell(self, broker):
+        """매도 정상 처리"""
+        broker.set_prices({"AAPL": 150.0})
+        broker.set_date(pd.Timestamp("2024-01-02"))
+
+        # 먼저 매수
+        buy_orders = [Order(ticker="AAPL", action=OrderAction.BUY, quantity=5, price=150.0)]
+        broker.execute_orders(buy_orders)
+
+        # 매도
+        sell_orders = [Order(ticker="AAPL", action=OrderAction.SELL, quantity=3, price=150.0)]
+        sell_execs = broker.execute_orders(sell_orders)
+
+        assert len(sell_execs) == 1
+        assert sell_execs[0].action == OrderAction.SELL
+        assert sell_execs[0].quantity == 3
+
+    def test_holdings_update_after_buy(self, broker):
+        """매수 후 보유 수량이 증가"""
+        broker.set_prices({"AAPL": 100.0})
+        broker.set_date(pd.Timestamp("2024-01-02"))
+
+        orders = [Order(ticker="AAPL", action=OrderAction.BUY, quantity=5, price=100.0)]
+        broker.execute_orders(orders)
+
+        assert broker.holdings["AAPL"] == 5
+
+    def test_cash_decreases_after_buy(self, broker):
+        """매수 후 현금이 감소"""
+        broker.set_prices({"AAPL": 100.0})
+        broker.set_date(pd.Timestamp("2024-01-02"))
+
+        orders = [Order(ticker="AAPL", action=OrderAction.BUY, quantity=5, price=100.0)]
+        broker.execute_orders(orders)
+
+        # 100 * 1.001 * 5 + fee(0.25%) ≈ 501.75
+        assert broker.cash < 10000.0
+
+    def test_portfolio_value_reflects_holdings(self, broker):
+        """포트폴리오 가치가 보유 종목을 반영"""
+        broker.set_prices({"AAPL": 100.0})
+        broker.set_date(pd.Timestamp("2024-01-02"))
+
+        orders = [Order(ticker="AAPL", action=OrderAction.BUY, quantity=5, price=100.0)]
+        broker.execute_orders(orders)
+
+        broker.set_prices({"AAPL": 110.0})
+        portfolio = broker.get_portfolio()
+
+        # 보유 가치: 5 * 110 = 550
+        assert portfolio.holdings["AAPL"] == 5
+        assert portfolio.current_prices["AAPL"] == 110.0

--- a/tests/test_backtest_runner.py
+++ b/tests/test_backtest_runner.py
@@ -1,0 +1,213 @@
+# tests/test_backtest_runner.py
+import json
+import os
+import pandas as pd
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+from src.backtest.runner import run_backtest, _validate_tickers
+
+
+@pytest.fixture
+def backtest_config(tmp_path):
+    """백테스트용 config.json 생성"""
+    config = {
+        "stocks": [
+            {
+                "ticker": "AAPL",
+                "exchange": "NAS",
+                "market_type": "overseas",
+                "buy_threshold_pct": -5.0,
+                "sell_threshold_pct": 10.0,
+                "buy_amount": 500,
+                "max_lots": 10,
+                "enabled": True,
+            }
+        ],
+        "global": {
+            "check_interval_minutes": 60,
+            "notification_enabled": False,
+        },
+    }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config))
+    return str(config_path)
+
+
+@pytest.fixture
+def multi_stock_config(tmp_path):
+    """2종목 백테스트 config.json"""
+    config = {
+        "stocks": [
+            {
+                "ticker": "AAPL",
+                "exchange": "NAS",
+                "market_type": "overseas",
+                "buy_threshold_pct": -5.0,
+                "sell_threshold_pct": 10.0,
+                "buy_amount": 300,
+                "max_lots": 5,
+                "enabled": True,
+            },
+            {
+                "ticker": "MSFT",
+                "exchange": "NAS",
+                "market_type": "overseas",
+                "buy_threshold_pct": -5.0,
+                "sell_threshold_pct": 10.0,
+                "buy_amount": 300,
+                "max_lots": 5,
+                "enabled": True,
+            },
+        ],
+        "global": {},
+    }
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(config))
+    return str(config_path)
+
+
+def _make_close_df(tickers, days=20, start_price=100.0, price_step=-1.0):
+    """가격이 점진적으로 변하는 종가 DataFrame 생성.
+
+    기본값: 100 → 99 → 98 → ... (하락 추세, 추가 매수 유도)
+    """
+    dates = pd.bdate_range("2024-01-02", periods=days)
+    data = {}
+    for t in tickers:
+        data[t] = [start_price + i * price_step for i in range(days)]
+    return pd.DataFrame(data, index=dates)
+
+
+class TestValidateTickers:
+    def test_no_missing(self):
+        """모든 티커가 존재하면 빈 리스트 반환"""
+        df = pd.DataFrame({"AAPL": [100], "MSFT": [200]})
+
+        class FakeLogger:
+            def warning(self, msg): pass
+
+        assert _validate_tickers(df, ["AAPL", "MSFT"], FakeLogger()) == []
+
+    def test_missing_tickers(self):
+        """누락 티커가 있으면 리스트로 반환"""
+        df = pd.DataFrame({"AAPL": [100]})
+
+        class FakeLogger:
+            def warning(self, msg): pass
+
+        result = _validate_tickers(df, ["AAPL", "GOOG"], FakeLogger())
+        assert result == ["GOOG"]
+
+
+class TestRunBacktest:
+    def test_basic_backtest_flow(self, backtest_config, tmp_path):
+        """기본 백테스트 흐름: 데이터 다운 → 시뮬레이션 → 결과 파일 생성"""
+        close_df = _make_close_df(["AAPL"], days=10, start_price=100.0, price_step=-2.0)
+        output_dir = str(tmp_path / "output")
+
+        with patch("src.backtest.runner.download_historical_data", return_value=close_df):
+            result = run_backtest(
+                config_path=backtest_config,
+                start_date="2024-01-02",
+                end_date="2024-01-15",
+                initial_cash=10000.0,
+                output_dir=output_dir,
+            )
+
+        assert result is not None
+        assert result.date is not None
+        # 결과 파일 존재 확인
+        assert os.path.exists(os.path.join(output_dir, "positions.json"))
+        assert os.path.exists(os.path.join(output_dir, "history.json"))
+        assert os.path.exists(os.path.join(output_dir, "status.json"))
+
+    def test_initial_buy_occurs(self, backtest_config, tmp_path):
+        """첫 거래일에 Lv1 초기 매수가 발생"""
+        close_df = _make_close_df(["AAPL"], days=5, start_price=100.0, price_step=0.0)
+        output_dir = str(tmp_path / "output")
+
+        with patch("src.backtest.runner.download_historical_data", return_value=close_df):
+            result = run_backtest(
+                config_path=backtest_config,
+                start_date="2024-01-02",
+                end_date="2024-01-08",
+                initial_cash=10000.0,
+                output_dir=output_dir,
+            )
+
+        # history.json에 매수 내역이 있어야 함
+        with open(os.path.join(output_dir, "history.json")) as f:
+            history = json.load(f)
+        assert len(history) > 0
+        first_exec = history[0]["executions"][0]
+        assert first_exec["action"] == "BUY"
+        assert first_exec["ticker"] == "AAPL"
+
+    def test_no_rules_returns_none(self, tmp_path):
+        """활성화된 종목이 없으면 None 반환"""
+        config = {
+            "stocks": [
+                {
+                    "ticker": "AAPL",
+                    "exchange": "NAS",
+                    "market_type": "domestic",  # overseas 요청 시 매칭 안됨
+                    "buy_threshold_pct": -5.0,
+                    "sell_threshold_pct": 10.0,
+                    "buy_amount": 500,
+                    "max_lots": 10,
+                    "enabled": True,
+                }
+            ],
+            "global": {},
+        }
+        config_path = str(tmp_path / "config.json")
+        with open(config_path, "w") as f:
+            json.dump(config, f)
+
+        result = run_backtest(
+            config_path=config_path,
+            start_date="2024-01-01",
+            end_date="2024-01-31",
+            market_type="overseas",
+            output_dir=str(tmp_path / "output"),
+        )
+        assert result is None
+
+    def test_multi_stock_backtest(self, multi_stock_config, tmp_path):
+        """2종목 백테스트가 정상 실행"""
+        close_df = _make_close_df(
+            ["AAPL", "MSFT"], days=10, start_price=100.0, price_step=-1.0,
+        )
+        output_dir = str(tmp_path / "output")
+
+        with patch("src.backtest.runner.download_historical_data", return_value=close_df):
+            result = run_backtest(
+                config_path=multi_stock_config,
+                start_date="2024-01-02",
+                end_date="2024-01-15",
+                initial_cash=10000.0,
+                output_dir=output_dir,
+            )
+
+        assert result is not None
+        # status.json에 포트폴리오 정보 존재
+        with open(os.path.join(output_dir, "status.json")) as f:
+            status = json.load(f)
+        assert "portfolio" in status
+
+    def test_missing_ticker_data_returns_none(self, backtest_config, tmp_path):
+        """필요한 티커 데이터가 없으면 None 반환"""
+        # AAPL이 필요한데 MSFT만 있는 데이터
+        close_df = _make_close_df(["MSFT"], days=5)
+        output_dir = str(tmp_path / "output")
+
+        with patch("src.backtest.runner.download_historical_data", return_value=close_df):
+            result = run_backtest(
+                config_path=backtest_config,
+                start_date="2024-01-02",
+                end_date="2024-01-08",
+                output_dir=output_dir,
+            )
+        assert result is None


### PR DESCRIPTION
## Summary
- StockAsset 저장소의 백테스트 패턴을 MagicSplit에 적용하여 과거 데이터 기반 전략 검증 기능 추가
- yfinance로 종가 데이터를 다운로드/캐시하고, BacktestBroker가 시뮬레이션 가격을 주입하여 MagicSplitEngine을 코드 수정 없이 100% 재사용
- Level 기반 분할매수/익절 전략의 파라미터(buy_threshold_pct, sell_threshold_pct, buy_amount, max_lots)를 과거 데이터로 검증 가능

### 백테스트 시스템 (`src/backtest/`)
- **cache.py**: `BacktestDataCache` — yfinance로 종가 다운로드, Parquet 캐시
- **fetcher.py**: `download_historical_data()` — 캐시 래퍼
- **components.py**: `BacktestBroker` — MockBroker 상속, 시뮬레이션 가격/날짜 주입
- **runner.py**: `run_backtest()` — 일별 시뮬레이션 루프, 결과는 JsonRepository를 통해 positions.json/history.json/status.json에 자동 저장

### 프로젝트 전체 구조 (초기 설정 포함)
- Clean Architecture: core(도메인) → infra(인프라) 의존 방향
- 엔진 레지스트리 패턴, 종목별 순차 실행, 매도 우선
- KIS 국내/해외 브로커, JSON 저장소, Slack/Telegram 알림
- GitHub Actions: 테스트, 트레이딩 봇 실행, 백테스트 실행

## Test plan
- [x] 전체 테스트 통과: `pytest --cov=src --cov-fail-under=80 tests/` (123 passed, 91% coverage)
- [ ] 실제 yfinance 데이터로 단기간 백테스트 실행하여 매수/매도 흐름 확인
- [ ] output_dir에 positions.json, history.json, status.json 정상 생성 확인

https://claude.ai/code/session_017fmF7PBNHPidKjZtZSqFLu