### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and visual cues to profit/loss indicators

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,6 @@
+# Palette's Journal
+
+## Learnings
+* Accessibility enhancements like ARIA labels (`aria-label`) and hidden span text (`aria-hidden="true"`) improve screen-reader experiences without disrupting visual designs.
+* Simple spacing touches (e.g. adding a space before "shares") contribute to readability and clarify tabular data.
+* Ensure visual profit/loss cues don't rely purely on color, using indicators like arrows (`▲`/`▼`) helps users with color blindness.

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -54,12 +54,18 @@
             const lots = info.lots || [];
             let lotsHtml = '';
             for (const lot of lots) {
-                const pctClass = lot.pct_change >= 0 ? 'pct-positive' : 'pct-negative';
-                const pctStr = (lot.pct_change >= 0 ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const isProfit = lot.pct_change >= 0;
+                const pctClass = isProfit ? 'pct-positive' : 'pct-negative';
+                const pctStr = (isProfit ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const arrow = isProfit ? '▲' : '▼';
+                const ariaLabel = isProfit ? `Profit of ${lot.pct_change.toFixed(1)}%` : `Loss of ${Math.abs(lot.pct_change).toFixed(1)}%`;
+
                 lotsHtml += `
                     <li class="lot-item">
-                        <span>${lot.buy_date} | ${lot.quantity}shares @$${lot.buy_price.toFixed(2)}</span>
-                        <span class="${pctClass}">${pctStr}</span>
+                        <span>${lot.buy_date} | ${lot.quantity} shares @$${lot.buy_price.toFixed(2)}</span>
+                        <span class="${pctClass}" aria-label="${ariaLabel}">
+                            ${pctStr} <span aria-hidden="true">${arrow}</span>
+                        </span>
                     </li>`;
             }
 


### PR DESCRIPTION
💡 **What:** Added ARIA labels (`aria-label`) and visual up/down arrows (`▲`/`▼`) with `aria-hidden="true"` to the profit/loss percentages. Also added a space before the word "shares" to fix text spacing. Added learnings to `.jules/palette.md`.
🎯 **Why:** To improve financial clarity by not relying solely on colors to indicate profit/loss, thereby assisting users with color blindness, and ensuring screen readers explicitly announce "Profit" or "Loss". Small spacing adjustments enhance readability.
📸 **Before/After:** Before, the display merely read e.g., "+10.5%" in green and "10shares". Now, it reads "+10.5% ▲" in green with an `aria-label` reading "Profit of 10.5%" and "10 shares". 
♿ **Accessibility:** The `aria-label` explicit reads out what the number means on screen readers, while visual indicators use `aria-hidden="true"` to prevent visual cues from cluttering audio outputs.

---
*PR created automatically by Jules for task [2500836335581567465](https://jules.google.com/task/2500836335581567465) started by @Junghyun99*