### PR TITLE
feat(strategy): 1차수 재진입 가드 스캐폴드 추가

### DIFF
--- a/config_domestic.json
+++ b/config_domestic.json
@@ -8,6 +8,7 @@
             "sell_threshold_pct": 10.0,
             "buy_amount": 500000,
             "max_lots": 10,
+            "reentry_guard_pct": -0.1,
             "enabled": true
         },
         {
@@ -18,6 +19,7 @@
             "sell_threshold_pct": 10.0,
             "buy_amount": 500000,
             "max_lots": 10,
+            "reentry_guard_pct": -0.1,
             "enabled": true
         }
     ],

--- a/config_overseas.json
+++ b/config_overseas.json
@@ -8,6 +8,7 @@
             "sell_threshold_pct": 10.0,
             "buy_amount": 500,
             "max_lots": 100,
+            "reentry_guard_pct": -0.1,
             "enabled": true
         },
         {
@@ -18,6 +19,7 @@
             "sell_threshold_pct": 10.0,
             "buy_amount": 500,
             "max_lots": 100,
+            "reentry_guard_pct": -0.1,
             "enabled": true
         }
     ],

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -82,6 +82,11 @@ class MagicSplitEngine:
             positions = self.repo.load_positions()
             self.logger.info(f"Loaded {len(positions)} position lot(s)")
 
+            # 재진입 가드용 직전 매도가 조회.
+            # TODO(reentry_guard): repo/history에서 티커별 직전 (전량 청산)
+            # 매도 단가를 추출해 채운다. 현재는 비어 있어 가드 비활성.
+            last_sell_prices: dict = {}
+
             # Step 2.5: 브로커 수량 ↔ positions 수량 합 불일치 검사
             # 불일치 종목은 이번 사이클에서 매매 중단 (자동 보정 미지원)
             halted_tickers = self._check_reconcile(positions, portfolio)
@@ -99,7 +104,9 @@ class MagicSplitEngine:
                     self.logger.info(f">>> Processing {rule.ticker}")
 
                     # 3a. 해당 종목 신호 평가
-                    signals = self.evaluator.evaluate_stock(rule, positions, portfolio)
+                    signals = self.evaluator.evaluate_stock(
+                        rule, positions, portfolio, last_sell_prices,
+                    )
                     all_signals.extend(signals)
 
                     if not signals:

--- a/src/core/logic/split_evaluator.py
+++ b/src/core/logic/split_evaluator.py
@@ -79,7 +79,12 @@ class SplitEvaluator:
 
         # 보유 lot이 없으면 → 1차수 초기 매수
         if not ticker_lots:
-            signal = self._evaluate_initial_buy(rule, current_price)
+            # TODO(reentry_guard): repo/history에서 직전 매도가를 조회하여 전달.
+            # 현재는 None으로 가드 비활성 (기존 동작 유지).
+            last_sell_price: Optional[float] = None
+            signal = self._evaluate_initial_buy(
+                rule, current_price, last_sell_price=last_sell_price,
+            )
             return [signal] if signal else []
 
         # 마지막 차수(가장 높은 level) lot 찾기
@@ -129,8 +134,12 @@ class SplitEvaluator:
         self,
         rule: StockRule,
         current_price: float,
+        last_sell_price: Optional[float] = None,
     ) -> Optional[SplitSignal]:
         """보유 lot이 없을 때 1차수 초기 매수를 평가한다."""
+        if not self._passes_reentry_guard(rule, current_price, last_sell_price):
+            return None
+
         buy_qty = math.floor(rule.buy_amount / current_price)
         if buy_qty <= 0:
             if self._logger:
@@ -154,6 +163,42 @@ class SplitEvaluator:
             pct_change=0.0,
             level=1,
         )
