### PR TITLE
fix(#45): kis_overseas.py의 dead code _send_order 메서드 제거

### DIFF
--- a/src/infra/broker/kis_overseas.py
+++ b/src/infra/broker/kis_overseas.py
@@ -105,69 +105,6 @@ class KisOverseasBrokerBase(KisBrokerCommon):
             current_prices=all_prices
         )
 
-    def _send_order(self, order: Order) -> Optional[TradeExecution]:
-        """실제 주문 API 호출 (체결 대기 없음)"""
-        tr_id = self.BUY_TR_ID if order.action == OrderAction.BUY else self.SELL_TR_ID
-
-        url = f"{self.base_url}/uapi/overseas-stock/v1/trading/order"
-        exch = self._get_exchange_code(order.ticker, api_type="order")
-
-        bid, ask = self._fetch_asking_price(order.ticker)
-
-        if not self._check_spread(bid, ask):
-            mid = (bid + ask) / 2
-            spread_pct = (ask - bid) / mid * 100
-            self.logger.warning(
-                f"[KisBroker] 스프레드 비정상 — {order.ticker} "
-                f"bid={bid} ask={ask} spread={spread_pct:.2f}% > {self.SPREAD_THRESHOLD_PCT}% — 주문 보류"
-            )
-            return None
-
-        if order.action == OrderAction.BUY:
-            order_price = round(ask, 2) if ask > 0 else round(order.price, 2)
-        else:
-            order_price = round(bid, 2) if bid > 0 else round(order.price, 2)
-
-        data = {
-            "CANO": self.cano,
-            "ACNT_PRDT_CD": self.acnt_prdt_cd,
-            "OVRS_EXCG_CD": exch,
-            "PDNO": order.ticker,
-            "ORD_QTY": str(order.quantity),
-            "OVRS_ORD_UNPR": str(order_price),
-            "CTAC_TLNO": "",
-            "MGCO_APTM_ODNO": "",
-            "SLL_TYPE": "00" if order.action == OrderAction.SELL else "",
-            "ORD_SVR_DVSN_CD": "0",
-            "ORD_DVSN": "00"
-        }
-
-        try:
-            headers = self._get_header(tr_id, data)
-            res = _pkg.requests.post(url, headers=headers, json=data, timeout=DEFAULT_HTTP_TIMEOUT)
-            res.raise_for_status()
-            resp_data = res.json()
-
-            if resp_data['rt_cd'] != '0':
-                self.logger.error(f"[KisBroker] Order Failed: {resp_data.get('msg1')}")
-                return None
-
-            self.logger.info(f"[KisBroker] Order Sent: {order.action} {order.ticker} {order.quantity} @ {order_price}")
-
-            return TradeExecution(
-                ticker=order.ticker,
-                action=order.action,
-                quantity=order.quantity,
-                price=order_price,
-                fee=0.0,
-                date=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-                status=ExecutionStatus.ORDERED
-            )
-
-        except Exception as e:
-            self.logger.error(f"[KisBroker] Order Error: {e}")
-            return None
-
     def _send_order_and_wait(self, order: Order, timeout: int = 30) -> Optional[TradeExecution]:
         """주문 전송 후 체결 대기. 체결 시 FILLED, 타임아웃 시 ORDERED(미확인 체결) 반환."""
         tr_id = self.BUY_TR_ID if order.action == OrderAction.BUY else self.SELL_TR_ID

--- a/tests/test_infra_broker.py
+++ b/tests/test_infra_broker.py
@@ -221,3 +221,10 @@ class TestKisOverseasGetPortfolio:
 
         pf = broker.get_portfolio()
         assert pf.total_cash == 5000.0
+
+
+class TestKisOverseasSendOrderRemoved:
+    def test_send_order_does_not_exist(self):
+        """_send_order는 dead code로 제거됨 — _send_order_and_wait만 존재해야 함."""
+        assert not hasattr(KisOverseasBrokerBase, '_send_order')
+        assert hasattr(KisOverseasBrokerBase, '_send_order_and_wait')


### PR DESCRIPTION
## Summary

- `KisOverseasBrokerBase._send_order` 메서드(62줄)를 삭제함 — 프로젝트 전체에서 한 번도 호출되지 않는 dead code
- 실제 주문 플로우는 `_send_order_and_wait`으로 완전히 통합되어 있어 기능 영향 없음
- 실수로 `_send_order`가 호출될 경우 체결 확인/취소 로직 없이 주문이 전송되는 위험 제거

## Test plan

- [x] `TestKisOverseasSendOrderRemoved::test_send_order_does_not_exist` 신규 회귀 테스트 추가 및 통과
- [x] 기존 78개 테스트 전체 통과 확인

Closes #45

https://claude.ai/code/session_01BorJaGQ3FFeHbnfbEfEwEd