### PR TITLE
fix: _check_spread bid/ask=0 시 주문 차단 (이슈 #47)

### DIFF
--- a/src/infra/broker/kis_base.py
+++ b/src/infra/broker/kis_base.py
@@ -198,9 +198,9 @@ class KisBrokerCommon(IBrokerAdapter):
         return False
 
     def _check_spread(self, bid: float, ask: float) -> bool:
-        """스프레드 정상 여부 반환. bid/ask가 0이면 True (fallback 허용)"""
+        """스프레드 정상 여부 반환. bid/ask가 0이면 False (호가 조회 실패 → 주문 차단)"""
         if bid <= 0 or ask <= 0:
-            return True
+            return False
         mid = (bid + ask) / 2
         spread_pct = (ask - bid) / mid * 100
         return spread_pct <= self.SPREAD_THRESHOLD_PCT

--- a/src/infra/broker/kis_base.py
+++ b/src/infra/broker/kis_base.py
@@ -198,8 +198,8 @@ class KisBrokerCommon(IBrokerAdapter):
         return False
 
     def _check_spread(self, bid: float, ask: float) -> bool:
-        """스프레드 정상 여부 반환. bid/ask가 0이면 False (호가 조회 실패 → 주문 차단)"""
-        if bid <= 0 or ask <= 0:
+        """스프레드 정상 여부 반환. bid/ask가 유효하지 않거나(<=0) 역전되면 False"""
+        if bid <= 0 or ask <= 0 or ask < bid:
             return False
         mid = (bid + ask) / 2
         spread_pct = (ask - bid) / mid * 100

--- a/tests/test_infra_broker.py
+++ b/tests/test_infra_broker.py
@@ -1,6 +1,8 @@
 # tests/test_infra_broker.py
 import pytest
+from unittest.mock import MagicMock, patch
 from src.infra.broker.mock import MockBroker
+from src.infra.broker.kis_base import KisBrokerCommon
 from src.core.models import Order, OrderAction, ExecutionStatus
 
 
@@ -103,3 +105,38 @@ class TestMockBroker:
         pf = broker.get_portfolio()
         assert pf.holdings["AAPL"] == 5
         assert pf.holdings["MSFT"] == 3
+
+
+class TestCheckSpread:
+    @pytest.fixture
+    def broker(self):
+        with patch.object(KisBrokerCommon, "_auth", return_value="fake_token"):
+            b = KisBrokerCommon.__new__(KisBrokerCommon)
+            b.SPREAD_THRESHOLD_PCT = 0.5
+            return b
+
+    def test_ask_zero_returns_false(self, broker):
+        assert broker._check_spread(100.0, 0.0) is False
+
+    def test_bid_zero_returns_false(self, broker):
+        assert broker._check_spread(0.0, 100.0) is False
+
+    def test_both_zero_returns_false(self, broker):
+        assert broker._check_spread(0.0, 0.0) is False
+
+    def test_negative_bid_returns_false(self, broker):
+        assert broker._check_spread(-1.0, 100.0) is False
+
+    def test_normal_spread_within_threshold_returns_true(self, broker):
+        # spread = (100.2 - 100.0) / 100.1 * 100 ≈ 0.2% < 0.5%
+        assert broker._check_spread(100.0, 100.2) is True
+
+    def test_spread_exceeds_threshold_returns_false(self, broker):
+        # spread = (101.0 - 99.0) / 100.0 * 100 = 2.0% > 0.5%
+        assert broker._check_spread(99.0, 101.0) is False
+
+    def test_spread_equal_threshold_returns_true(self, broker):
+        # spread = (100.5 - 99.5) / 100.0 * 100 = 1.0% — threshold 맞춰 커스텀
+        b = broker
+        b.SPREAD_THRESHOLD_PCT = 1.0
+        assert b._check_spread(99.5, 100.5) is True

--- a/tests/test_infra_broker.py
+++ b/tests/test_infra_broker.py
@@ -140,3 +140,6 @@ class TestCheckSpread:
         b = broker
         b.SPREAD_THRESHOLD_PCT = 1.0
         assert b._check_spread(99.5, 100.5) is True
+
+    def test_inverted_spread_returns_false(self, broker):
+        assert broker._check_spread(100.0, 90.0) is False


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- `KisBrokerCommon._check_spread`에서 bid/ask가 0 이하일 때 `True` → `False`로 변경
- 호가 조회 실패 시 `order.price` 폴백으로 주문이 진행되던 위험 경로 차단
- 기존 caller(`kis_base.py`, `kis_domestic.py`, `kis_overseas.py`)는 이미 `if not _check_spread: continue`로 처리하므로 추가 수정 없이 안전하게 주문 스킵

## Test plan
- [ ] `TestCheckSpread::test_ask_zero_returns_false` — ask=0 → False
- [ ] `TestCheckSpread::test_bid_zero_returns_false` — bid=0 → False
- [ ] `TestCheckSpread::test_both_zero_returns_false` — 둘 다 0 → False
- [ ] `TestCheckSpread::test_negative_bid_returns_false` — 음수 bid → False
- [ ] `TestCheckSpread::test_normal_spread_within_threshold_returns_true` — 정상 호가 → True
- [ ] `TestCheckSpread::test_spread_exceeds_threshold_returns_false` — 스프레드 초과 → False
- [ ] `TestCheckSpread::test_spread_equal_threshold_returns_true` — 임계값 동일 → True

Closes #47

https://claude.ai/code/session_015PXJaXS1A6Ff2g9XehPSeT
EOF
)