### PR TITLE
feat: 브로커 보유수량 ↔ positions 불일치 감지 및 매매 중단

### DIFF
--- a/scripts/reconcile_positions.py
+++ b/scripts/reconcile_positions.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""브로커 보유수량과 positions.json 의 차수별 수량 합 불일치를 수동으로 보정하는 CLI.
+
+엔진은 불일치 감지 시 해당 종목 매매를 중단한다. 이 스크립트로 사용자가
+직접 lot 데이터를 조정한 뒤 엔진을 재개한다.
+
+동작:
+    1. 브로커 portfolio 조회 + positions.json 로드
+    2. detect_mismatches() 로 불일치 종목 나열
+    3. 각 종목마다 사용자에게 선택지 제시:
+        [s] shrink: positions 가 많을 때 최고 차수부터 축소/제거
+        [p] pad   : broker 가 많을 때 새 lot 추가
+        [r] ratio : 주식분할/병합 비율 적용 (모든 lot quantity/price 일괄 조정)
+        [k] keep  : 그대로 두기
+    4. 변경 사항 dry-run 출력 → 최종 확인 → 저장
+
+사용:
+    python scripts/reconcile_positions.py                 # 대화형
+    python scripts/reconcile_positions.py --dry-run       # 저장 없이 미리보기만
+"""
+import argparse
+import os
+import sys
+from datetime import datetime
+from typing import List, Optional
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
+
+from src.config import Config
+from src.core.logic.position_reconciler import QuantityMismatch, detect_mismatches
+from src.core.models import PositionLot
+from src.infra.broker import (
+    KisDomesticLiveBroker,
+    KisDomesticPaperBroker,
+    KisOverseasLiveBroker,
+    KisOverseasPaperBroker,
+)
+from src.infra.repo import JsonRepository
+from src.strategy_config import StrategyConfig
+from src.utils.logger import TradeLogger
+
+
+def _prompt(msg: str, default: str = "") -> str:
+    suffix = f" [{default}]" if default else ""
+    val = input(f"{msg}{suffix}: ").strip()
+    return val or default
+
+
+def _prompt_int(msg: str, default: Optional[int] = None) -> Optional[int]:
+    default_str = str(default) if default is not None else ""
+    val = _prompt(msg, default_str)
+    if not val:
+        return None
+    try:
+        return int(val)
+    except ValueError:
+        print(f"  ⚠️  정수가 아닙니다: {val!r}")
+        return _prompt_int(msg, default)
+
+
+def _prompt_float(msg: str, default: Optional[float] = None) -> Optional[float]:
+    default_str = str(default) if default is not None else ""
+    val = _prompt(msg, default_str)
+    if not val:
+        return None
+    try:
+        return float(val)
+    except ValueError:
+        print(f"  ⚠️  숫자가 아닙니다: {val!r}")
+        return _prompt_float(msg, default)
+
+
+def _shrink_to(lots: List[PositionLot], ticker: str, target_qty: int) -> List[PositionLot]:
+    """최고 차수 lot 부터 수량을 축소하여 전체 합을 target_qty 로 맞춘다."""
+    ticker_lots = sorted(
+        [l for l in lots if l.ticker == ticker],
+        key=lambda l: l.level,
+        reverse=True,
+    )
+    remaining = sum(l.quantity for l in ticker_lots) - target_qty
+    if remaining < 0:
+        raise ValueError(
+            f"target_qty({target_qty}) 가 현재 수량 합보다 큽니다. pad 를 사용하세요."
+        )
+
+    out = [l for l in lots if l.ticker != ticker]
+    for lot in ticker_lots:
+        if remaining <= 0:
+            out.append(lot)
+            continue
+        if remaining >= lot.quantity:
+            remaining -= lot.quantity
+            continue
+        out.append(PositionLot(
+            lot_id=lot.lot_id,
+            ticker=lot.ticker,
+            buy_price=lot.buy_price,
+            quantity=lot.quantity - remaining,
+            buy_date=lot.buy_date,
+            level=lot.level,
+        ))
+        remaining = 0
+    return out
+
+
+def _pad_with_lot(
+    lots: List[PositionLot],
+    ticker: str,
+    level: int,
+    quantity: int,
+    buy_price: float,
+) -> List[PositionLot]:
+    """브로커 초과분을 포함하는 새 lot 을 추가한다."""
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    new_lot = PositionLot(
+        lot_id=f"lot_{ts}_{ticker}_{level:03d}_reconcile",
+        ticker=ticker,
+        buy_price=buy_price,
+        quantity=quantity,
+        buy_date=datetime.now().strftime("%Y-%m-%d"),
+        level=level,
+    )
+    return lots + [new_lot]
+
+
+def _apply_split_ratio(
+    lots: List[PositionLot],
+    ticker: str,
+    num: int,
+    den: int,
+) -> List[PositionLot]:
+    """주식분할/병합 비율 적용 (num:den, 예 1:2 → 1주를 2주로)."""
+    if num <= 0 or den <= 0:
+        raise ValueError("비율은 양수여야 합니다.")
+    out: List[PositionLot] = []
+    for lot in lots:
+        if lot.ticker != ticker:
+            out.append(lot)
+            continue
+        new_qty = lot.quantity * den // num
+        new_price = lot.buy_price * num / den
+        out.append(PositionLot(
+            lot_id=lot.lot_id,
+            ticker=lot.ticker,
+            buy_price=round(new_price, 4),
+            quantity=new_qty,
+            buy_date=lot.buy_date,
+            level=lot.level,
+        ))
+    return out
+
+
+def _print_mismatch(m: QuantityMismatch) -> None:
+    print()
+    print(f"── [{m.ticker}] ─────────────────────────────")
+    print(f"  broker_qty   : {m.broker_qty}")
+    print(f"  positions_qty: {m.positions_qty}  (lots={m.lot_count}, levels={m.levels})")
+    print(f"  diff         : {m.diff:+d}")
+
+
+def _handle_ticker(
+    mismatch: QuantityMismatch,
+    lots: List[PositionLot],
+) -> List[PositionLot]:
+    _print_mismatch(mismatch)
+    while True:
+        choice = _prompt(
+            "  액션 [s=shrink / p=pad / r=ratio / k=keep]", default="k",
+        ).lower()
+
+        if choice == "k":
+            return lots
+
+        if choice == "s":
+            target = _prompt_int(
+                "  목표 수량(브로커와 일치시킬 값)", default=mismatch.broker_qty,
+            )
+            if target is None:
+                continue
+            try:
+                return _shrink_to(lots, mismatch.ticker, target)
+            except ValueError as e:
+                print(f"  ⚠️  {e}")
+                continue
+
+        if choice == "p":
+            qty = _prompt_int(
+                "  새 lot 수량", default=max(0, mismatch.diff),
+            )
+            if qty is None or qty <= 0:
+                continue
+            price = _prompt_float("  매수가 (buy_price)")
+            if price is None or price <= 0:
+                continue
+            next_level = (max(mismatch.levels) if mismatch.levels else 0) + 1
+            level = _prompt_int("  차수(level)", default=next_level) or next_level
+            return _pad_with_lot(lots, mismatch.ticker, level, qty, price)
+
+        if choice == "r":
+            ratio = _prompt("  분할/병합 비율 (num:den, 예 1:2)")
+            if ":" not in ratio:
+                print("  ⚠️  형식 오류")
+                continue
+            try:
+                num, den = [int(x) for x in ratio.split(":", 1)]
+            except ValueError:
+                print("  ⚠️  정수 형식 오류")
+                continue
+            try:
+                return _apply_split_ratio(lots, mismatch.ticker, num, den)
+            except ValueError as e:
+                print(f"  ⚠️  {e}")
+                continue
+
+        print("  ⚠️  알 수 없는 액션")
+
+
+def _build_repo_and_broker(logger):
+    config = Config()
+    strategy = StrategyConfig(config.CONFIG_JSON_PATH)
+    rules = [r for r in strategy.rules if r.enabled] or strategy.rules
+    if not rules:
+        raise ValueError("config.json 에 종목이 없습니다.")
+    market_type = rules[0].market_type
+
+    if market_type == "domestic":
+        broker_cls = KisDomesticLiveBroker if config.IS_LIVE else KisDomesticPaperBroker
+    else:
+        broker_cls = KisOverseasLiveBroker if config.IS_LIVE else KisOverseasPaperBroker
+    broker = broker_cls(
+        config.KIS_APP_KEY, config.KIS_APP_SECRET, config.KIS_ACC_NO, logger,
+    )
+    repo = JsonRepository(
+        os.path.join(config.DATA_PATH, market_type),
+        max_history_records=config.MAX_HISTORY_RECORDS,
+    )
+    return repo, broker, strategy.rules, market_type
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="positions.json 에 저장하지 않고 미리보기만 출력",
+    )
+    args = parser.parse_args()
+
+    logger = TradeLogger(Config().LOG_PATH)
+    repo, broker, rules, market_type = _build_repo_and_broker(logger)
+
+    print(f"=== reconcile_positions ({market_type}) ===")
+    portfolio = broker.get_portfolio()
+    positions = repo.load_positions()
+    mismatches = detect_mismatches(positions, portfolio, rules)
+
+    if not mismatches:
+        print("✓ 불일치 없음. 수량이 모두 일치합니다.")
+        return 0
+
+    print(f"불일치 {len(mismatches)}건:")
+    lots = list(positions)
+    for m in mismatches:
+        lots = _handle_ticker(m, lots)
+
+    print()
+    print("── 변경 후 수량 요약 ──")
+    after_mismatches = detect_mismatches(lots, portfolio, rules)
+    for ticker in sorted({m.ticker for m in mismatches}):
+        after = [a for a in after_mismatches if a.ticker == ticker]
+        if after:
+            print(f"  {ticker}: 여전히 불일치 {after[0].diff:+d}")
+        else:
+            print(f"  {ticker}: ✓ 일치")
+
+    if args.dry_run:
+        print()
+        print("--dry-run 모드: 저장하지 않습니다.")
+        return 0
+
+    confirm = _prompt("positions.json 에 저장할까요? (y/N)", default="N").lower()
+    if confirm != "y":
+        print("취소. 변경 사항을 버립니다.")
+        return 0
+
+    repo.save_positions(lots)
+    print("✓ 저장 완료.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/reconcile_positions.py
+++ b/scripts/reconcile_positions.py
@@ -218,7 +218,9 @@ def _handle_ticker(
 def _build_repo_and_broker(logger):
     config = Config()
     strategy = StrategyConfig(config.CONFIG_JSON_PATH)
-    rules = [r for r in strategy.rules if r.enabled] or strategy.rules
+    # detect_mismatches 는 enabled 여부와 무관하게 모든 rule ∪ positions 티커를
+    # 검사하므로, 여기서는 전체 rule 을 그대로 전달한다.
+    rules = strategy.rules
     if not rules:
         raise ValueError("config.json 에 종목이 없습니다.")
     market_type = rules[0].market_type

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -1,7 +1,7 @@
 # src/core/engine/base.py
 import time
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Set
 
 from src.core.interfaces import IBrokerAdapter, IRepository, ILogger, INotifier
 from src.core.models import (
@@ -14,7 +14,7 @@ from src.core.models import (
     SplitSignal,
     DayResult,
 )
-from src.core.logic import SplitEvaluator
+from src.core.logic import SplitEvaluator, detect_mismatches
 from src.core.engine.registry import register_engine
 
 
@@ -81,8 +81,19 @@ class MagicSplitEngine:
             positions = self.repo.load_positions()
             self.logger.info(f"Loaded {len(positions)} position lot(s)")
 
+            # Step 2.5: 브로커 수량 ↔ positions 수량 합 불일치 검사
+            # 불일치 종목은 이번 사이클에서 매매 중단 (자동 보정 미지원)
+            halted_tickers = self._check_reconcile(positions, portfolio)
+
             # Step 3~5: 종목별 순차 실행
             for rule in self.stock_rules:
+                if rule.ticker in halted_tickers:
+                    self.logger.warning(
+                        f"[{rule.ticker}] 수량 불일치로 매매 중단. "
+                        f"scripts/reconcile_positions.py 로 보정 후 재실행."
+                    )
+                    failed_tickers.append(rule.ticker)
+                    continue
                 try:
                     self.logger.info(f">>> Processing {rule.ticker}")
 
@@ -198,6 +209,33 @@ class MagicSplitEngine:
         if not executions:
             self._notify_alert("Orders sent but NO execution result returned.")
         return executions
+
+    def _check_reconcile(
+        self,
+        positions: List[PositionLot],
+        portfolio: Portfolio,
+    ) -> Set[str]:
+        """브로커 보유수량과 positions 수량 합의 불일치 티커 집합을 반환한다.
+
+        불일치 감지 시 로그 + 알림을 발송한다. 자동 보정은 수행하지 않는다.
+        """
+        mismatches = detect_mismatches(positions, portfolio, self.stock_rules)
+        if not mismatches:
+            self.logger.info(">>> Step 2.5: Reconcile OK (수량 일치)")
+            return set()
+
+        self.logger.error(
+            f">>> Step 2.5: 수량 불일치 {len(mismatches)}건 감지 — 해당 종목 매매 중단"
+        )
+        for m in mismatches:
+            msg = (
+                f"[{m.ticker}] Qty Mismatch: broker={m.broker_qty}, "
+                f"positions={m.positions_qty} (lots={m.lot_count}, levels={m.levels}) "
+                f"— 매매 중단. scripts/reconcile_positions.py 실행 권장."
+            )
+            self.logger.error(msg)
+            self._notify_alert(msg)
+        return {m.ticker for m in mismatches}
 
     def _refresh_portfolio(self, old_portfolio: Portfolio) -> Portfolio:
         """종목 처리 후 포트폴리오(현금 잔고) 갱신."""

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -224,17 +224,21 @@ class MagicSplitEngine:
             self.logger.info(">>> Step 2.5: Reconcile OK (수량 일치)")
             return set()
 
-        self.logger.error(
-            f">>> Step 2.5: 수량 불일치 {len(mismatches)}건 감지 — 해당 종목 매매 중단"
+        # 불일치 N건을 한 통의 알림으로 묶어 전송 — 대규모 코퍼릿 액션 등으로
+        # 다수 종목이 동시에 불일치할 때 Slack 스팸을 방지한다.
+        detail_lines = [
+            f"[{m.ticker}] Qty Mismatch: broker={m.broker_qty}, "
+            f"positions={m.positions_qty} (lots={m.lot_count}, levels={m.levels})"
+            for m in mismatches
+        ]
+        summary = (
+            f">>> Step 2.5: 수량 불일치 {len(mismatches)}건 감지 — "
+            f"해당 종목 매매 중단\n"
+            + "\n".join(detail_lines)
+            + "\n실행 권장: scripts/reconcile_positions.py"
         )
-        for m in mismatches:
-            msg = (
-                f"[{m.ticker}] Qty Mismatch: broker={m.broker_qty}, "
-                f"positions={m.positions_qty} (lots={m.lot_count}, levels={m.levels}) "
-                f"— 매매 중단. scripts/reconcile_positions.py 실행 권장."
-            )
-            self.logger.error(msg)
-            self._notify_alert(msg)
+        self.logger.error(summary)
+        self._notify_alert(summary)
         return {m.ticker for m in mismatches}
 
     def _refresh_portfolio(self, old_portfolio: Portfolio) -> Portfolio:

--- a/src/core/logic/__init__.py
+++ b/src/core/logic/__init__.py
@@ -1,3 +1,4 @@
+from src.core.logic.position_reconciler import QuantityMismatch, detect_mismatches
 from src.core.logic.split_evaluator import SplitEvaluator
 
-__all__ = ["SplitEvaluator"]
+__all__ = ["SplitEvaluator", "QuantityMismatch", "detect_mismatches"]

--- a/src/core/logic/position_reconciler.py
+++ b/src/core/logic/position_reconciler.py
@@ -1,0 +1,55 @@
+# src/core/logic/position_reconciler.py
+from dataclasses import dataclass
+from typing import List
+
+from src.core.models import PositionLot, Portfolio, StockRule
+
+
+@dataclass
+class QuantityMismatch:
+    """브로커 보유수량과 positions.json 차수별 수량 합의 불일치 내역."""
+    ticker: str
+    broker_qty: int
+    positions_qty: int
+    lot_count: int
+    levels: List[int]
+
+    @property
+    def diff(self) -> int:
+        """broker_qty - positions_qty (양수면 브로커가 많음)."""
+        return self.broker_qty - self.positions_qty
+
+
+def detect_mismatches(
+    positions: List[PositionLot],
+    portfolio: Portfolio,
+    rules: List[StockRule],
+) -> List[QuantityMismatch]:
+    """브로커 보유수량과 positions.json 수량 합의 불일치 종목을 찾아 반환한다.
+
+    검사 대상: rules 에 정의된 모든 ticker ∪ positions 에 등장하는 ticker.
+    rules 에 정의되지 않고 positions 에도 없는, 단순히 브로커에만 있는 ticker 는
+    봇의 관리 대상이 아니므로 무시한다 (수동으로 별도 매수한 종목 등).
+    """
+    rule_tickers = {r.ticker for r in rules}
+    position_tickers = {lot.ticker for lot in positions}
+    target_tickers = rule_tickers | position_tickers
+
+    mismatches: List[QuantityMismatch] = []
+    for ticker in sorted(target_tickers):
+        ticker_lots = [lot for lot in positions if lot.ticker == ticker]
+        positions_qty = sum(lot.quantity for lot in ticker_lots)
+        broker_qty = int(portfolio.holdings.get(ticker, 0))
+
+        if broker_qty == positions_qty:
+            continue
+
+        mismatches.append(QuantityMismatch(
+            ticker=ticker,
+            broker_qty=broker_qty,
+            positions_qty=positions_qty,
+            lot_count=len(ticker_lots),
+            levels=sorted(lot.level for lot in ticker_lots),
+        ))
+
+    return mismatches

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -13,7 +13,7 @@ def mock_broker():
     broker = MagicMock()
     broker.get_portfolio.return_value = Portfolio(
         total_cash=10000.0,
-        holdings={"AAPL": 5},
+        holdings={},
         current_prices={"AAPL": 100.0},
     )
     broker.fetch_current_prices.return_value = {"AAPL": 100.0}
@@ -194,6 +194,12 @@ class TestRunOneCycle:
         mock_repo.load_positions.return_value = [
             PositionLot("lot_001", "AAPL", 90.0, 5, "2026-04-01", level=1),
         ]
+        # 브로커 수량과 positions 합 일치 (불일치 감지 회피)
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0,
+            holdings={"AAPL": 5},
+            current_prices={"AAPL": 100.0},
+        )
 
         execution = TradeExecution(
             "AAPL", OrderAction.SELL, 5, 99.9, 1.25,
@@ -205,6 +211,78 @@ class TestRunOneCycle:
 
         assert result.has_orders is True
         mock_repo.save_positions.assert_called_once()
+
+
+class TestReconcileHalt:
+    """브로커 수량 ≠ positions 수량 합 불일치 감지 후 매매 중단 동작."""
+
+    def test_halts_mismatched_ticker_and_trades_others(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """불일치 종목은 스킵, 일치 종목은 정상 매매."""
+        rules = [
+            StockRule("AAPL", -5.0, 10.0, 500, 10),
+            StockRule("MSFT", -5.0, 10.0, 500, 10),
+        ]
+        # AAPL: broker=7, positions sum=5 → 불일치
+        # MSFT: broker=0, positions=[] → 일치
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0,
+            holdings={"AAPL": 7},
+            current_prices={"AAPL": 100.0, "MSFT": 200.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 100.0, "MSFT": 200.0}
+        mock_repo.load_positions.return_value = [
+            PositionLot("lot_001", "AAPL", 90.0, 5, "2026-04-01", level=1),
+        ]
+
+        notifier = MagicMock()
+        engine = MagicSplitEngine(
+            broker=mock_broker, repo=mock_repo,
+            logger=mock_logger, stock_rules=rules, notifier=notifier,
+        )
+
+        msft_exe = TradeExecution(
+            "MSFT", OrderAction.BUY, 2, 200.0, 1.0,
+            "2026-04-10", ExecutionStatus.FILLED,
+        )
+        mock_broker.execute_orders.return_value = [msft_exe]
+
+        result = engine.run_one_cycle(sim_date="2026-04-10")
+
+        # AAPL 은 매매 신호/체결 없어야 한다
+        assert all(s.ticker != "AAPL" for s in result.signals)
+        assert all(e.ticker != "AAPL" for e in result.executions)
+
+        # MSFT 는 정상 처리
+        assert any(e.ticker == "MSFT" for e in result.executions)
+
+        # 알림이 AAPL 불일치로 한 번 이상 호출되어야 한다
+        alert_msgs = [c.args[0] for c in notifier.send_alert.call_args_list]
+        assert any("AAPL" in m and "Mismatch" in m for m in alert_msgs)
+
+    def test_no_halt_when_all_match(self, mock_broker, mock_repo, mock_logger):
+        """모든 종목 수량 일치 시 halt 티커 없음."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0,
+            holdings={"AAPL": 5},
+            current_prices={"AAPL": 100.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 100.0}
+        mock_repo.load_positions.return_value = [
+            PositionLot("lot_001", "AAPL", 90.0, 5, "2026-04-01", level=1),
+        ]
+
+        engine = MagicSplitEngine(
+            broker=mock_broker, repo=mock_repo,
+            logger=mock_logger, stock_rules=rules,
+        )
+        halted = engine._check_reconcile(
+            mock_repo.load_positions.return_value,
+            mock_broker.get_portfolio.return_value,
+        )
+        assert halted == set()
 
 
 class TestUpdatePositions:

