### PR TITLE
fix: 중복 import 제거 및 sys.path 안티패턴 제거 (#44, #51)

### DIFF
--- a/.github/workflows/trading-bot-domestic.yml
+++ b/.github/workflows/trading-bot-domestic.yml
@@ -33,7 +33,7 @@ jobs:
         KIS_ACC_NO: ${{ secrets.KIS_ACC_NO }}
         IS_LIVE: ${{ secrets.IS_LIVE }}
       run: |
-        python src/main.py
+        python -m src.main
 
     - name: Commit updated data files
       run: |

--- a/.github/workflows/trading-bot.yml
+++ b/.github/workflows/trading-bot.yml
@@ -35,7 +35,7 @@ jobs:
         MY_ACCOUNT_KIS_APP_SECRET: ${{ secrets.MY_ACCOUNT_KIS_APP_SECRET }}
         MY_ACCOUNT_KIS_ACC_NO: ${{ secrets.MY_ACCOUNT_KIS_ACC_NO }}
       run: |
-        python src/main.py
+        python -m src.main
 
     - name: Commit updated data files
       run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@
 
 ## 주요 명령어
 - 테스트: `pytest --cov=src --cov-report=term-missing --cov-fail-under=80 tests/`
-- 봇 실행: `python src/main.py`
+- 봇 실행: `python -m src.main`
 - 의존성 설치: `pip install -r requirements.txt`
 
 ## 프로젝트 구조

--- a/src/infra/broker/kis_domestic.py
+++ b/src/infra/broker/kis_domestic.py
@@ -5,8 +5,6 @@ import time
 import src.infra.broker as _pkg  # test patch 타깃: src.infra.broker.requests
 from datetime import datetime
 from src.config import DEFAULT_HTTP_TIMEOUT
-
-from src.config import DEFAULT_HTTP_TIMEOUT
 from src.core.models import Portfolio, Order, TradeExecution, OrderAction, ExecutionStatus
 
 from .kis_base import KisBrokerCommon

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,5 @@
 # src/main.py
-import sys
 import os
-sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
-
 from src.config import Config
 from src.strategy_config import StrategyConfig
 from src.core.engine import MagicSplitEngine  # noqa: F401  (레지스트리 등록)


### PR DESCRIPTION
## Summary

- **#44** `kis_domestic.py`: `DEFAULT_HTTP_TIMEOUT` 중복 import 1줄 제거
- **#51** `main.py`: `sys.path.append()` 3줄 제거, `import os`는 실제 사용처가 있어 유지
- CI 워크플로우 2개(`trading-bot.yml`, `trading-bot-domestic.yml`): `python src/main.py` → `python -m src.main`
- `CLAUDE.md`: 봇 실행 명령어 동기화

## Test plan

- [x] 기존 157개 테스트 전부 통과
- [x] 커버리지 80% 충족

https://claude.ai/code/session_01VcaVfQ8sMBScQ85m7raHhi