### PR TITLE
🔒 [security fix] Add missing timeouts to KIS HTTP requests

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -25,6 +25,8 @@ EXCHANGE_CODE_SHORT_TO_FULL: dict[str, str] = {
     'AMS': 'AMEX',
 }
 
+DEFAULT_HTTP_TIMEOUT = 10
+
 
 class Config:
     def __init__(self):

--- a/src/infra/broker/kis_base.py
+++ b/src/infra/broker/kis_base.py
@@ -5,6 +5,7 @@ import time
 import src.infra.broker as _pkg  # test patch 타깃: src.infra.broker.requests
 from datetime import datetime, timedelta
 
+from src.config import DEFAULT_HTTP_TIMEOUT
 from src.core.interfaces import IBrokerAdapter
 from src.core.models import Portfolio, Order, TradeExecution, OrderAction, ExecutionStatus
 
@@ -60,7 +61,7 @@ class KisBrokerCommon(IBrokerAdapter):
             "appsecret": self.app_secret,
         }
         try:
-            res = _pkg.requests.post(url, json=payload, timeout=10)
+            res = _pkg.requests.post(url, json=payload, timeout=DEFAULT_HTTP_TIMEOUT)
             res.raise_for_status()
             data = res.json()
             if 'access_token' not in data:

--- a/src/infra/broker/kis_base.py
+++ b/src/infra/broker/kis_base.py
@@ -60,7 +60,7 @@ class KisBrokerCommon(IBrokerAdapter):
             "appsecret": self.app_secret,
         }
         try:
-            res = _pkg.requests.post(url, json=payload)
+            res = _pkg.requests.post(url, json=payload, timeout=10)
             res.raise_for_status()
             data = res.json()
             if 'access_token' not in data:

--- a/src/infra/broker/kis_domestic.py
+++ b/src/infra/broker/kis_domestic.py
@@ -5,6 +5,7 @@ import time
 import src.infra.broker as _pkg  # test patch 타깃: src.infra.broker.requests
 from datetime import datetime
 
+from src.config import DEFAULT_HTTP_TIMEOUT
 from src.core.models import Portfolio, Order, TradeExecution, OrderAction, ExecutionStatus
 
 from .kis_base import KisBrokerCommon
@@ -47,7 +48,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
             headers = self._get_header(tr_id)
             try:
                 time.sleep(0.1)
-                res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
+                res = _pkg.requests.get(url, headers=headers, params=params, timeout=DEFAULT_HTTP_TIMEOUT)
                 res.raise_for_status()
                 data = res.json()
 
@@ -89,7 +90,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
 
         try:
             time.sleep(0.2)
-            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=DEFAULT_HTTP_TIMEOUT)
             res.raise_for_status()
             data = res.json()
 
@@ -156,7 +157,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
 
         try:
             headers = self._get_header(tr_id, data)
-            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=DEFAULT_HTTP_TIMEOUT)
             res.raise_for_status()
             resp_data = res.json()
 
@@ -239,7 +240,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
             "INQR_DVSN_2": "0"
         }
         headers = self._get_header(tr_id)
-        res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
+        res = _pkg.requests.get(url, headers=headers, params=params, timeout=DEFAULT_HTTP_TIMEOUT)
         res.raise_for_status()
         data = res.json()
         if data['rt_cd'] == '0':
@@ -283,7 +284,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
         }
         try:
             headers = self._get_header(self.FILL_TR_ID)
-            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=DEFAULT_HTTP_TIMEOUT)
             res.raise_for_status()
             data = res.json()
             if data['rt_cd'] != '0':
@@ -320,7 +321,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
         }
         try:
             headers = self._get_header(self.CANCEL_TR_ID, data)
-            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=DEFAULT_HTTP_TIMEOUT)
             res.raise_for_status()
             resp_data = res.json()
             if resp_data['rt_cd'] == '0':
@@ -346,7 +347,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
         headers = self._get_header(self.ASKING_PRICE_TR_ID)
         try:
             time.sleep(0.1)
-            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=DEFAULT_HTTP_TIMEOUT)
             res.raise_for_status()
             data = res.json()
 

--- a/src/infra/broker/kis_domestic.py
+++ b/src/infra/broker/kis_domestic.py
@@ -47,7 +47,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
             headers = self._get_header(tr_id)
             try:
                 time.sleep(0.1)