--- a/tests/test_position_reconciler.py
+++ b/tests/test_position_reconciler.py
@@ -1,0 +1,89 @@
+# tests/test_position_reconciler.py
+from src.core.logic.position_reconciler import QuantityMismatch, detect_mismatches
+from src.core.models import PositionLot, Portfolio, StockRule
+
+
+def _rule(ticker: str, enabled: bool = True) -> StockRule:
+    return StockRule(ticker, -5.0, 10.0, 500, 10, enabled=enabled)
+
+
+def _lot(ticker: str, qty: int, level: int, lot_id: str = "lot_x") -> PositionLot:
+    return PositionLot(lot_id, ticker, 100.0, qty, "2026-04-01", level=level)
+
+
+def _portfolio(holdings: dict) -> Portfolio:
+    return Portfolio(total_cash=0, holdings=holdings, current_prices={})
+
+
+class TestDetectMismatches:
+    def test_match_returns_empty(self):
+        positions = [_lot("AAPL", 5, 1, "a1"), _lot("AAPL", 3, 2, "a2")]
+        portfolio = _portfolio({"AAPL": 8})
+        assert detect_mismatches(positions, portfolio, [_rule("AAPL")]) == []
+
+    def test_broker_less_than_positions(self):
+        positions = [_lot("AAPL", 5, 1, "a1"), _lot("AAPL", 5, 2, "a2")]
+        portfolio = _portfolio({"AAPL": 7})
+
+        out = detect_mismatches(positions, portfolio, [_rule("AAPL")])
+
+        assert len(out) == 1
+        m = out[0]
+        assert m.ticker == "AAPL"
+        assert m.broker_qty == 7
+        assert m.positions_qty == 10
+        assert m.lot_count == 2
+        assert m.levels == [1, 2]
+        assert m.diff == -3
+
+    def test_broker_greater_than_positions(self):
+        """브로커에는 있지만 positions 에는 없는 경우 — 이중 매수 위험."""
+        portfolio = _portfolio({"AAPL": 5})
+        out = detect_mismatches([], portfolio, [_rule("AAPL")])
+
+        assert len(out) == 1
+        assert out[0].broker_qty == 5
+        assert out[0].positions_qty == 0
+        assert out[0].lot_count == 0
+        assert out[0].levels == []
+        assert out[0].diff == 5
+
+    def test_positions_exist_broker_zero(self):
+        """브로커에서 전량 사라진 경우 (외부 전량 매도 등)."""
+        positions = [_lot("AAPL", 5, 1)]
+        portfolio = _portfolio({})
+
+        out = detect_mismatches(positions, portfolio, [_rule("AAPL")])
+
+        assert len(out) == 1
+        assert out[0].broker_qty == 0
+        assert out[0].positions_qty == 5
+
+    def test_ignores_tickers_not_in_rules_and_not_in_positions(self):
+        """봇 관리 대상이 아닌 티커(브로커에만 있음)는 무시."""
+        portfolio = _portfolio({"TSLA": 10, "AAPL": 5})
+        positions = [_lot("AAPL", 5, 1)]
+
+        out = detect_mismatches(positions, portfolio, [_rule("AAPL")])
+        assert out == []
+
+    def test_disabled_rule_ticker_still_checked_when_lot_exists(self):
+        """disabled rule 이라도 lot 이 남아있으면 검사 대상."""
+        positions = [_lot("MSFT", 3, 1)]
+        portfolio = _portfolio({"MSFT": 5})
+        rules = [_rule("MSFT", enabled=False)]
+
+        out = detect_mismatches(positions, portfolio, rules)
+        assert len(out) == 1
+        assert out[0].ticker == "MSFT"
+
+    def test_multiple_tickers_sorted(self):
+        positions = [_lot("AAPL", 5, 1), _lot("MSFT", 3, 1)]
+        portfolio = _portfolio({"AAPL": 4, "MSFT": 10})
+
+        out = detect_mismatches(positions, portfolio, [_rule("AAPL"), _rule("MSFT")])
+        assert [m.ticker for m in out] == ["AAPL", "MSFT"]
+
+    def test_quantity_mismatch_diff_property(self):
+        m = QuantityMismatch("X", broker_qty=3, positions_qty=5, lot_count=1, levels=[1])
+        assert m.diff == -2


