### PR TITLE
fix: TICKER_EXCHANGE_MAP 전역 상태 수정 제거 (이슈 #50)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -5,7 +5,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # 티커별 거래소 단축 코드 (현재가 조회 API용)
-# config.json의 종목 추가 시 StrategyConfig에서 동적으로 확장됨
+# 기본 거래소 단축 코드. config.json에 exchange 미지정 시 fallback으로 사용.
 TICKER_EXCHANGE_MAP: dict[str, str] = {
     'SPY': 'AMS',
     'QQQ': 'NAS',

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -32,6 +32,7 @@ class StockRule:
     max_lots: int               # 최대 분할 횟수
     market_type: str = "overseas"  # "overseas" | "domestic"
     enabled: bool = True
+    exchange: str = ""  # 거래소 단축 코드 (NAS, NYS, AMS 등; 해외주식 전용)
 
 
 @dataclass

--- a/src/infra/broker/kis_overseas.py
+++ b/src/infra/broker/kis_overseas.py
@@ -16,6 +16,11 @@ class KisOverseasBrokerBase(KisBrokerCommon):
     """해외주식(미국) 전용 브로커 베이스 클래스."""
     ASKING_PRICE_TR_ID: str = "HHDFS76200100"  # 해외주식 호가 조회 (실전/모의 동일)
 
+    def __init__(self, app_key: str, app_secret: str, acc_no: str, logger,
+                 exchange_map: dict | None = None):
+        super().__init__(app_key, app_secret, acc_no, logger)
+        self._exchange_map: dict[str, str] = exchange_map or {}
+
     def fetch_current_prices(self, tickers: List[str]) -> Dict[str, float]:
         """해외주식 현재가 조회 (반복 호출)"""
         prices = {}
@@ -384,15 +389,16 @@ class KisOverseasBrokerBase(KisBrokerCommon):
 
     def _get_exchange_code(self, ticker: str, api_type: str = "price") -> str:
         """
-        티커별 거래소 코드 반환 (config.TICKER_EXCHANGE_MAP 참조)
+        티커별 거래소 코드 반환.
         - api_type="price"  : 현재가 조회 API용 단축 코드 (NAS, NYS, AMS)
         - api_type="order"  : 주문/잔고/미체결 API용 전체 코드 (NASD, NYSE, AMEX)
+        주입된 exchange_map 우선, 없으면 전역 기본값 fallback.
         """
-        price_code = TICKER_EXCHANGE_MAP.get(ticker)
+        price_code = self._exchange_map.get(ticker) or TICKER_EXCHANGE_MAP.get(ticker)
         if price_code is None:
             self.logger.warning(
                 f"[KisBroker] 알 수 없는 티커 '{ticker}' - 기본 거래소 코드(NAS/NASD) 사용. "
-                f"src/config.py의 TICKER_EXCHANGE_MAP에 티커를 추가하세요."
+                f"config.json의 exchange 필드를 확인하세요."
             )
             price_code = 'NAS'
         if api_type == "order":
@@ -411,8 +417,9 @@ class KisOverseasPaperBroker(KisOverseasBrokerBase):
     FILL_TR_ID = "VTTS3035R"
     CANCEL_TR_ID = "VTTT1004U"
 
-    def __init__(self, app_key: str, app_secret: str, acc_no: str, logger):
-        super().__init__(app_key, app_secret, acc_no, logger)
+    def __init__(self, app_key: str, app_secret: str, acc_no: str, logger,
+                 exchange_map: dict | None = None):
+        super().__init__(app_key, app_secret, acc_no, logger, exchange_map)
         self.logger.info("[KisOverseasPaperBroker] Mode: PAPER TRADING (Virtual)")
 
 
@@ -427,6 +434,7 @@ class KisOverseasLiveBroker(KisOverseasBrokerBase):
     FILL_TR_ID = "TTTS3035R"
     CANCEL_TR_ID = "TTTT1004U"
 
-    def __init__(self, app_key: str, app_secret: str, acc_no: str, logger):
-        super().__init__(app_key, app_secret, acc_no, logger)
+    def __init__(self, app_key: str, app_secret: str, acc_no: str, logger,
+                 exchange_map: dict | None = None):
+        super().__init__(app_key, app_secret, acc_no, logger, exchange_map)
         self.logger.info("[KisOverseasLiveBroker] Mode: LIVE TRADING")

--- a/src/main.py
+++ b/src/main.py
@@ -27,12 +27,14 @@ def _resolve_engine_class(engine_name: str):
 
 
 def _create_broker(market_type: str, is_live: bool,
-                    app_key: str, app_secret: str, acc_no: str, logger):
+                    app_key: str, app_secret: str, acc_no: str, logger,
+                    exchange_map: dict | None = None):
     """(market_type, is_live) 조합에 따라 KIS 브로커를 생성."""
     args = (app_key, app_secret, acc_no, logger)
     if market_type == "domestic":
         return KisDomesticLiveBroker(*args) if is_live else KisDomesticPaperBroker(*args)
-    return KisOverseasLiveBroker(*args) if is_live else KisOverseasPaperBroker(*args)
+    return (KisOverseasLiveBroker(*args, exchange_map)
+            if is_live else KisOverseasPaperBroker(*args, exchange_map))
 
 
 class MagicSplitBot:
@@ -62,6 +64,7 @@ class MagicSplitBot:
             f"mode={'LIVE' if self.config.IS_LIVE else 'PAPER'}"
         )
 
