### PR TITLE
🧹 [Code Health] Remove unused Tuple import in base.py

### DIFF
--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -1,7 +1,7 @@
 # src/core/engine/base.py
 import time
 from datetime import datetime
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from src.core.interfaces import IBrokerAdapter, IRepository, ILogger, INotifier
 from src.core.models import (


### PR DESCRIPTION
🎯 **What:** The unused `Tuple` import from `typing` was removed from `src/core/engine/base.py`.
💡 **Why:** Removing unused imports improves code readability and hygiene.
✅ **Verification:** Ran pytest tests for `test_core_engine.py` which all passed. Tested that the module compiles without errors.
✨ **Result:** The codebase is cleaner and maintainability is improved without changing any behavior.

---
*PR created automatically by Jules for task [11463543126603200500](https://jules.google.com/task/11463543126603200500) started by @Junghyun99*