-                res = _pkg.requests.get(url, headers=headers, params=params)
+                res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
                 res.raise_for_status()
                 data = res.json()
 
@@ -89,7 +89,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
 
         try:
             time.sleep(0.2)
-            res = _pkg.requests.get(url, headers=headers, params=params)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
             res.raise_for_status()
             data = res.json()
 
@@ -156,7 +156,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
 
         try:
             headers = self._get_header(tr_id, data)
-            res = _pkg.requests.post(url, headers=headers, json=data)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
             res.raise_for_status()
             resp_data = res.json()
 
@@ -239,7 +239,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
             "INQR_DVSN_2": "0"
         }
         headers = self._get_header(tr_id)
-        res = _pkg.requests.get(url, headers=headers, params=params)
+        res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
         res.raise_for_status()
         data = res.json()
         if data['rt_cd'] == '0':
@@ -283,7 +283,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
         }
         try:
             headers = self._get_header(self.FILL_TR_ID)
-            res = _pkg.requests.get(url, headers=headers, params=params)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
             res.raise_for_status()
             data = res.json()
             if data['rt_cd'] != '0':
@@ -320,7 +320,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
         }
         try:
             headers = self._get_header(self.CANCEL_TR_ID, data)
-            res = _pkg.requests.post(url, headers=headers, json=data)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
             res.raise_for_status()
             resp_data = res.json()
             if resp_data['rt_cd'] == '0':
@@ -346,7 +346,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
         headers = self._get_header(self.ASKING_PRICE_TR_ID)
         try:
             time.sleep(0.1)
-            res = _pkg.requests.get(url, headers=headers, params=params)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
             res.raise_for_status()
             data = res.json()
 

--- a/src/infra/broker/kis_http.py
+++ b/src/infra/broker/kis_http.py
@@ -41,6 +41,7 @@ def fetch_hashkey(base_url: str, app_key: str, app_secret: str, data: dict, logg
                 "appsecret": app_secret,
             },
             json=data,
+            timeout=10,
         )
         res.raise_for_status()
         return res.json()["HASH"]

--- a/src/infra/broker/kis_http.py
+++ b/src/infra/broker/kis_http.py
@@ -1,6 +1,7 @@
 # src/infra/broker/kis_http.py
 """KIS REST 요청 공통 헤더/HashKey 헬퍼."""
 from typing import Optional
+from src.config import DEFAULT_HTTP_TIMEOUT
 import src.infra.broker as _pkg  # test patch 타깃: src.infra.broker.requests
 
 
@@ -41,7 +42,7 @@ def fetch_hashkey(base_url: str, app_key: str, app_secret: str, data: dict, logg
                 "appsecret": app_secret,
             },
             json=data,
-            timeout=10,
+            timeout=DEFAULT_HTTP_TIMEOUT,
         )
         res.raise_for_status()
         return res.json()["HASH"]

--- a/src/infra/broker/kis_overseas.py
+++ b/src/infra/broker/kis_overseas.py
@@ -6,7 +6,7 @@ import src.infra.broker as _pkg  # test patch 타깃: src.infra.broker.requests
 from datetime import datetime
 
 from src.core.models import Portfolio, Order, TradeExecution, OrderAction, ExecutionStatus
-from src.config import TICKER_EXCHANGE_MAP, EXCHANGE_CODE_SHORT_TO_FULL
+from src.config import TICKER_EXCHANGE_MAP, EXCHANGE_CODE_SHORT_TO_FULL, DEFAULT_HTTP_TIMEOUT
 
 from .kis_base import KisBrokerCommon
 from .kis_order_helpers import poll_order_fill
@@ -27,7 +27,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
             headers = self._get_header(tr_id)
             try:
                 time.sleep(0.1)
-                res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
+                res = _pkg.requests.get(url, headers=headers, params=params, timeout=DEFAULT_HTTP_TIMEOUT)
                 res.raise_for_status()
                 data = res.json()
 
@@ -72,7 +72,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
             headers = self._get_header(tr_id)
             try:
                 time.sleep(0.2)
-                res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
+                res = _pkg.requests.get(url, headers=headers, params=params, timeout=DEFAULT_HTTP_TIMEOUT)
                 res.raise_for_status()
                 data = res.json()
 
@@ -139,7 +139,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
 
         try:
             headers = self._get_header(tr_id, data)
