### PR TITLE
fix: MockBroker SELL 보유량 0일 때 REJECTED 반환 (#52)

### DIFF
--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -232,6 +232,11 @@ class MagicSplitEngine:
             signal_map[(sig.ticker, sig.action)] = sig
 
         for exe in executions:
+            if exe.status == ExecutionStatus.REJECTED:
+                self.logger.warning(
+                    f"[Position] Skip: {exe.ticker} {exe.action} rejected"
+                )
+                continue
             if exe.action == OrderAction.BUY:
                 sig = signal_map.get((exe.ticker, OrderAction.BUY))
                 level = sig.level if sig else 1
@@ -252,11 +257,6 @@ class MagicSplitEngine:
                 )
 
             elif exe.action == OrderAction.SELL:
-                if exe.status == ExecutionStatus.REJECTED:
-                    self.logger.warning(
-                        f"[Position] Skip lot removal: {exe.ticker} SELL rejected"
-                    )
-                    continue
                 sig = signal_map.get((exe.ticker, OrderAction.SELL))
                 if sig and sig.lot_id:
                     # 신호에 지정된 lot_id로 제거

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -11,6 +11,7 @@ from src.core.models import (
     Order,
     OrderAction,
     TradeExecution,
+    ExecutionStatus,
     SplitSignal,
     DayResult,
 )
@@ -251,6 +252,11 @@ class MagicSplitEngine:
                 )
 
             elif exe.action == OrderAction.SELL:
+                if exe.status == ExecutionStatus.REJECTED:
+                    self.logger.warning(
+                        f"[Position] Skip lot removal: {exe.ticker} SELL rejected"
+                    )
+                    continue
                 sig = signal_map.get((exe.ticker, OrderAction.SELL))
                 if sig and sig.lot_id:
                     # 신호에 지정된 lot_id로 제거

--- a/src/infra/broker/mock.py
+++ b/src/infra/broker/mock.py
@@ -83,6 +83,22 @@ class MockBroker(IBrokerAdapter):
         elif order.action == OrderAction.SELL:
             current_qty = self.holdings.get(order.ticker, 0)
             actual_qty = min(order.quantity, current_qty)
+
+            if actual_qty <= 0:
+                if self.logger:
+                    self.logger.warning(
+                        f"[REJECTED] SELL {order.ticker}: 보유량 없음 (보유: {current_qty}주)"
+                    )
+                return TradeExecution(
+                    ticker=order.ticker,
+                    action=order.action,
+                    quantity=0,
+                    price=round(exec_price, 2),
+                    fee=0.0,
+                    date=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                    status=ExecutionStatus.REJECTED,
+                )
+
             if actual_qty < order.quantity and self.logger:
                 self.logger.warning(
                     f"[QTY ADJUSTED] {order.ticker} SELL: "

--- a/tests/test_infra_broker.py
+++ b/tests/test_infra_broker.py
@@ -81,6 +81,29 @@ class TestMockBroker:
 
         assert executions[0].quantity == 3  # 보유량만큼만
 
+    def test_sell_with_zero_holdings_returns_rejected(self):
+        """보유량 0인 종목 매도 시도 → REJECTED 반환, 상태 변경 없음"""
+        from src.core.models import ExecutionStatus
+        initial_cash = 5000.0
+        broker = MockBroker(initial_cash=initial_cash, holdings={"AAPL": 0}, prices={"AAPL": 100.0})
+        orders = [Order("AAPL", OrderAction.SELL, 10, 100.0)]
+        executions = broker.execute_orders(orders)
+
+        assert len(executions) == 1
+        assert executions[0].status == ExecutionStatus.REJECTED
+        assert executions[0].quantity == 0
+        assert broker.cash == initial_cash  # 현금 변동 없음
+        assert broker.holdings.get("AAPL", 0) == 0  # 보유량 변동 없음
+
+    def test_sell_unowned_ticker_returns_rejected(self):
+        """보유하지 않은 종목 매도 시도 → REJECTED 반환"""
+        from src.core.models import ExecutionStatus
+        broker = MockBroker(holdings={}, prices={"AAPL": 100.0})
+        orders = [Order("AAPL", OrderAction.SELL, 5, 100.0)]
+        executions = broker.execute_orders(orders)
+
+        assert executions[0].status == ExecutionStatus.REJECTED
+
     def test_buy_insufficient_cash(self):
         """자금 부족 시 가능한 만큼만 매수"""
         broker = MockBroker(initial_cash=200.0, prices={"AAPL": 100.0})

--- a/tests/test_infra_broker.py
+++ b/tests/test_infra_broker.py
@@ -83,7 +83,6 @@ class TestMockBroker:
 
     def test_sell_with_zero_holdings_returns_rejected(self):
         """보유량 0인 종목 매도 시도 → REJECTED 반환, 상태 변경 없음"""
-        from src.core.models import ExecutionStatus
         initial_cash = 5000.0
         broker = MockBroker(initial_cash=initial_cash, holdings={"AAPL": 0}, prices={"AAPL": 100.0})
         orders = [Order("AAPL", OrderAction.SELL, 10, 100.0)]
@@ -97,7 +96,6 @@ class TestMockBroker:
 
     def test_sell_unowned_ticker_returns_rejected(self):
         """보유하지 않은 종목 매도 시도 → REJECTED 반환"""
-        from src.core.models import ExecutionStatus
         broker = MockBroker(holdings={}, prices={"AAPL": 100.0})
         orders = [Order("AAPL", OrderAction.SELL, 5, 100.0)]
         executions = broker.execute_orders(orders)


### PR DESCRIPTION
## Summary

- **MockBroker**: `actual_qty <= 0`인 SELL 주문은 `ExecutionStatus.REJECTED` 반환, `cash`/`holdings` 상태 변경 없음
- **Engine**: `_update_positions`에서 REJECTED 체결은 lot 제거를 skip
- **테스트 2개 추가**: 보유량 0 SELL → REJECTED, 미보유 종목 SELL → REJECTED

## 배경

증권앱으로 수동 매매 시 `broker.holdings`는 즉시 반영되지만 `positions.json`은 봇이 모름. 다음 사이클에 봇이 `positions.json`을 보고 SELL 신호를 생성하면 실제 보유량이 0인데 `FILLED`가 반환되는 버그 발생.

## Test plan

- [ ] `test_sell_with_zero_holdings_returns_rejected` 통과 확인
- [ ] `test_sell_unowned_ticker_returns_rejected` 통과 확인
- [ ] 기존 147개 테스트 전체 통과 확인

Closes #52

https://claude.ai/code/session_01CGVSwScdXbER5HV2skS25t