### PR TITLE
🧪 Add test for _update_positions error path

### DIFF
--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -112,6 +112,38 @@ class TestRunOneCycle:
         assert result.has_orders is True
         mock_repo.save_positions.assert_called_once()
 
+    def test_update_positions_exception(self, engine, mock_broker, mock_logger):
+        """포지션 반영 실패 시 예외 처리 및 알림 확인"""
+        engine.notifier = MagicMock()
+
+        execution = TradeExecution(
+            "AAPL", OrderAction.BUY, 5, 100.1, 1.25,
+            "2026-04-10", ExecutionStatus.FILLED,
+        )
+        mock_broker.execute_orders.return_value = [execution]
+
+        with patch.object(engine, '_update_positions', side_effect=Exception("Test Error")):
+            result = engine.run_one_cycle(sim_date="2026-04-10")
+
+        # 확인 사항
+        # 1. logger.error가 호출되었는지
+        assert any(
+            "포지션 반영 실패" in str(call) and "Test Error" in str(call)
+            for call in mock_logger.error.call_args_list
+        )
+
+        # 2. _notify_alert가 호출되었는지
+        assert any(
+            "포지션 반영 실패" in str(call) and "Test Error" in str(call)
+            for call in engine.notifier.send_alert.call_args_list
+        )
+
+        # 3. failed_tickers에 추가되어 결과 노티에 반영되었는지
+        assert any(
+            "(실패: AAPL)" in str(call)
+            for call in engine.notifier.send_message.call_args_list
+        )
+
 
 class TestUpdatePositions:
     def test_buy_adds_new_lot_with_level(self, engine):

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -112,7 +112,7 @@ class TestRunOneCycle:
         assert result.has_orders is True
         mock_repo.save_positions.assert_called_once()
 
-    def test_update_positions_exception(self, engine, mock_broker, mock_logger):
+    def test_update_positions_exception(self, engine, mock_broker, mock_logger, mock_repo):
         """포지션 반영 실패 시 예외 처리 및 알림 확인"""
         engine.notifier = MagicMock()
 
@@ -126,23 +126,23 @@ class TestRunOneCycle:
             result = engine.run_one_cycle(sim_date="2026-04-10")
 
         # 확인 사항
-        # 1. logger.error가 호출되었는지
-        assert any(
-            "포지션 반영 실패" in str(call) and "Test Error" in str(call)
-            for call in mock_logger.error.call_args_list
+        # 1. logger.error가 명확한 인자와 함께 호출되었는지
+        mock_logger.error.assert_called_once_with(
+            "[AAPL] 포지션 반영 실패 (체결은 완료됨): Test Error"
         )
 
-        # 2. _notify_alert가 호출되었는지
-        assert any(
-            "포지션 반영 실패" in str(call) and "Test Error" in str(call)
-            for call in engine.notifier.send_alert.call_args_list
+        # 2. _notify_alert가 명확한 인자와 함께 호출되었는지
+        engine.notifier.send_alert.assert_called_once_with(
+            "[AAPL] 포지션 반영 실패 (체결 1건 완료됨): Test Error"
         )
 
         # 3. failed_tickers에 추가되어 결과 노티에 반영되었는지
-        assert any(
-            "(실패: AAPL)" in str(call)
-            for call in engine.notifier.send_message.call_args_list
+        engine.notifier.send_message.assert_called_once_with(
+            "Orders Executed. Count: 1 (실패: AAPL)"
         )
+
+        # 4. _update_positions 실패 시에도 포지션 저장 등 finally 블록이 실행되었는지
+        mock_repo.save_positions.assert_called_once()
 
 
 class TestUpdatePositions:


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing error path test for `_update_positions` in `MagicSplitEngine.run_one_cycle()`. Added a test to verify `logger.error` and `notifier` (both `send_alert` and `send_message`) are correctly invoked when `_update_positions` fails despite executions completing.
📊 **Coverage:** What scenarios are now tested: Exception paths when updating positions fail in `src/core/engine/base.py`.
✨ **Result:** The improvement in test coverage: Improved coverage for the `MagicSplitEngine.run_one_cycle()` method and guarantees safety around error logging and notifications.

---
*PR created automatically by Jules for task [12598569253416874379](https://jules.google.com/task/12598569253416874379) started by @Junghyun99*