-            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=DEFAULT_HTTP_TIMEOUT)
             res.raise_for_status()
             resp_data = res.json()
 
@@ -206,7 +206,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
 
         try:
             headers = self._get_header(tr_id, data)
-            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=DEFAULT_HTTP_TIMEOUT)
             res.raise_for_status()
             resp_data = res.json()
 
@@ -289,7 +289,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
             "CTX_AREA_NK200": ""
         }
         headers = self._get_header(tr_id)
-        res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
+        res = _pkg.requests.get(url, headers=headers, params=params, timeout=DEFAULT_HTTP_TIMEOUT)
         res.raise_for_status()
         data = res.json()
         if data['rt_cd'] == '0':
@@ -317,7 +317,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
         }
         try:
             headers = self._get_header(self.FILL_TR_ID)
-            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=DEFAULT_HTTP_TIMEOUT)
             res.raise_for_status()
             data = res.json()
             if data['rt_cd'] != '0':
@@ -357,7 +357,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
         }
         try:
             headers = self._get_header(self.CANCEL_TR_ID, data)
-            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=DEFAULT_HTTP_TIMEOUT)
             res.raise_for_status()
             resp_data = res.json()
             if resp_data['rt_cd'] == '0':
@@ -396,7 +396,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
 
             try:
                 time.sleep(0.2)
-                res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
+                res = _pkg.requests.get(url, headers=headers, params=params, timeout=DEFAULT_HTTP_TIMEOUT)
                 res.raise_for_status()
                 data = res.json()
 
@@ -422,7 +422,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
         headers = self._get_header(self.ASKING_PRICE_TR_ID)
         try:
             time.sleep(0.1)
-            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=DEFAULT_HTTP_TIMEOUT)
             res.raise_for_status()
             data = res.json()
 

--- a/src/infra/broker/kis_overseas.py
+++ b/src/infra/broker/kis_overseas.py
@@ -27,7 +27,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
             headers = self._get_header(tr_id)
             try:
                 time.sleep(0.1)
-                res = _pkg.requests.get(url, headers=headers, params=params)
+                res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
                 res.raise_for_status()
                 data = res.json()
 
@@ -72,7 +72,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
             headers = self._get_header(tr_id)
             try:
                 time.sleep(0.2)
-                res = _pkg.requests.get(url, headers=headers, params=params)
+                res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
                 res.raise_for_status()
                 data = res.json()
 
@@ -139,7 +139,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
 
         try:
             headers = self._get_header(tr_id, data)
-            res = _pkg.requests.post(url, headers=headers, json=data)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
             res.raise_for_status()
             resp_data = res.json()
 
@@ -206,7 +206,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
 
         try:
             headers = self._get_header(tr_id, data)
-            res = _pkg.requests.post(url, headers=headers, json=data)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
             res.raise_for_status()
             resp_data = res.json()
 
@@ -289,7 +289,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
             "CTX_AREA_NK200": ""
         }
         headers = self._get_header(tr_id)
-        res = _pkg.requests.get(url, headers=headers, params=params)
+        res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
         res.raise_for_status()
         data = res.json()
         if data['rt_cd'] == '0':
@@ -317,7 +317,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
         }
         try:
             headers = self._get_header(self.FILL_TR_ID)
-            res = _pkg.requests.get(url, headers=headers, params=params)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
             res.raise_for_status()
             data = res.json()
             if data['rt_cd'] != '0':
@@ -357,7 +357,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
         }
         try:
             headers = self._get_header(self.CANCEL_TR_ID, data)
-            res = _pkg.requests.post(url, headers=headers, json=data)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
             res.raise_for_status()
             resp_data = res.json()
             if resp_data['rt_cd'] == '0':
@@ -396,7 +396,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
 
             try:
                 time.sleep(0.2)
-                res = _pkg.requests.get(url, headers=headers, params=params)
+                res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
                 res.raise_for_status()
                 data = res.json()
 
@@ -422,7 +422,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
         headers = self._get_header(self.ASKING_PRICE_TR_ID)
         try:
             time.sleep(0.1)
-            res = _pkg.requests.get(url, headers=headers, params=params)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
             res.raise_for_status()
             data = res.json()
 

