### PR TITLE
feat(strategy): 차수별 배열 threshold/amount + 공유 프리셋 지원

### DIFF
--- a/src/core/logic/split_evaluator.py
+++ b/src/core/logic/split_evaluator.py
@@ -120,8 +120,9 @@ class SplitEvaluator:
     ) -> Optional[SplitSignal]:
         """마지막 차수 lot의 매도 여부를 평가한다."""
         pct_change = (current_price - last_lot.buy_price) / last_lot.buy_price * 100
+        sell_threshold = rule.sell_threshold_at(last_lot.level)
 
-        if pct_change >= rule.sell_threshold_pct:
+        if pct_change >= sell_threshold:
             if self._logger:
                 self._logger.info(
                     f"[{rule.ticker}] Lv{last_lot.level}: 매수가 ${last_lot.buy_price:.2f} → "
@@ -150,11 +151,12 @@ class SplitEvaluator:
         if not self._passes_reentry_guard(rule, current_price, last_sell_price):
             return None
 
-        buy_qty = math.floor(rule.buy_amount / current_price)
+        buy_amount = rule.buy_amount_at(1)
+        buy_qty = math.floor(buy_amount / current_price)
         if buy_qty <= 0:
             if self._logger:
                 self._logger.info(
-                    f"[{rule.ticker}] 매수 금액(${rule.buy_amount:.2f})으로 "
+                    f"[{rule.ticker}] 매수 금액(${buy_amount:.2f})으로 "
                     f"1주도 매수 불가 (현재가 ${current_price:.2f}). 스킵."
                 )
             return None
@@ -228,20 +230,22 @@ class SplitEvaluator:
                 )
             return None
 
-        # 매수 수량 계산
-        buy_qty = math.floor(rule.buy_amount / current_price)
+        # 매수 수량 계산 (다음 차수 기준 금액)
+        buy_amount = rule.buy_amount_at(next_level)
+        buy_qty = math.floor(buy_amount / current_price)
         if buy_qty <= 0:
             if self._logger:
                 self._logger.info(
-                    f"[{rule.ticker}] 매수 금액(${rule.buy_amount:.2f})으로 "
+                    f"[{rule.ticker}] 매수 금액(${buy_amount:.2f})으로 "
                     f"1주도 매수 불가 (현재가 ${current_price:.2f}). 스킵."
                 )
             return None
 
-        # 마지막 차수 매수가 대비 현재가 비교
+        # 마지막 차수 매수가 대비 현재가 비교 (임계치는 마지막 차수 기준)
         pct_from_last = (current_price - last_lot.buy_price) / last_lot.buy_price * 100
+        buy_threshold = rule.buy_threshold_at(last_lot.level)
 
