### PR TITLE
fix: KisDomesticPaperBroker PENDING_TR_ID 모의투자용 TR_ID로 수정 (#46)

### DIFF
--- a/src/infra/broker/kis_domestic.py
+++ b/src/infra/broker/kis_domestic.py
@@ -378,7 +378,7 @@ class KisDomesticPaperBroker(KisDomesticBrokerBase):
     PORTFOLIO_TR_ID = "VTTC8434R"
     BUY_TR_ID = "VTTC0012U"
     SELL_TR_ID = "VTTC0011U"
-    PENDING_TR_ID = "TTTC0084R"
+    PENDING_TR_ID = "VTTC0084R"
     FILL_TR_ID = "VTTC0081R"
     CANCEL_TR_ID = "VTTC0013U"
 

--- a/tests/test_infra_broker_kis_domestic.py
+++ b/tests/test_infra_broker_kis_domestic.py
@@ -41,3 +41,7 @@ def test_to_yf_ticker():
     assert _to_yf_ticker("005930") == "005930.KS"
     # Already has extension
     assert _to_yf_ticker("005930.KS") == "005930.KS"
+
+
+def test_paper_broker_uses_mock_pending_tr_id():
+    assert KisDomesticPaperBroker.PENDING_TR_ID == "VTTC0084R"


### PR DESCRIPTION
## Summary

- `KisDomesticPaperBroker.PENDING_TR_ID`가 실전 TR_ID(`TTTC0084R`)를 사용하던 버그 수정
- KIS API 모의투자 접두사 패턴(`TTTC` → `VTTC`)에 따라 `VTTC0084R`로 교체
- PAPER 모드에서 미체결 조회(`_get_pending_order_ids`, `poll_order_fill`)가 실패하던 문제 해결

## Test plan

- [ ] `tests/test_infra_broker_kis_domestic.py::test_paper_broker_uses_mock_pending_tr_id` — `PENDING_TR_ID == "VTTC0084R"` 검증
- [ ] 전체 테스트 134개 통과 확인

Closes #46

https://claude.ai/code/session_01H784bt1fULAcG7FDZMuH1N