--- a/tests/test_infra_broker_kis_domestic.py
+++ b/tests/test_infra_broker_kis_domestic.py
@@ -1,0 +1,25 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from src.infra.broker.kis_domestic import KisDomesticPaperBroker
+from src.config import DEFAULT_HTTP_TIMEOUT
+
+class TestKisDomesticBroker:
+    @patch("src.infra.broker.kis_domestic._pkg.requests.get")
+    def test_fetch_current_prices_timeout(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'rt_cd': '0',
+            'output': {'stck_prpr': '100'}
+        }
+        mock_get.return_value = mock_response
+
+        logger = MagicMock()
+        # Mock auth to avoid real API call
+        with patch.object(KisDomesticPaperBroker, "_auth", return_value="fake_token"):
+            broker = KisDomesticPaperBroker("key", "secret", "acc", logger)
+            broker.token_expires_at = None # ensure _auth not called again unnecessarily if not needed
+            prices = broker.fetch_current_prices(["069500.KS"])
+
+            assert prices["069500.KS"] == 100.0
+            args, kwargs = mock_get.call_args
+            assert kwargs["timeout"] == DEFAULT_HTTP_TIMEOUT

--- a/tests/test_kis_http.py
+++ b/tests/test_kis_http.py
@@ -1,0 +1,31 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from src.infra.broker.kis_http import fetch_hashkey
+from src.config import DEFAULT_HTTP_TIMEOUT
+
+class TestKisHttpHelpers:
+    def setup_method(self):
+        self.base_url = "https://example.com"
+        self.app_key = "test_app_key"
+        self.app_secret = "test_app_secret"
+
+    @patch("src.infra.broker.kis_http._pkg.requests.post")
+    def test_fetch_hashkey_success(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"HASH": "fake_hash_123"}
+        mock_post.return_value = mock_response
+
+        data = {"key": "value"}
+        result = fetch_hashkey(self.base_url, self.app_key, self.app_secret, data, None)
+
+        assert result == "fake_hash_123"
+        mock_post.assert_called_once_with(
+            f"{self.base_url}/uapi/hashkey",
+            headers={
+                "content-type": "application/json",
+                "appkey": self.app_key,
+                "appsecret": self.app_secret,
+            },
+            json=data,
+            timeout=DEFAULT_HTTP_TIMEOUT,
+        )

--- a/tests/test_kis_token_cache.py
+++ b/tests/test_kis_token_cache.py
@@ -1,0 +1,25 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from src.infra.broker.kis_base import KisBrokerCommon
+from src.config import DEFAULT_HTTP_TIMEOUT
+
+class TestKisTokenCache:
+    @patch("src.infra.broker.kis_base._pkg.requests.post")
+    @patch("src.infra.broker.kis_base.kis_token_cache.load_token_from_cache", return_value=None)
+    @patch("src.infra.broker.kis_base.kis_token_cache.save_token_to_cache")
+    def test_auth_timeout(self, mock_save, mock_load, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "access_token": "new_token",
+            "expires_in": 3600
+        }
+        mock_post.return_value = mock_response
+
+        logger = MagicMock()
+        # KisBrokerCommon is abstract-ish, but let's see if we can instantiate it for testing _auth
+        with patch.multiple(KisBrokerCommon, __abstractmethods__=set()):
+            broker = KisBrokerCommon("key", "secret", "acc", logger)
+            # KisBrokerCommon calls _auth in __init__
+
+            args, kwargs = mock_post.call_args
+            assert kwargs["timeout"] == DEFAULT_HTTP_TIMEOUT


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Added missing `timeout` parameters to all HTTP request calls using the `requests` library in the KIS broker integration.

⚠️ **Risk:** The potential impact if left unfixed
Without a timeout, an unresponsive API or network issue could cause the application to hang indefinitely. This can lead to resource exhaustion (e.g., thread or process pool depletion), blocking the entire trading engine and potentially causing a Denial of Service (DoS) for the application.

🛡️ **Solution:** How the fix addresses the vulnerability
All instances of `requests.get` and `requests.post` in the `src/infra/broker/` directory were updated to include a `timeout=10` parameter. This ensures that any network call that takes longer than 10 seconds will raise a `Timeout` exception, allowing the application to handle the error gracefully instead of hanging. 10 seconds was chosen as a sensible default that provides enough buffer for standard API responses while protecting the system.

---
*PR created automatically by Jules for task [3882798577859509931](https://jules.google.com/task/3882798577859509931) started by @Junghyun99*