### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels, directional arrows, and KRX color conventions for P/L

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+# Palette's Journal
+
+- The dashboard target audience is Korean, so we should adapt to KRX color conventions (Red = Up/Profit, Blue = Down/Loss).
+- We should use directional arrows (▲/▼) alongside colors and ARIA labels for accessibility, particularly for colorblind users.

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,8 +1,8 @@
 /* MagicSplit Dashboard Style */
 :root {
     --primary: #2563eb;
-    --success: #16a34a;
-    --danger: #dc2626;
+    --success: #dc2626; /* KRX convention: Red is up/profit */
+    --danger: #2563eb;  /* KRX convention: Blue is down/loss */
     --warning: #d97706;
     --bg: #f8fafc;
     --card-bg: #ffffff;

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -54,12 +54,18 @@
             const lots = info.lots || [];
             let lotsHtml = '';
             for (const lot of lots) {
-                const pctClass = lot.pct_change >= 0 ? 'pct-positive' : 'pct-negative';
-                const pctStr = (lot.pct_change >= 0 ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const isPositive = lot.pct_change >= 0;
+                const pctClass = isPositive ? 'pct-positive' : 'pct-negative';
+                const arrow = isPositive ? '▲' : '▼';
+                const pctStr = (isPositive ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const ariaLabel = (isPositive ? 'Profit of ' : 'Loss of ') + Math.abs(lot.pct_change).toFixed(1) + '%';
+
                 lotsHtml += `
                     <li class="lot-item">
                         <span>${lot.buy_date} | ${lot.quantity}shares @$${lot.buy_price.toFixed(2)}</span>
-                        <span class="${pctClass}">${pctStr}</span>
+                        <span class="${pctClass}" aria-label="${ariaLabel}">
+                            ${pctStr} <span aria-hidden="true">${arrow}</span>
+                        </span>
                     </li>`;
             }
 


### PR DESCRIPTION
💡 What: Added directional arrows (▲/▼) alongside profit/loss percentages, updated colors to match KRX conventions (Red = Profit, Blue = Loss), and added ARIA labels for screen readers. 
🎯 Why: Financial clarity and instantly readable results for Korean users and visually impaired users.
📸 Before/After Screenshots: Verified frontend visually.
♿ Accessibility: Ensures that users with screen readers can interpret profit and loss properly, and avoids relying on color alone for positive and negative numbers.

---
*PR created automatically by Jules for task [15405782239234575075](https://jules.google.com/task/15405782239234575075) started by @Junghyun99*