### PR TITLE
fix: 해외 포트폴리오 조회 전체 실패 시 RuntimeError 발생 (#48)

### DIFF
--- a/src/infra/broker/kis_overseas.py
+++ b/src/infra/broker/kis_overseas.py
@@ -94,6 +94,11 @@ class KisOverseasBrokerBase(KisBrokerCommon):
             except Exception as e:
                 self.logger.error(f"[KisBroker] Error getting portfolio ({exch}): {e}")
 
+        if not cash_fetched:
+            raise RuntimeError(
+                "모든 거래소(NASD/NYSE/AMEX) 잔고 조회 실패 — 사이클을 중단합니다."
+            )
+
         return Portfolio(
             total_cash=total_cash,
             holdings=all_holdings,

--- a/src/infra/broker/kis_overseas.py
+++ b/src/infra/broker/kis_overseas.py
@@ -96,7 +96,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
 
         if not cash_fetched:
             raise RuntimeError(
-                "모든 거래소(NASD/NYSE/AMEX) 잔고 조회 실패 — 사이클을 중단합니다."
+                f"모든 거래소({'/'.join(target_exchanges)}) 잔고 조회 실패 — 사이클을 중단합니다."
             )
 
         return Portfolio(

--- a/tests/test_infra_broker.py
+++ b/tests/test_infra_broker.py
@@ -3,6 +3,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 from src.infra.broker.mock import MockBroker
 from src.infra.broker.kis_base import KisBrokerCommon
+from src.infra.broker.kis_overseas import KisOverseasBrokerBase
 from src.core.models import Order, OrderAction, ExecutionStatus
 
 
@@ -143,3 +144,59 @@ class TestCheckSpread:
 
     def test_inverted_spread_returns_false(self, broker):
         assert broker._check_spread(100.0, 90.0) is False
+
+
+class TestKisOverseasGetPortfolio:
+    @pytest.fixture
+    def broker(self):
+        from datetime import datetime, timedelta
+        b = KisOverseasBrokerBase.__new__(KisOverseasBrokerBase)
+        b.logger = MagicMock()
+        b.base_url = "https://fake"
+        b.cano = "12345678"
+        b.acnt_prdt_cd = "01"
+        b.PORTFOLIO_TR_ID = "TTTS3012R"
+        b.app_key = "fake_key"
+        b.app_secret = "fake_secret"
+        b.access_token = "fake_token"
+        b.token_expires_at = datetime.now() + timedelta(hours=1)
+        return b
+
+    @patch("src.infra.broker.kis_overseas._pkg.requests.get")
+    def test_all_exchanges_fail_raises_runtime_error(self, mock_get, broker):
+        """모든 거래소 조회 실패 시 RuntimeError 발생"""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"rt_cd": "1", "msg1": "error"}
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+
+        with pytest.raises(RuntimeError, match="모든 거래소"):
+            broker.get_portfolio()
+
+    @patch("src.infra.broker.kis_overseas._pkg.requests.get")
+    def test_all_exchanges_raise_exception_raises_runtime_error(self, mock_get, broker):
+        """모든 거래소에서 예외 발생 시 RuntimeError 발생"""
+        mock_get.side_effect = Exception("network error")
+
+        with pytest.raises(RuntimeError, match="모든 거래소"):
+            broker.get_portfolio()
+
+    @patch("src.infra.broker.kis_overseas._pkg.requests.get")
+    def test_first_exchange_fails_second_succeeds(self, mock_get, broker):
+        """첫 번째 거래소 실패 → 두 번째 성공 시 total_cash 정상 반환"""
+        fail_resp = MagicMock()
+        fail_resp.json.return_value = {"rt_cd": "1", "msg1": "error"}
+        fail_resp.raise_for_status.return_value = None
+
+        success_resp = MagicMock()
+        success_resp.raise_for_status.return_value = None
+        success_resp.json.return_value = {
+            "rt_cd": "0",
+            "output1": [],
+            "output2": {"ovrs_ord_psbl_amt": "5000.00"},
+        }
+
+        mock_get.side_effect = [fail_resp, success_resp, success_resp]
+
+        pf = broker.get_portfolio()
+        assert pf.total_cash == 5000.0


### PR DESCRIPTION
## Summary

- `KisOverseasBrokerBase.get_portfolio()`에서 NASD/NYSE/AMEX 모든 거래소 조회가 실패해도 `total_cash=0`으로 조용히 반환되던 버그 수정
- 루프 종료 후 `cash_fetched=False`이면 `RuntimeError`를 발생시켜 엔진이 해당 사이클을 즉시 중단하도록 변경
- 기존 동작: `budget = 0 * 0.98 = 0` → 모든 매수 주문이 0주로 조정되어 예외 없이 스킵

## Test plan

- [ ] `test_all_exchanges_fail_raises_runtime_error`: 모든 거래소가 rt_cd≠'0' 반환 시 RuntimeError 발생 확인
- [ ] `test_all_exchanges_raise_exception_raises_runtime_error`: 모든 거래소에서 네트워크 예외 발생 시 RuntimeError 확인
- [ ] `test_first_exchange_fails_second_succeeds`: 첫 거래소 실패 → 두 번째 성공 시 정상 Portfolio 반환 확인
- [ ] 기존 145개 테스트 모두 통과

Closes #48

https://claude.ai/code/session_01LXSrXSe4XSxJub3usubDGo