+
+    def _passes_reentry_guard(
+        self,
+        rule: StockRule,
+        current_price: float,
+        last_sell_price: Optional[float],
+    ) -> bool:
+        """1차수 재진입 가드: 직전 매도가 대비 충분히 하락했는지 확인한다.
+
+        예: rule.reentry_guard_pct = -0.1 이면
+            current_price <= last_sell_price * (1 - 0.001) 일 때만 진입 허용.
+
+        Args:
+            rule: 종목 규칙 (reentry_guard_pct 포함)
+            current_price: 현재가
+            last_sell_price: 직전 (전량 청산) 매도 단가. None이면 가드 미적용.
+
+        Returns:
+            True: 진입 허용 (가드 통과 또는 가드 미설정).
+            False: 진입 차단.
+        """
+        if rule.reentry_guard_pct is None:
+            return True
+        if last_sell_price is None or last_sell_price <= 0:
+            return True
+
+        pct_from_sell = (current_price - last_sell_price) / last_sell_price * 100
+        if pct_from_sell <= rule.reentry_guard_pct:
+            return True
+
+        if self._logger:
+            self._logger.info(
+                f"[{rule.ticker}] 재진입 가드: 직전 매도가 ${last_sell_price:.2f} 대비 "
+                f"{pct_from_sell:+.2f}% > 임계 {rule.reentry_guard_pct:+.2f}% → 진입 보류"
+            )
+        return False
 
     def _evaluate_buy(
         self,

--- a/src/core/logic/split_evaluator.py
+++ b/src/core/logic/split_evaluator.py
@@ -1,6 +1,6 @@
 # src/core/logic/split_evaluator.py
 import math
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from src.core.interfaces import ILogger
 from src.core.models import (
@@ -31,6 +31,7 @@ class SplitEvaluator:
         stock_rules: List[StockRule],
         positions: List[PositionLot],
         portfolio: Portfolio,
+        last_sell_prices: Optional[Dict[str, float]] = None,
     ) -> List[SplitSignal]:
         """모든 종목에 대해 매수/매도 신호를 평가한다.
 
@@ -38,13 +39,17 @@ class SplitEvaluator:
             stock_rules: config.json에서 로드된 종목별 매매 규칙
             positions: 현재 보유 중인 분할 포지션 목록
             portfolio: 현재 포트폴리오 (현금, 보유 종목, 현재가)
+            last_sell_prices: 티커별 직전(전량 청산) 매도 단가.
+                재진입 가드 평가에만 사용. 미상이면 생략.
 
         Returns:
             매수/매도 신호 리스트 (매도 신호가 먼저, 자금 확보 우선)
         """
         signals: List[SplitSignal] = []
         for rule in stock_rules:
-            signals.extend(self.evaluate_stock(rule, positions, portfolio))
+            signals.extend(
+                self.evaluate_stock(rule, positions, portfolio, last_sell_prices)
+            )
 
         # 매도 신호를 먼저, 매수 신호를 나중에 (자금 확보 우선)
         sell_first = [s for s in signals if s.action == OrderAction.SELL]
@@ -56,10 +61,15 @@ class SplitEvaluator:
         rule: StockRule,
         positions: List[PositionLot],
         portfolio: Portfolio,
+        last_sell_prices: Optional[Dict[str, float]] = None,
     ) -> List[SplitSignal]:
         """단일 종목에 대해 매수/매도 신호를 평가한다.
 
         마지막 차수만 기준으로 판단하며, 매도 OR 매수 중 하나만 반환한다.
+
+        Args:
+            last_sell_prices: 티커별 직전 매도 단가 (재진입 가드용).
+                상위 호출부(엔진)에서 history/repo로부터 조회해 전달한다.
 
         Returns:
             최대 1개의 신호를 담은 리스트
@@ -79,9 +89,9 @@ class SplitEvaluator:
 
         # 보유 lot이 없으면 → 1차수 초기 매수
         if not ticker_lots:
-            # TODO(reentry_guard): repo/history에서 직전 매도가를 조회하여 전달.
-            # 현재는 None으로 가드 비활성 (기존 동작 유지).
-            last_sell_price: Optional[float] = None
+            last_sell_price = (
+                last_sell_prices.get(rule.ticker) if last_sell_prices else None
+            )
             signal = self._evaluate_initial_buy(
                 rule, current_price, last_sell_price=last_sell_price,
             )
@@ -195,7 +205,7 @@ class SplitEvaluator:
 
         if self._logger:
             self._logger.info(
-                f"[{rule.ticker}] 재진입 가드: 직전 매도가 ${last_sell_price:.2f} 대비 "
+                f"[{rule.ticker}] 재진입 가드: 직전 매도가 {last_sell_price:.2f} 대비 "
                 f"{pct_from_sell:+.2f}% > 임계 {rule.reentry_guard_pct:+.2f}% → 진입 보류"
             )
         return False

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -33,6 +33,9 @@ class StockRule:
     market_type: str = "overseas"  # "overseas" | "domestic"
     enabled: bool = True
     exchange: str = ""  # 거래소 단축 코드 (NAS, NYS, AMS 등; 해외주식 전용)
+    # 재진입 가드: 직전 매도가 대비 X% 하락해야 1차수 재매수 허용 (음수, 예: -0.1)
+    # None이면 가드 비활성 (전량 청산 직후에도 다음 사이클 즉시 재진입)
+    reentry_guard_pct: Optional[float] = None
 
 
 @dataclass

--- a/src/strategy_config.py
+++ b/src/strategy_config.py
@@ -79,6 +79,11 @@ class StrategyConfig:
                     f"'overseas' 또는 'domestic'이어야 합니다. got '{market_type}'"
                 )
 
+            reentry_raw = raw.get("reentry_guard_pct")
+            reentry_guard_pct = (
+                float(reentry_raw) if reentry_raw is not None else None
+            )
+
             rule = StockRule(
                 ticker=ticker,
                 buy_threshold_pct=float(raw.get("buy_threshold_pct", -5.0)),
@@ -88,6 +93,7 @@ class StrategyConfig:
                 market_type=market_type,
                 enabled=bool(raw.get("enabled", True)),
                 exchange=exchange,
+                reentry_guard_pct=reentry_guard_pct,
             )
             self.rules.append(rule)
             self.market_types.add(market_type)

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -79,7 +79,7 @@ class TestRunOneCycle:
             logger=mock_logger, stock_rules=rules,
         )
 
-        def mock_evaluate_stock(rule, positions, portfolio):
+        def mock_evaluate_stock(rule, positions, portfolio, last_sell_prices=None):
             if rule.ticker == "AAPL":
                 raise Exception("Mock evaluator error")
             elif rule.ticker == "MSFT":
@@ -119,7 +119,7 @@ class TestRunOneCycle:
             logger=mock_logger, stock_rules=rules,
         )
 
-        def mock_evaluate_stock(rule, positions, portfolio):
+        def mock_evaluate_stock(rule, positions, portfolio, last_sell_prices=None):
             if rule.ticker == "AAPL":
                 return [SplitSignal("AAPL", None, OrderAction.BUY, 5, 100.0, "AAPL Buy", 0.0, 1)]
             elif rule.ticker == "MSFT":


### PR DESCRIPTION
## Summary
전량 청산 직후 다음 사이클에 즉시 1차수 재매수가 발생하는 현상을 설정으로 제어할 수 있는 출발점을 마련합니다. 실제 동작은 `reentry_guard_pct=null`(기본)일 때 기존과 완전히 동일하며, 값을 지정하면 가드 함수가 호출되도록 배선만 해 두었습니다.

## 배경 (백테스트 결과 검증에서 발견)
- `docs/data/backtest/history.json` 검증 결과, 모든 매매가 `buy_threshold_pct(-5%)` / `sell_threshold_pct(+10%)`를 정확히 충족 (close.parquet 기준).
- 다만 Lv1 전량 청산 후 다음 거래일에 가격이 `buy_amount` 이하면 곧장 1차수 재매수가 일어남 (예: 2025-06-02 MSFT 매도 → 6-03 재매수, 2025-10-27 AAPL 매도 → 10-28 재매수).
- 이를 “직전 매도가 대비 X% 하락” 같은 조건으로 막을 수 있도록 인터페이스부터 잡아두는 변경입니다.

## Changes
- `StockRule.reentry_guard_pct: Optional[float]` 신설 (기본 `None` = 가드 비활성).
- `SplitEvaluator._passes_reentry_guard()` 가드 골격 추가.
  - `current_price <= last_sell_price * (1 + reentry_guard_pct/100)`이면 진입 허용.
  - 가드 미설정 또는 직전 매도가 미상이면 항상 통과.
- `_evaluate_initial_buy()`에 `last_sell_price` 파라미터 연결, 호출부(`evaluate_stock`)에 `TODO(reentry_guard)` 마커. 직전 매도가 조회는 별도 PR에서 repo/history 연동.
- `config_domestic.json` / `config_overseas.json`에 예시값 `-0.1` 노출.

## Test plan
- [x] `tests/test_split_evaluator.py`, `tests/test_strategy_config.py`, `tests/test_core_models.py` 42 PASS
- [ ] 후속 PR: 직전 매도가 조회 로직(repo or in-memory cache) 구현 + 가드 동작 단위 테스트 추가
- [ ] 백테스트 재실행하여 가드 적용 시 거래 빈도 변화 확인

https://claude.ai/code/session_018YwW2XGwDuYspakTwKhb3q