### PR DESCRIPTION
## Summary

- 각 종목에 대해 **브로커 보유수량**과 **positions.json 의 차수별 수량 합**은 이론적으로 같아야 하지만, 증권 앱으로 직접 매매하거나 주식 분할/병합 이벤트가 있을 때 불일치가 발생할 수 있다.
- 사이클 시작 시점에 불일치를 감지하여 **해당 종목 매매를 중단(halt) + Slack 알림** 을 발송한다. 자동 보정은 하지 않는다 (사용자 선택).
- 수동 보정은 `scripts/reconcile_positions.py` 대화형 CLI 에서 `shrink` / `pad` / `ratio` 옵션으로 수행한다.

## Changes

| 파일 | 내용 |
|---|---|
| `src/core/logic/position_reconciler.py` (신규) | `QuantityMismatch` dataclass + `detect_mismatches(positions, portfolio, rules)` |
| `src/core/logic/__init__.py` | `QuantityMismatch`, `detect_mismatches` export |
| `src/core/engine/base.py` | `run_one_cycle()` 에 Step 2.5 reconcile check 추가, 불일치 티커는 종목 루프에서 스킵하고 실패 목록으로 기록 |
| `scripts/reconcile_positions.py` (신규) | `KisBroker.get_portfolio()` + `JsonRepository` 재사용하는 대화형 수동 보정 도구. `--dry-run` 지원 |
| `tests/test_position_reconciler.py` (신규) | `detect_mismatches()` 단위 테스트 8개 |
| `tests/test_core_engine.py` | 엔진 halt 동작 테스트 추가, 기존 fixture 의 holdings 를 비우고 sell 테스트에서 명시적으로 설정 |

