### PR TITLE
🧹 Remove unused TradeSignal import in src/core/engine/base.py

### DIFF
--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -11,7 +11,6 @@ from src.core.models import (
     Order,
     OrderAction,
     TradeExecution,
-    TradeSignal,
     SplitSignal,
     DayResult,
 )


### PR DESCRIPTION
🎯 **What:** Removed unused `TradeSignal` import from `src/core/engine/base.py`.
💡 **Why:** `TradeSignal` was imported but never used in the file, which clutters the namespace and reduces code readability. Removing it improves maintainability without changing behavior.
✅ **Verification:** Verified via manual inspection and by running the full test suite (`pytest --cov=src`) which passed successfully with sufficient code coverage.
✨ **Result:** Improved code hygiene.

---
*PR created automatically by Jules for task [3007012296176554537](https://jules.google.com/task/3007012296176554537) started by @Junghyun99*