### PR TITLE
🛡️ Sentinel: [Critical] Missing Timeouts on API Calls

### DIFF
--- a/src/infra/broker/kis_base.py
+++ b/src/infra/broker/kis_base.py
@@ -60,7 +60,7 @@ class KisBrokerCommon(IBrokerAdapter):
             "appsecret": self.app_secret,
         }
         try:
-            res = _pkg.requests.post(url, json=payload)
+            res = _pkg.requests.post(url, json=payload, timeout=10)
             res.raise_for_status()
             data = res.json()
             if 'access_token' not in data:

--- a/src/infra/broker/kis_domestic.py
+++ b/src/infra/broker/kis_domestic.py
@@ -47,7 +47,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
             headers = self._get_header(tr_id)
             try:
                 time.sleep(0.1)
-                res = _pkg.requests.get(url, headers=headers, params=params)
+                res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
                 res.raise_for_status()
                 data = res.json()
 
@@ -89,7 +89,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
 
         try:
             time.sleep(0.2)
-            res = _pkg.requests.get(url, headers=headers, params=params)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
             res.raise_for_status()
             data = res.json()
 
@@ -156,7 +156,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
 
         try:
             headers = self._get_header(tr_id, data)
-            res = _pkg.requests.post(url, headers=headers, json=data)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
             res.raise_for_status()
             resp_data = res.json()
 
@@ -239,7 +239,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
             "INQR_DVSN_2": "0"
         }
         headers = self._get_header(tr_id)
-        res = _pkg.requests.get(url, headers=headers, params=params)
+        res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
         res.raise_for_status()
         data = res.json()
         if data['rt_cd'] == '0':
@@ -283,7 +283,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
         }
         try:
             headers = self._get_header(self.FILL_TR_ID)
-            res = _pkg.requests.get(url, headers=headers, params=params)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
             res.raise_for_status()
             data = res.json()
             if data['rt_cd'] != '0':
@@ -320,7 +320,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
         }
         try:
             headers = self._get_header(self.CANCEL_TR_ID, data)
-            res = _pkg.requests.post(url, headers=headers, json=data)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
             res.raise_for_status()
             resp_data = res.json()
             if resp_data['rt_cd'] == '0':
@@ -346,7 +346,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
         headers = self._get_header(self.ASKING_PRICE_TR_ID)
         try:
             time.sleep(0.1)
-            res = _pkg.requests.get(url, headers=headers, params=params)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
             res.raise_for_status()
             data = res.json()
 

--- a/src/infra/broker/kis_http.py
+++ b/src/infra/broker/kis_http.py
@@ -40,7 +40,7 @@ def fetch_hashkey(base_url: str, app_key: str, app_secret: str, data: dict, logg
                 "appkey": app_key,
                 "appsecret": app_secret,
             },
-            json=data,
+            json=data, timeout=10
         )
         res.raise_for_status()
         return res.json()["HASH"]

--- a/src/infra/broker/kis_overseas.py
+++ b/src/infra/broker/kis_overseas.py
@@ -27,7 +27,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
             headers = self._get_header(tr_id)
             try:
                 time.sleep(0.1)
-                res = _pkg.requests.get(url, headers=headers, params=params)
+                res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
                 res.raise_for_status()
                 data = res.json()
 
@@ -72,7 +72,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
             headers = self._get_header(tr_id)
             try:
                 time.sleep(0.2)
-                res = _pkg.requests.get(url, headers=headers, params=params)
+                res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
                 res.raise_for_status()
                 data = res.json()
 
@@ -139,7 +139,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
 
         try:
             headers = self._get_header(tr_id, data)
-            res = _pkg.requests.post(url, headers=headers, json=data)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
             res.raise_for_status()
             resp_data = res.json()
 
@@ -206,7 +206,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
 
         try:
             headers = self._get_header(tr_id, data)
-            res = _pkg.requests.post(url, headers=headers, json=data)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
             res.raise_for_status()
             resp_data = res.json()
 
@@ -289,7 +289,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
             "CTX_AREA_NK200": ""
         }
         headers = self._get_header(tr_id)
-        res = _pkg.requests.get(url, headers=headers, params=params)
+        res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
         res.raise_for_status()
         data = res.json()
         if data['rt_cd'] == '0':
@@ -317,7 +317,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
         }
         try:
             headers = self._get_header(self.FILL_TR_ID)
-            res = _pkg.requests.get(url, headers=headers, params=params)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
             res.raise_for_status()
             data = res.json()
             if data['rt_cd'] != '0':
@@ -357,7 +357,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
         }
         try:
             headers = self._get_header(self.CANCEL_TR_ID, data)
-            res = _pkg.requests.post(url, headers=headers, json=data)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
             res.raise_for_status()
             resp_data = res.json()
             if resp_data['rt_cd'] == '0':
@@ -396,7 +396,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
 
             try:
                 time.sleep(0.2)
-                res = _pkg.requests.get(url, headers=headers, params=params)
+                res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
                 res.raise_for_status()
                 data = res.json()
 
@@ -422,7 +422,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
         headers = self._get_header(self.ASKING_PRICE_TR_ID)
         try:
             time.sleep(0.1)
-            res = _pkg.requests.get(url, headers=headers, params=params)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
             res.raise_for_status()
             data = res.json()
 


### PR DESCRIPTION
🚨 Severity: Critical
💡 Vulnerability/Risk: Missing timeouts on external API calls (can freeze the bot indefinitely during market volatility or server outages).
🎯 Financial Impact: High risk of bot crash/freeze, leading to missed critical trades or duplicate order requests if the loop hangs.
🔧 Fix: Added `timeout=10` to all `requests.get` and `requests.post` calls in `kis_base.py`, `kis_domestic.py`, `kis_http.py`, and `kis_overseas.py`.
✅ Verification: Ran unit tests via `python -m pytest` with 100% success rate, verifying the core logic still behaves properly without hanging.

---
*PR created automatically by Jules for task [7804275194341912333](https://jules.google.com/task/7804275194341912333) started by @Junghyun99*