-        if pct_from_last <= rule.buy_threshold_pct:
+        if pct_from_last <= buy_threshold:
             if self._logger:
                 self._logger.info(
                     f"[{rule.ticker}] Lv{last_lot.level} 매수가 ${last_lot.buy_price:.2f} 대비 "

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -24,18 +24,69 @@ class ExecutionStatus(str, Enum):
 
 @dataclass
 class StockRule:
-    """종목별 매매 규칙 (config.json에서 로드)"""
+    """종목별 매매 규칙 (config.json에서 로드).
+
+    차수별 차등을 위해 배열 필드(`*_pcts`, `buy_amounts`)를 제공한다.
+    배열이 있으면 배열이 우선, 없으면 단일값(`*_pct`, `buy_amount`)을 사용.
+    배열 길이가 실제 차수보다 짧으면 마지막 값으로 clamp.
+    """
     ticker: str
-    buy_threshold_pct: float    # 매수가 대비 -N% 이하 시 추가매수 (음수, 예: -5.0)
-    sell_threshold_pct: float   # 매수가 대비 +N% 이상 시 매도 (양수, 예: 10.0)
-    buy_amount: float           # 1회 매수 금액 (원 or USD)
-    max_lots: int               # 최대 분할 횟수
+    buy_threshold_pct: Optional[float] = None    # 매수가 대비 -N% 이하 시 추가매수 (음수, 예: -5.0)
+    sell_threshold_pct: Optional[float] = None   # 매수가 대비 +N% 이상 시 매도 (양수, 예: 10.0)
+    buy_amount: Optional[float] = None           # 1회 매수 금액 (원 or USD)
+    max_lots: int = 10                           # 최대 분할 횟수
     market_type: str = "overseas"  # "overseas" | "domestic"
     enabled: bool = True
     exchange: str = ""  # 거래소 단축 코드 (NAS, NYS, AMS 등; 해외주식 전용)
     # 재진입 가드: 직전 매도가 대비 X% 하락해야 1차수 재매수 허용 (음수, 예: -0.1)
     # None이면 가드 비활성 (전량 청산 직후에도 다음 사이클 즉시 재진입)
     reentry_guard_pct: Optional[float] = None
+    # 차수별 배열 (있으면 단일값보다 우선). level(1-based)을 배열 인덱스로 매핑.
+    buy_threshold_pcts: Optional[List[float]] = None
+    sell_threshold_pcts: Optional[List[float]] = None
+    buy_amounts: Optional[List[float]] = None
+
+    def __post_init__(self):
+        if self.buy_threshold_pct is None and not self.buy_threshold_pcts:
+            raise ValueError(
+                f"StockRule({self.ticker}): buy_threshold_pct 또는 buy_threshold_pcts 중 하나는 필요합니다."
+            )
+        if self.sell_threshold_pct is None and not self.sell_threshold_pcts:
+            raise ValueError(
+                f"StockRule({self.ticker}): sell_threshold_pct 또는 sell_threshold_pcts 중 하나는 필요합니다."
+            )
+        if self.buy_amount is None and not self.buy_amounts:
+            raise ValueError(
+                f"StockRule({self.ticker}): buy_amount 또는 buy_amounts 중 하나는 필요합니다."
+            )
+        for name, arr in (
+            ("buy_threshold_pcts", self.buy_threshold_pcts),
+            ("sell_threshold_pcts", self.sell_threshold_pcts),
+            ("buy_amounts", self.buy_amounts),
+        ):
+            if arr is not None and len(arr) == 0:
+                raise ValueError(f"StockRule({self.ticker}): {name}는 비어 있으면 안 됩니다.")
+
+    @staticmethod
+    def _at(arr: Optional[List[float]], scalar: Optional[float], level: int) -> float:
+        if arr:
+            idx = max(0, min(level - 1, len(arr) - 1))
+            return float(arr[idx])
+        if scalar is not None:
+            return float(scalar)
+        raise ValueError("array and scalar are both missing")
+
+    def buy_threshold_at(self, level: int) -> float:
+        """주어진 차수(1-based)의 매수 임계치(%)를 반환한다."""
+        return self._at(self.buy_threshold_pcts, self.buy_threshold_pct, level)
+
+    def sell_threshold_at(self, level: int) -> float:
+        """주어진 차수(1-based)의 매도 임계치(%)를 반환한다."""
+        return self._at(self.sell_threshold_pcts, self.sell_threshold_pct, level)
+
+    def buy_amount_at(self, level: int) -> float:
+        """주어진 차수(1-based)의 1회 매수 금액을 반환한다."""
+        return self._at(self.buy_amounts, self.buy_amount, level)
 
 
 @dataclass

--- a/src/strategy_config.py
+++ b/src/strategy_config.py
@@ -1,7 +1,7 @@
 # src/strategy_config.py
 """config.json에서 종목별 매매 규칙(StockRule)을 로드한다.
 
-config.json 구조:
+config.json 구조 (단일값 단순 형태):
 {
     "stocks": [
         {
@@ -15,15 +15,29 @@ config.json 구조:
             "enabled": true
         }
     ],
-    "global": {
-        "check_interval_minutes": 60,
-        "notification_enabled": true
-    }
+    "global": { "check_interval_minutes": 60 }
 }
+
+차수별 배열 및 프리셋(공유 파일) 사용 예:
+- `presets.json` (repo 루트, 국내/해외 config와 동일 디렉토리에 위치):
+  {
+      "large_cap_us": {
+          "buy_threshold_pcts": [-3, -5, -7, -10],
+          "sell_threshold_pcts": [5, 7, 10, 15],
+          "buy_amounts": [1000, 1500, 2000, 3000],
+          "max_lots": 10
+      }
+  }
+- `config_overseas.json`의 stock 항목:
+  { "ticker": "AAPL", "exchange": "NAS", "preset": "large_cap_us",
+    "sell_threshold_pcts": [7, 10, 15, 25] }  # 종목 필드가 preset을 override
+
+경로 해석 순서: 생성자 인자 → 환경변수 `PRESETS_JSON_PATH` → config 파일 디렉토리/`presets.json`.
+프리셋 파일이 없고 어떤 종목도 `preset` 키를 쓰지 않으면 무시된다.
 """
 import json
 import os
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 
 from src.core.models import StockRule
 
@@ -34,8 +48,14 @@ class StrategyConfig:
     config.json을 읽어 종목별 StockRule 리스트를 생성한다.
     """
 
-    def __init__(self, config_path: str = "config.json"):
+    def __init__(
+        self,
+        config_path: str = "config.json",
+        presets_path: Optional[str] = None,
+    ):
         self.config_path = config_path
+        self.presets_path = self._resolve_presets_path(config_path, presets_path)
+        self.presets: Dict[str, dict] = {}
         self.rules: List[StockRule] = []
         self.market_types: Set[str] = set()
         self.global_config: dict = {}
@@ -48,6 +68,42 @@ class StrategyConfig:
     def get_exchange_map(self) -> Dict[str, str]:
         """티커→거래소 단축 코드 맵을 반환한다 (exchange 미지정 종목 제외)."""
         return {r.ticker: r.exchange for r in self.rules if r.exchange}
+
+    @staticmethod
+    def _resolve_presets_path(config_path: str, explicit: Optional[str]) -> str:
+        if explicit:
+            return explicit
+        env = os.environ.get("PRESETS_JSON_PATH")
+        if env:
+            return env
+        base_dir = os.path.dirname(config_path) or "."
+        return os.path.join(base_dir, "presets.json")
+
+    def _load_presets(self) -> Dict[str, dict]:
+        if not os.path.exists(self.presets_path):
+            return {}
+        with open(self.presets_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"{self.presets_path}의 최상위는 프리셋 이름→설정 객체여야 합니다."
+            )
+        return data
+
+    @staticmethod
+    def _merge_preset(raw: dict, presets: Dict[str, dict]) -> dict:
+        """stock 설정에 preset을 병합한다. stock 필드가 preset을 덮어쓴다."""
+        if "preset" not in raw:
+            return raw
+        name = raw["preset"]
+        if name not in presets:
+            raise KeyError(
+                f"Unknown preset '{name}' (ticker={raw.get('ticker')}). "
+                f"presets.json에 정의되어 있어야 합니다."
+            )
+        merged = {**presets[name], **raw}
+        merged.pop("preset", None)
+        return merged
 
     def _load(self):
         if not os.path.exists(self.config_path):
@@ -65,35 +121,64 @@ class StrategyConfig:
         if not raw_stocks:
             raise ValueError(f"{self.config_path}에 'stocks' 항목이 비어 있습니다.")
 
+        needs_presets = any("preset" in s for s in raw_stocks)
+        self.presets = self._load_presets()
+        if needs_presets and not self.presets:
+            raise FileNotFoundError(
+                f"프리셋을 참조하는 종목이 있지만 presets 파일을 찾을 수 없습니다: "
+                f"{self.presets_path}"
+            )
+
         for idx, raw in enumerate(raw_stocks):
-            ticker = raw.get("ticker")
+            merged = self._merge_preset(raw, self.presets)
+
+            ticker = merged.get("ticker")
             if not ticker:
                 raise ValueError(f"{self.config_path}[{idx}]: 'ticker' 필드가 필요합니다.")
 
-            exchange = raw.get("exchange") or ""
+            exchange = merged.get("exchange") or ""
 
-            market_type = raw.get("market_type", "overseas")
+            market_type = merged.get("market_type", "overseas")
             if market_type not in ("overseas", "domestic"):
                 raise ValueError(
                     f"{self.config_path}[{idx}]: market_type은 "
                     f"'overseas' 또는 'domestic'이어야 합니다. got '{market_type}'"
                 )
 
-            reentry_raw = raw.get("reentry_guard_pct")
+            reentry_raw = merged.get("reentry_guard_pct")
             reentry_guard_pct = (
                 float(reentry_raw) if reentry_raw is not None else None
             )
 
+            buy_pcts = merged.get("buy_threshold_pcts")
+            sell_pcts = merged.get("sell_threshold_pcts")
+            buy_amounts = merged.get("buy_amounts")
+
+            buy_pct = merged.get("buy_threshold_pct")
+            sell_pct = merged.get("sell_threshold_pct")
+            buy_amount = merged.get("buy_amount")
+
+            # 배열/단일값 모두 미제공이면 레거시 기본값(-5/10/500) 적용 → 하위 호환
+            if buy_pct is None and not buy_pcts:
+                buy_pct = -5.0
+            if sell_pct is None and not sell_pcts:
+                sell_pct = 10.0
+            if buy_amount is None and not buy_amounts:
+                buy_amount = 500
+
             rule = StockRule(
                 ticker=ticker,
-                buy_threshold_pct=float(raw.get("buy_threshold_pct", -5.0)),
-                sell_threshold_pct=float(raw.get("sell_threshold_pct", 10.0)),
-                buy_amount=float(raw.get("buy_amount", 500)),
-                max_lots=int(raw.get("max_lots", 10)),
+                buy_threshold_pct=float(buy_pct) if buy_pct is not None else None,
+                sell_threshold_pct=float(sell_pct) if sell_pct is not None else None,
+                buy_amount=float(buy_amount) if buy_amount is not None else None,
+                max_lots=int(merged.get("max_lots", 10)),
                 market_type=market_type,
-                enabled=bool(raw.get("enabled", True)),
+                enabled=bool(merged.get("enabled", True)),
                 exchange=exchange,
                 reentry_guard_pct=reentry_guard_pct,
+                buy_threshold_pcts=[float(x) for x in buy_pcts] if buy_pcts else None,
+                sell_threshold_pcts=[float(x) for x in sell_pcts] if sell_pcts else None,
+                buy_amounts=[float(x) for x in buy_amounts] if buy_amounts else None,
             )
             self.rules.append(rule)
             self.market_types.add(market_type)

--- a/src/strategy_config.py
+++ b/src/strategy_config.py
@@ -122,12 +122,14 @@ class StrategyConfig:
             raise ValueError(f"{self.config_path}에 'stocks' 항목이 비어 있습니다.")
 
         needs_presets = any("preset" in s for s in raw_stocks)
-        self.presets = self._load_presets()
-        if needs_presets and not self.presets:
+        if needs_presets and not os.path.exists(self.presets_path):
             raise FileNotFoundError(
                 f"프리셋을 참조하는 종목이 있지만 presets 파일을 찾을 수 없습니다: "
                 f"{self.presets_path}"
             )
+        self.presets = self._load_presets()
+        # 파일은 있으나 비어 있거나 참조한 프리셋이 없는 경우는
+        # 아래 _merge_preset에서 KeyError로 구체적으로 실패한다.
 
         for idx, raw in enumerate(raw_stocks):
             merged = self._merge_preset(raw, self.presets)

--- a/tests/test_core_models.py
+++ b/tests/test_core_models.py
@@ -26,6 +26,63 @@ class TestStockRule:
         rule = StockRule("TSLA", -3.0, 8.0, 300, 5, enabled=False)
         assert rule.enabled is False
 
+    def test_accessor_uses_scalar_when_no_array(self):
+        rule = StockRule("AAPL", -5.0, 10.0, 500, 10)
+        assert rule.buy_threshold_at(1) == -5.0
+        assert rule.buy_threshold_at(5) == -5.0
+        assert rule.sell_threshold_at(3) == 10.0
+        assert rule.buy_amount_at(2) == 500
+
+    def test_accessor_uses_array_when_present(self):
+        rule = StockRule(
+            "AAPL",
+            buy_threshold_pct=-5.0,      # 배열이 있으면 무시되어야 함
+            sell_threshold_pct=10.0,
+            buy_amount=500,
+            max_lots=10,
+            buy_threshold_pcts=[-3.0, -5.0, -7.0, -10.0],
+            sell_threshold_pcts=[5.0, 7.0, 10.0, 15.0],
+            buy_amounts=[100.0, 200.0, 300.0, 400.0],
+        )
+        assert rule.buy_threshold_at(1) == -3.0
+        assert rule.buy_threshold_at(3) == -7.0
+        assert rule.sell_threshold_at(2) == 7.0
+        assert rule.buy_amount_at(4) == 400.0
+
+    def test_accessor_clamps_to_last_when_level_exceeds_array(self):
+        rule = StockRule(
+            "AAPL",
+            buy_amount=500,
+            max_lots=10,
+            buy_threshold_pcts=[-5.0],
+            sell_threshold_pcts=[10.0],
+            buy_amounts=[100.0, 200.0],
+        )
+        assert rule.buy_threshold_at(4) == -5.0
+        assert rule.sell_threshold_at(9) == 10.0
+        assert rule.buy_amount_at(7) == 200.0
+
+    def test_missing_buy_threshold_raises(self):
+        with pytest.raises(ValueError, match="buy_threshold"):
+            StockRule("AAPL", sell_threshold_pct=10.0, buy_amount=500)
+
+    def test_missing_sell_threshold_raises(self):
+        with pytest.raises(ValueError, match="sell_threshold"):
+            StockRule("AAPL", buy_threshold_pct=-5.0, buy_amount=500)
+
+    def test_missing_buy_amount_raises(self):
+        with pytest.raises(ValueError, match="buy_amount"):
+            StockRule("AAPL", buy_threshold_pct=-5.0, sell_threshold_pct=10.0)
+
+    def test_empty_array_rejected(self):
+        with pytest.raises(ValueError, match="buy_threshold_pcts"):
+            StockRule(
+                "AAPL",
+                sell_threshold_pct=10.0,
+                buy_amount=500,
+                buy_threshold_pcts=[],
+            )
+
 
 class TestPositionLot:
     def test_creation(self):

--- a/tests/test_split_evaluator.py
+++ b/tests/test_split_evaluator.py
@@ -280,3 +280,135 @@ class TestEvaluateEdgeCases:
         assert len(signals) == 2
         tickers = {s.ticker for s in signals}
         assert tickers == {"AAPL", "MSFT"}
+
+
+class TestPerLevelThresholds:
+    """차수별 배열 threshold/amount 테스트"""
+
+    def _rule_with_arrays(
+        self,
+        ticker="AAPL",
+        buy_pcts=None,
+        sell_pcts=None,
+        buy_amounts=None,
+        max_lots=10,
+    ):
+        from src.core.models import StockRule
+        return StockRule(
+            ticker=ticker,
+            buy_threshold_pcts=buy_pcts,
+            sell_threshold_pcts=sell_pcts,
+            buy_amounts=buy_amounts,
+            buy_threshold_pct=(None if buy_pcts else -5.0),
+            sell_threshold_pct=(None if sell_pcts else 10.0),
+            buy_amount=(None if buy_amounts else 500.0),
+            max_lots=max_lots,
+        )
+
+    def test_buy_uses_level_specific_threshold(
+        self, evaluator, create_lot, create_portfolio
+    ):
+        """Lv1 → Lv2 매수 판단은 buy_threshold_pcts[0] 기준, Lv2→Lv3는 [1]."""
+        rule = self._rule_with_arrays(
+            buy_pcts=[-3.0, -5.0, -7.0],
+            buy_amounts=[100.0, 200.0, 300.0],
+            max_lots=5,
+        )
+        # Lv1 매수가 100, 현재가 96 → -4% ≤ -3% → Lv2 매수 트리거
+        lots = [create_lot(ticker="AAPL", buy_price=100.0, quantity=1, level=1)]
+        portfolio = create_portfolio(prices={"AAPL": 96.0}, holdings={"AAPL": 1})
+
+        signals = evaluator.evaluate_stock(rule, lots, portfolio)
+        assert len(signals) == 1
+        assert signals[0].action == OrderAction.BUY
+        assert signals[0].level == 2
+
+    def test_lv2_to_lv3_requires_stricter_drop(
+        self, evaluator, create_lot, create_portfolio
+    ):
+        """Lv2→Lv3 평가는 buy_threshold_pcts[1]=-5% 기준: -4%로는 부족."""
+        rule = self._rule_with_arrays(
+            buy_pcts=[-3.0, -5.0, -7.0],
+            buy_amounts=[100.0, 200.0, 300.0],
+            max_lots=5,
+        )
+        lots = [
+            create_lot(lot_id="l1", ticker="AAPL", buy_price=100.0, level=1),
+            create_lot(lot_id="l2", ticker="AAPL", buy_price=95.0, level=2),
+        ]
+        # Lv2 매수가 95, 현재가 91.2 → -4% (> -5%) → 매수 안 됨
+        portfolio = create_portfolio(prices={"AAPL": 91.2}, holdings={"AAPL": 2})
+
+        buy_signals = [
+            s for s in evaluator.evaluate_stock(rule, lots, portfolio)
+            if s.action == OrderAction.BUY
+        ]
+        assert buy_signals == []
+
+    def test_buy_amount_for_next_level(
+        self, evaluator, create_lot, create_portfolio
+    ):
+        """추가 매수 금액은 다음 차수(new lot) 기준."""
+        rule = self._rule_with_arrays(
+            buy_pcts=[-3.0, -5.0, -7.0],
+            buy_amounts=[100.0, 200.0, 300.0],
+            max_lots=5,
+        )
+        lots = [create_lot(ticker="AAPL", buy_price=100.0, level=1)]
+        portfolio = create_portfolio(prices={"AAPL": 96.0}, holdings={"AAPL": 1})
+
+        signals = evaluator.evaluate_stock(rule, lots, portfolio)
+        # Lv2 신규 lot → buy_amounts[1] = 200, 200/96 = 2주
+        assert signals[0].level == 2
+        assert signals[0].quantity == 2
+
+    def test_sell_uses_level_specific_threshold(
+        self, evaluator, create_lot, create_portfolio
+    ):
+        """Lv2 매도 판단은 sell_threshold_pcts[1] 기준."""
+        rule = self._rule_with_arrays(
+            sell_pcts=[5.0, 8.0, 12.0],
+            buy_amounts=[100.0, 200.0, 300.0],
+            max_lots=5,
+        )
+        lots = [
+            create_lot(lot_id="l1", ticker="AAPL", buy_price=100.0, level=1),
+            create_lot(lot_id="l2", ticker="AAPL", buy_price=100.0, level=2),
+        ]
+        # Lv2 매수가 100, 현재가 109 → +9% ≥ 8% → 매도
+        portfolio = create_portfolio(prices={"AAPL": 109.0}, holdings={"AAPL": 2})
+
+        signals = evaluator.evaluate_stock(rule, lots, portfolio)
+        assert signals and signals[0].action == OrderAction.SELL
+        assert signals[0].level == 2
+
+    def test_sell_threshold_clamps_for_deep_level(
+        self, evaluator, create_lot, create_portfolio
+    ):
+        """배열보다 깊은 level은 마지막 값으로 clamp."""
+        rule = self._rule_with_arrays(
+            sell_pcts=[5.0],
+            buy_amounts=[100.0],
+            max_lots=10,
+        )
+        lots = [create_lot(ticker="AAPL", buy_price=100.0, level=4)]
+        # Lv4에서도 sell threshold는 배열의 마지막 값 5% 사용 → +6% → 매도
+        portfolio = create_portfolio(prices={"AAPL": 106.0}, holdings={"AAPL": 5})
+
+        signals = evaluator.evaluate_stock(rule, lots, portfolio)
+        assert signals and signals[0].action == OrderAction.SELL
+
+    def test_initial_buy_uses_level1_amount(
+        self, evaluator, create_portfolio
+    ):
+        """보유 lot 없을 때 초기 매수는 buy_amounts[0] 사용."""
+        rule = self._rule_with_arrays(
+            buy_amounts=[300.0, 500.0, 800.0],
+            max_lots=5,
+        )
+        portfolio = create_portfolio(cash=10000.0, prices={"AAPL": 100.0})
+
+        signals = evaluator.evaluate([rule], [], portfolio)
+        assert len(signals) == 1
+        assert signals[0].level == 1
+        assert signals[0].quantity == 3  # 300 / 100

--- a/tests/test_strategy_config.py
+++ b/tests/test_strategy_config.py
@@ -108,3 +108,137 @@ class TestStrategyConfig:
         assert sc.rules[0].exchange == "NYS"
         from src.config import TICKER_EXCHANGE_MAP
         assert "NEWSTOCK" not in TICKER_EXCHANGE_MAP
+
+
+class TestPerLevelArrays:
+    """차수별 배열 필드 로딩"""
+
+    def test_arrays_loaded(self, tmp_path):
+        config = {
+            "stocks": [{
+                "ticker": "AAPL",
+                "buy_threshold_pcts": [-3, -5, -7, -10],
+                "sell_threshold_pcts": [5, 7, 10, 15],
+                "buy_amounts": [1000, 1500, 2000, 3000],
+                "max_lots": 10,
+            }]
+        }
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(config))
+
+        sc = StrategyConfig(str(config_file))
+        rule = sc.rules[0]
+
+        assert rule.buy_threshold_pcts == [-3.0, -5.0, -7.0, -10.0]
+        assert rule.sell_threshold_pcts == [5.0, 7.0, 10.0, 15.0]
+        assert rule.buy_amounts == [1000.0, 1500.0, 2000.0, 3000.0]
+        assert rule.buy_threshold_pct is None
+        assert rule.sell_threshold_pct is None
+        assert rule.buy_amount is None
+
+    def test_mixed_array_and_scalar(self, tmp_path):
+        """배열과 단일값이 공존하면 둘 다 저장 (접근자는 배열 우선)."""
+        config = {
+            "stocks": [{
+                "ticker": "AAPL",
+                "buy_threshold_pct": -5.0,
+                "buy_threshold_pcts": [-3, -5, -7],
+                "sell_threshold_pct": 10.0,
+                "buy_amount": 500,
+            }]
+        }
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps(config))
+
+        rule = StrategyConfig(str(config_file)).rules[0]
+        assert rule.buy_threshold_pct == -5.0
+        assert rule.buy_threshold_pcts == [-3.0, -5.0, -7.0]
+        assert rule.buy_threshold_at(1) == -3.0  # 배열 우선
+
+
+class TestPresets:
+    """공유 프리셋 파일 로딩 및 병합"""
+
+    def _write(self, tmp_path, cfg: dict, presets: dict | None = None):
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(json.dumps(cfg))
+        if presets is not None:
+            (tmp_path / "presets.json").write_text(json.dumps(presets))
+        return str(cfg_file)
+
+    def test_preset_applied(self, tmp_path):
+        presets = {
+            "large_cap_us": {
+                "buy_threshold_pcts": [-3, -5, -7, -10],
+                "sell_threshold_pcts": [5, 7, 10, 15],
+                "buy_amounts": [1000, 1500, 2000, 3000],
+                "max_lots": 10,
+            }
+        }
+        cfg = {"stocks": [{"ticker": "AAPL", "exchange": "NAS", "preset": "large_cap_us"}]}
+        cfg_path = self._write(tmp_path, cfg, presets)
+
+        sc = StrategyConfig(cfg_path)
+        rule = sc.rules[0]
+        assert rule.ticker == "AAPL"
+        assert rule.exchange == "NAS"
+        assert rule.buy_threshold_pcts == [-3.0, -5.0, -7.0, -10.0]
+        assert rule.buy_amounts == [1000.0, 1500.0, 2000.0, 3000.0]
+        assert rule.max_lots == 10
+
+    def test_stock_overrides_preset(self, tmp_path):
+        presets = {
+            "large_cap_us": {
+                "buy_threshold_pcts": [-3, -5, -7, -10],
+                "sell_threshold_pcts": [5, 7, 10, 15],
+                "buy_amounts": [1000, 1500, 2000, 3000],
+                "max_lots": 10,
+            }
+        }
+        cfg = {"stocks": [{
+            "ticker": "TSLA",
+            "preset": "large_cap_us",
+            "sell_threshold_pcts": [7, 10, 15, 25],
+            "max_lots": 6,
+        }]}
+        cfg_path = self._write(tmp_path, cfg, presets)
+
+        rule = StrategyConfig(cfg_path).rules[0]
+        assert rule.sell_threshold_pcts == [7.0, 10.0, 15.0, 25.0]
+        assert rule.buy_threshold_pcts == [-3.0, -5.0, -7.0, -10.0]  # from preset
+        assert rule.max_lots == 6
+
+    def test_unknown_preset_raises(self, tmp_path):
+        presets = {"large_cap_us": {"buy_threshold_pcts": [-5], "sell_threshold_pcts": [10], "buy_amounts": [500]}}
+        cfg = {"stocks": [{"ticker": "AAPL", "preset": "nonexistent"}]}
+        cfg_path = self._write(tmp_path, cfg, presets)
+
+        with pytest.raises(KeyError, match="nonexistent"):
+            StrategyConfig(cfg_path)
+
+    def test_missing_presets_file_ok_when_unused(self, tmp_path):
+        """presets.json이 없어도 preset을 쓰지 않으면 정상 로드."""
+        cfg = {"stocks": [{"ticker": "AAPL", "buy_amount": 500}]}
+        cfg_path = self._write(tmp_path, cfg)
+
+        sc = StrategyConfig(cfg_path)
+        assert sc.presets == {}
+        assert sc.rules[0].buy_amount == 500
+
+    def test_missing_presets_file_fails_when_referenced(self, tmp_path):
+        cfg = {"stocks": [{"ticker": "AAPL", "preset": "large_cap_us"}]}
+        cfg_path = self._write(tmp_path, cfg)
+
+        with pytest.raises(FileNotFoundError):
+            StrategyConfig(cfg_path)
+
+    def test_explicit_presets_path(self, tmp_path):
+        presets_file = tmp_path / "custom_presets.json"
+        presets_file.write_text(json.dumps({
+            "p1": {"buy_threshold_pcts": [-5], "sell_threshold_pcts": [10], "buy_amounts": [500]}
+        }))
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(json.dumps({"stocks": [{"ticker": "AAPL", "preset": "p1"}]}))
+
+        sc = StrategyConfig(str(cfg_file), presets_path=str(presets_file))
+        assert sc.rules[0].buy_amounts == [500.0]

--- a/tests/test_strategy_config.py
+++ b/tests/test_strategy_config.py
@@ -232,6 +232,14 @@ class TestPresets:
         with pytest.raises(FileNotFoundError):
             StrategyConfig(cfg_path)
 
+    def test_empty_presets_file_raises_key_error_not_file_not_found(self, tmp_path):
+        """파일은 존재하나 비어 있으면 FileNotFoundError가 아니라 KeyError(미존재 preset)로 실패."""
+        cfg = {"stocks": [{"ticker": "AAPL", "preset": "large_cap_us"}]}
+        cfg_path = self._write(tmp_path, cfg, presets={})
+
+        with pytest.raises(KeyError, match="large_cap_us"):
+            StrategyConfig(cfg_path)
+
     def test_explicit_presets_path(self, tmp_path):
         presets_file = tmp_path / "custom_presets.json"
         presets_file.write_text(json.dumps({


### PR DESCRIPTION
## Summary
- `StockRule`에 차수별 배열 필드(`buy_threshold_pcts`, `sell_threshold_pcts`, `buy_amounts`)와 접근자(`buy_threshold_at(level)` 등) 추가. 배열이 있으면 배열이 우선, 배열 길이 초과 레벨은 마지막 값으로 clamp.
- `StrategyConfig`가 `presets.json`(repo 루트, 국내/해외 config가 공유)을 선택적으로 로드. stocks의 `preset` 키로 참조, 종목 필드가 preset을 override. 경로는 생성자 인자 → `PRESETS_JSON_PATH` → config 디렉토리의 `presets.json` 순.
- `split_evaluator`가 접근자를 사용해 차수별 차등 반영: 매수 금액은 다음 차수(신규 lot) 기준, 임계치는 마지막 차수 기준. 기존 단일값 config는 수정 없이 그대로 동작.

## Changes
| 파일 | 내용 |
|---|---|
| `src/core/models.py` | 배열 필드 3개 + 접근자 3개 + `__post_init__` 검증 |
| `src/strategy_config.py` | `presets.json` 공유 파일 로딩 + 병합 로직 + 레거시 기본값 유지 |
| `src/core/logic/split_evaluator.py` | 4개 참조 지점을 접근자로 교체 |
| `tests/*` | 모델 접근자, 프리셋/override/미존재 케이스, 레벨별 차등 회귀 테스트 추가 |

## Backward Compatibility
- 기존 `config_domestic.json` / `config_overseas.json`은 **수정 없이 동일 동작**.
- `presets.json`이 없고 어떤 종목도 `preset`을 쓰지 않으면 기능 비활성.
- `StockRule`의 기존 positional 호출(`StockRule("AAPL", -5.0, 10.0, 500, 10)`) 그대로 유효.

## Usage (optional)
`presets.json` (repo 루트):
```json
{
  "large_cap_us": {
    "buy_threshold_pcts": [-3, -5, -7, -10],
    "sell_threshold_pcts": [5, 7, 10, 15],
    "buy_amounts": [1000, 1500, 2000, 3000],
    "max_lots": 10
  }
}
```
`config_overseas.json`의 개별 종목:
```json
{ "ticker": "AAPL", "exchange": "NAS", "preset": "large_cap_us" }
```

## Test Plan
- [x] `pytest tests/` (173 passed; yfinance 미설치 환경에서 backtest 관련 4개 모듈 제외)
- [x] 변경 파일 단위 커버리지 확인: models 98%, strategy_config 95%, split_evaluator 94%
- [ ] CI `pytest --cov=src --cov-fail-under=80 tests/` 통과 (yfinance 포함)
- [ ] 실 데이터 `config_*.json`으로 1 사이클 스모크 테스트 (presets.json 없는 상태)
- [ ] `presets.json` 샘플 + `preset` 키 추가 후 스모크 테스트

https://claude.ai/code/session_016W29aqzXwSCLe1cBFFWiFo