### PR TITLE
🎨 Palette: [UX improvement] Improve UI Accessibility for Dashboard Lots

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -54,12 +54,15 @@
             const lots = info.lots || [];
             let lotsHtml = '';
             for (const lot of lots) {
-                const pctClass = lot.pct_change >= 0 ? 'pct-positive' : 'pct-negative';
-                const pctStr = (lot.pct_change >= 0 ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const isPositive = lot.pct_change >= 0;
+                const pctClass = isPositive ? 'pct-positive' : 'pct-negative';
+                const pctStr = (isPositive ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const ariaLabel = (isPositive ? 'Profit of ' : 'Loss of ') + Math.abs(lot.pct_change).toFixed(1) + '%';
+                const icon = isPositive ? '▲' : '▼';
                 lotsHtml += `
                     <li class="lot-item">
-                        <span>${lot.buy_date} | ${lot.quantity}shares @$${lot.buy_price.toFixed(2)}</span>
-                        <span class="${pctClass}">${pctStr}</span>
+                        <span>${lot.buy_date} | ${lot.quantity} shares @ $${lot.buy_price.toFixed(2)}</span>
+                        <span class="${pctClass}" aria-label="${ariaLabel}">${pctStr} <span aria-hidden="true">${icon}</span></span>
                     </li>`;
             }
 


### PR DESCRIPTION
💡 What: Add ARIA labels and visual indicator to lot items to improve accessibility. Fix visual spacing in shares @ price.
🎯 Why: Financial data must be instantly readable; ambiguity causes panic. It improves the accessibility for colorblind users when viewing their profit or loss on the dashboard.
♿ Accessibility: ARIA labels and hidden arrows make it read aloud as "Profit of 5.2%" and avoids redundant visual clutter.


---
*PR created automatically by Jules for task [17518701871411157860](https://jules.google.com/task/17518701871411157860) started by @Junghyun99*