### PR TITLE
ci: add download-market-data workflow

### DIFF
--- a/.github/workflows/download-market-data.yml
+++ b/.github/workflows/download-market-data.yml
@@ -1,0 +1,81 @@
+name: Download Market Data
+
+on:
+  workflow_dispatch:
+    inputs:
+      start_date:
+        description: '시작 날짜 (예: 2014-01-01)'
+        required: true
+        type: string
+      end_date:
+        description: '종료 날짜 (예: 2025-12-31)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Download market data
+      run: |
+        python -c "
+        from src.backtest.cache import BacktestDataCache
+        from src.utils.logger import TradeLogger
+        from datetime import datetime, timedelta
+
+        start_date = '${{ inputs.start_date }}'
+        end_date = '${{ inputs.end_date }}'
+
+        # 지표 계산용 500일 여유분 포함
+        real_start = datetime.strptime(start_date, '%Y-%m-%d') - timedelta(days=500)
+        real_start_str = real_start.strftime('%Y-%m-%d')
+
+        tickers = ['SSO', 'QLD', 'IEF', 'GLD', 'DBC', 'SHV', 'SDY', 'SPY',
+                   'EEM', 'EMB', 'QQQ', '069500.KS', '143850.KS', '132030.KS',
+                   '305080.KS', '148070.KS']
+
+        cache = BacktestDataCache(logger=TradeLogger())
+        close_df = cache.get_data(tickers, real_start_str, end_date)
+
+        print(f'Close shape: {close_df.shape}')
+        print(f'Close range: {close_df.index.min()} ~ {close_df.index.max()}')
+        print(f'Close columns: {list(close_df.columns)}')
+        print(close_df.head(10))
+        print('')
+        print('=== NaN 진단 (Close 기준) ===')
+        total_rows = len(close_df)
+        for ticker in tickers:
+            try:
+                col = close_df[ticker]
+                nan_count = int(col.isna().sum())
+                first_valid = col.first_valid_index()
+                pct = nan_count / total_rows * 100 if total_rows > 0 else 0
+                status = 'WARN' if nan_count > 0 else 'OK'
+                print(f'[{status}] {ticker}: NaN={nan_count}/{total_rows} ({pct:.1f}%), 첫 유효일={first_valid}')
+            except KeyError:
+                print(f'[FAIL] {ticker}: 컬럼 없음')
+            except Exception as e:
+                print(f'[ERROR] {ticker}: 조회 오류 - {e}')
+        "
+
+    - name: Commit and Push Cache
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: "data: download market data (${{ inputs.start_date }} ~ ${{ inputs.end_date }}) [skip ci]"
+        file_pattern: "src/backtest/cache/**"


### PR DESCRIPTION
workflow_dispatch로 기간을 입력받아 yfinance로 종가를 다운로드하고
src/backtest/cache/close.parquet을 자동 커밋한다. 지표 계산용
500일 여유분을 포함하며, 티커별 NaN 진단 로그를 출력한다.