+        exchange_map = {r.ticker: r.exchange for r in rules if r.exchange}
         broker = _create_broker(
             market_type=self.market_type,
             is_live=self.config.IS_LIVE,
@@ -69,6 +72,7 @@ class MagicSplitBot:
             app_secret=self.config.KIS_APP_SECRET,
             acc_no=self.config.KIS_ACC_NO,
             logger=self.logger,
+            exchange_map=exchange_map,
         )
         repo = JsonRepository(
             os.path.join(self.config.DATA_PATH, self.market_type),

--- a/src/main.py
+++ b/src/main.py
@@ -64,7 +64,6 @@ class MagicSplitBot:
             f"mode={'LIVE' if self.config.IS_LIVE else 'PAPER'}"
         )
 
-        exchange_map = {r.ticker: r.exchange for r in rules if r.exchange}
         broker = _create_broker(
             market_type=self.market_type,
             is_live=self.config.IS_LIVE,
@@ -72,7 +71,7 @@ class MagicSplitBot:
             app_secret=self.config.KIS_APP_SECRET,
             acc_no=self.config.KIS_ACC_NO,
             logger=self.logger,
-            exchange_map=exchange_map,
+            exchange_map=self.strategy.get_exchange_map(),
         )
         repo = JsonRepository(
             os.path.join(self.config.DATA_PATH, self.market_type),

--- a/src/main.py
+++ b/src/main.py
@@ -33,8 +33,8 @@ def _create_broker(market_type: str, is_live: bool,
     args = (app_key, app_secret, acc_no, logger)
     if market_type == "domestic":
         return KisDomesticLiveBroker(*args) if is_live else KisDomesticPaperBroker(*args)
-    return (KisOverseasLiveBroker(*args, exchange_map)
-            if is_live else KisOverseasPaperBroker(*args, exchange_map))
+    return (KisOverseasLiveBroker(*args, exchange_map=exchange_map)
+            if is_live else KisOverseasPaperBroker(*args, exchange_map=exchange_map))
 
 
 class MagicSplitBot:

--- a/src/strategy_config.py
+++ b/src/strategy_config.py
@@ -70,7 +70,7 @@ class StrategyConfig:
             if not ticker:
                 raise ValueError(f"{self.config_path}[{idx}]: 'ticker' 필드가 필요합니다.")
 
-            exchange = raw.get("exchange", "")
+            exchange = raw.get("exchange") or ""
 
             market_type = raw.get("market_type", "overseas")
             if market_type not in ("overseas", "domestic"):

--- a/src/strategy_config.py
+++ b/src/strategy_config.py
@@ -26,14 +26,12 @@ import os
 from typing import List, Set
 
 from src.core.models import StockRule
-from src.config import TICKER_EXCHANGE_MAP
 
 
 class StrategyConfig:
     """config.json 로더.
 
-    config.json을 읽어 종목별 StockRule 리스트를 생성하고,
-    종목의 거래소 코드를 TICKER_EXCHANGE_MAP에 동적으로 등록한다.
+    config.json을 읽어 종목별 StockRule 리스트를 생성한다.
     """
 
     def __init__(self, config_path: str = "config.json"):
@@ -68,10 +66,7 @@ class StrategyConfig:
             if not ticker:
                 raise ValueError(f"{self.config_path}[{idx}]: 'ticker' 필드가 필요합니다.")
 
-            # 거래소 코드 동적 등록
-            exchange = raw.get("exchange")
-            if exchange and ticker not in TICKER_EXCHANGE_MAP:
-                TICKER_EXCHANGE_MAP[ticker] = exchange
+            exchange = raw.get("exchange", "")
 
             market_type = raw.get("market_type", "overseas")
             if market_type not in ("overseas", "domestic"):
@@ -88,6 +83,7 @@ class StrategyConfig:
                 max_lots=int(raw.get("max_lots", 10)),
                 market_type=market_type,
                 enabled=bool(raw.get("enabled", True)),
+                exchange=exchange,
             )
             self.rules.append(rule)
             self.market_types.add(market_type)

--- a/src/strategy_config.py
+++ b/src/strategy_config.py
@@ -23,7 +23,7 @@ config.json 구조:
 """
 import json
 import os
-from typing import List, Set
+from typing import Dict, List, Set
 
 from src.core.models import StockRule
 
@@ -44,6 +44,10 @@ class StrategyConfig:
     def get_rules_by_market(self, market_type: str) -> List[StockRule]:
         """지정된 market_type에 해당하는 규칙만 반환한다."""
         return [r for r in self.rules if r.market_type == market_type]
+
+    def get_exchange_map(self) -> Dict[str, str]:
+        """티커→거래소 단축 코드 맵을 반환한다 (exchange 미지정 종목 제외)."""
+        return {r.ticker: r.exchange for r in self.rules if r.exchange}
 
     def _load(self):
         if not os.path.exists(self.config_path):

--- a/tests/test_strategy_config.py
+++ b/tests/test_strategy_config.py
@@ -33,6 +33,7 @@ class TestStrategyConfig:
         assert sc.rules[0].buy_amount == 500
         assert sc.rules[0].max_lots == 10
         assert sc.rules[0].enabled is True
+        assert sc.rules[0].exchange == "NAS"
 
     def test_load_multiple_stocks(self, tmp_path):
         """여러 종목 로드"""
@@ -95,14 +96,15 @@ class TestStrategyConfig:
         assert sc.rules[0].enabled is False
 
     def test_exchange_registered(self, tmp_path):
-        """exchange 필드가 TICKER_EXCHANGE_MAP에 동적 등록됨"""
+        """exchange 필드가 StockRule.exchange에 저장되고, TICKER_EXCHANGE_MAP은 변경되지 않음"""
         config = {
             "stocks": [{"ticker": "NEWSTOCK", "exchange": "NYS"}]
         }
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps(config))
 
-        StrategyConfig(str(config_file))
+        sc = StrategyConfig(str(config_file))
 
+        assert sc.rules[0].exchange == "NYS"
         from src.config import TICKER_EXCHANGE_MAP
-        assert TICKER_EXCHANGE_MAP.get("NEWSTOCK") == "NYS"
+        assert "NEWSTOCK" not in TICKER_EXCHANGE_MAP


### PR DESCRIPTION
## Summary

- `StockRule`에 `exchange: str = ""` 필드 추가 — 거래소 코드를 도메인 모델에 캡슐화
- `strategy_config.py`에서 `TICKER_EXCHANGE_MAP[ticker] = exchange` 전역 변형 제거 → `StockRule.exchange`에 저장
- `KisOverseasBrokerBase`에 `exchange_map` 생성자 주입 추가; `_get_exchange_code`는 주입 map 우선, 전역 기본값 fallback
- `main.py`에서 rules 기반 `exchange_map` 빌드 후 broker에 주입
- 테스트 격리 복원: `TICKER_EXCHANGE_MAP` 불변 검증 추가

## Resolves

Closes #50

## Test plan

- [x] 148개 기존 테스트 전체 통과
- [x] `test_exchange_registered`: `StockRule.exchange == "NYS"` 검증 및 `TICKER_EXCHANGE_MAP` 불변 검증
- [x] `test_load_valid_config`: `exchange == "NAS"` 필드 검증 추가
- [x] `KisOverseasPaperBroker` / `KisOverseasLiveBroker` 하위호환 (`exchange_map=None` 기본값)

https://claude.ai/code/session_01A2u3vZpXhVybm3uZXsHoaD