## 설계 원칙

- **엔진은 positions.json 을 자동 수정하지 않는다**: 잘못된 보정은 손실 가능. 사용자 판단으로 CLI 에서만 수정.
- **감지 범위**: `rules` 에 정의된 티커 ∪ `positions` 에 등장하는 티커. 봇 관리 대상이 아닌(수동으로 산) 티커는 무시.
- **Step 3c `_refresh_portfolio` 이후에는 재검사하지 않는다**: 정상 체결로 수량이 바뀌는 건 자연스러우므로.

## Test plan

- [x] `pytest --cov=src --cov-report=term-missing --cov-fail-under=80 tests/` — 155 passed, coverage 80.35%
- [x] 새 단위 테스트 `tests/test_position_reconciler.py` — match, broker < positions, broker > positions, positions empty broker zero, disabled rule, ignore unmanaged ticker, multi-ticker sort, diff property
- [x] 엔진 halt 테스트 `TestReconcileHalt::test_halts_mismatched_ticker_and_trades_others` — 불일치 종목은 스킵되고 정상 종목은 매매 진행, 알림 1회 이상 발송
- [x] CLI 스크립트 import 확인 (`python -c "import scripts.reconcile_positions"`)
- [ ] 실거래 환경에서 `python scripts/reconcile_positions.py --dry-run` 수동 스모크

https://claude.ai/code/session_019ztVkHGzsszAzuo7mdxP9C