### PR TITLE
🎨 Palette: Improve accessibility of profit/loss indicators

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,1 @@
+# Palette's Journal\n- The site uses a vanilla JS frontend rendering JSON data (`status.json`).\n- Financial metrics should use ARIA labels and visual indicators (like ▲ / ▼) to distinguish profit/loss for colorblind users and screen readers.

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1,83 +1,96 @@
 // MagicSplit Dashboard - main.js
 (function () {
-    'use strict';
+  "use strict";
 
-    const STATUS_URL = 'data/status.json';
+  const STATUS_URL = "data/status.json";
 
-    async function loadStatus() {
-        try {
-            const ts = Date.now();
-            const res = await fetch(`${STATUS_URL}?t=${ts}`);
-            if (!res.ok) throw new Error(`HTTP ${res.status}`);
-            return await res.json();
-        } catch (e) {
-            console.error('Failed to load status:', e);
-            return null;
-        }
+  async function loadStatus() {
+    try {
+      const ts = Date.now();
+      const res = await fetch(`${STATUS_URL}?t=${ts}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return await res.json();
+    } catch (e) {
+      console.error("Failed to load status:", e);
+      return null;
+    }
+  }
+
+  function formatCurrency(value) {
+    return (
+      "$" +
+      Number(value).toLocaleString("en-US", {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      })
+    );
+  }
+
+  function renderStatus(data) {
+    if (!data) {
+      document.getElementById("loading").textContent = "No data available.";
+      return;
     }
 
-    function formatCurrency(value) {
-        return '$' + Number(value).toLocaleString('en-US', {
-            minimumFractionDigits: 0,
-            maximumFractionDigits: 0,
-        });
+    document.getElementById("loading").style.display = "none";
+
+    // Status bar
+    document.getElementById("last-updated").textContent =
+      "Updated: " + (data.last_updated || "-");
+    document.getElementById("total-value").textContent = formatCurrency(
+      data.portfolio?.total_value || 0,
+    );
+
+    // Positions
+    const container = document.getElementById("positions-container");
+    container.innerHTML = "";
+
+    const positions = data.positions || {};
+    if (Object.keys(positions).length === 0) {
+      container.innerHTML = '<div class="card">No positions yet.</div>';
+      return;
     }
 
-    function renderStatus(data) {
-        if (!data) {
-            document.getElementById('loading').textContent = 'No data available.';
-            return;
-        }
+    for (const [ticker, info] of Object.entries(positions)) {
+      const card = document.createElement("div");
+      card.className = "card";
 
-        document.getElementById('loading').style.display = 'none';
+      const lots = info.lots || [];
+      let lotsHtml = "";
+      for (const lot of lots) {
+        const isProfit = lot.pct_change >= 0;
+        const pctClass = isProfit ? "pct-positive" : "pct-negative";
+        const pctStr = (isProfit ? "+" : "") + lot.pct_change.toFixed(1) + "%";
+        const ariaLabel =
+          (isProfit ? "Profit of " : "Loss of ") +
+          Math.abs(lot.pct_change).toFixed(1) +
+          "%";
+        const arrowIndicator = isProfit ? "▲" : "▼";
 
-        // Status bar
-        document.getElementById('last-updated').textContent =
-            'Updated: ' + (data.last_updated || '-');
-        document.getElementById('total-value').textContent =
-            formatCurrency(data.portfolio?.total_value || 0);
-
-        // Positions
-        const container = document.getElementById('positions-container');
-        container.innerHTML = '';
-
-        const positions = data.positions || {};
-        if (Object.keys(positions).length === 0) {
-            container.innerHTML = '<div class="card">No positions yet.</div>';
-            return;
-        }
-
-        for (const [ticker, info] of Object.entries(positions)) {
-            const card = document.createElement('div');
-            card.className = 'card';
-
-            const lots = info.lots || [];
-            let lotsHtml = '';
-            for (const lot of lots) {
-                const pctClass = lot.pct_change >= 0 ? 'pct-positive' : 'pct-negative';
-                const pctStr = (lot.pct_change >= 0 ? '+' : '') + lot.pct_change.toFixed(1) + '%';
-                lotsHtml += `
+        lotsHtml += `
                     <li class="lot-item">
-                        <span>${lot.buy_date} | ${lot.quantity}shares @$${lot.buy_price.toFixed(2)}</span>
-                        <span class="${pctClass}">${pctStr}</span>
+                        <span>${lot.buy_date} | ${lot.quantity} shares @ $${lot.buy_price.toFixed(2)}</span>
+                        <span class="${pctClass}" aria-label="${ariaLabel}">
+                            ${pctStr} <span aria-hidden="true">${arrowIndicator}</span>
+                        </span>
                     </li>`;
-            }
+      }
 
-            card.innerHTML = `
+      card.innerHTML = `
                 <div class="card-header">
                     <span class="ticker">${ticker}</span>
                     <span class="price">${info.total_qty} shares | ${info.lot_count} lots</span>
                 </div>
                 <ul class="lot-list">${lotsHtml}</ul>
             `;
-            container.appendChild(card);
-        }
+      container.appendChild(card);
     }
+  }
 
-    async function init() {
-        const data = await loadStatus();
-        renderStatus(data);
-    }
+  async function init() {
+    const data = await loadStatus();
+    renderStatus(data);
+  }
 
-    init();
+  init();
 })();


### PR DESCRIPTION
I've implemented a micro-UX improvement for the financial data visualization in the `docs/js/main.js` script.

💡 **What:**
- Added `aria-label`s to profit/loss percentage indicators.
- Added visual up/down arrows (▲/▼) that are hidden from screen readers to provide clear visual cues for profit and loss alongside the existing color coding.
- Prettier-formatted `docs/js/main.js`

🎯 **Why:**
Financial clarity is paramount. The current design relied solely on red/green color differentiation (`pct-positive` / `pct-negative` classes) to distinguish between profit and loss. Adding explicit text via screen readers and an icon ensures clarity for those who are colorblind.

📸 **Before/After Screenshots:**
Verification completed. The screenshot captures the portfolio UI showing the new visual arrows next to the percentages.

♿ **Accessibility:**
- Added robust `aria-label`s communicating profit vs. loss for screen readers explicitly.
- The visual arrows have `aria-hidden="true"` so they don't read out repetitively for screen readers, but ensure colorblind users can see the direction of the trade instantly.

---
*PR created automatically by Jules for task [13015720942593294529](https://jules.google.com/task/13015720942593294529) started by @Junghyun99*