### PR TITLE
fix: remove duplicate DEFAULT_HTTP_TIMEOUT declaration in config.py

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -48,4 +48,4 @@ class Config:
 
         # 저장소 크기 제한
         self.MAX_HISTORY_RECORDS = 100000
-DEFAULT_HTTP_TIMEOUT = 10
+


### PR DESCRIPTION
## Summary
- `src/config.py` 51번 라인에 중복 선언된 `DEFAULT_HTTP_TIMEOUT = 10` 삭제
- 28번 라인의 모듈 최상위 선언만 유지
- 파일 말미 개행 정상화

## Test plan
- [x] 133개 기존 테스트 모두 통과 확인
- [x] `src/config.py` 커버리지 100% 유지

Closes #43

https://claude.ai/code/session_017HPLdbNrJtgMkwrasJD6Gi