### PR TITLE
[UI] 종목 카드에 현재 차수(Level) 뱃지 표시 (#88)

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -85,9 +85,36 @@ h2 { font-size: 1.1rem; margin-bottom: 8px; color: var(--text-muted); }
 .pct-positive { color: var(--success); font-weight: 600; }
 .pct-negative { color: var(--danger); font-weight: 600; }
 
+.level-badge {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 2px 7px;
+    border-radius: 10px;
+    vertical-align: middle;
+    color: white;
+    background: #94a3b8;
+}
+.level-badge[data-level="1"] { background: #4ade80; color: #14532d; }
+.level-badge[data-level="2"] { background: #facc15; color: #713f12; }
+.level-badge[data-level="3"] { background: #fb923c; color: #431407; }
+.level-badge[data-level="4"] { background: #ef4444; }
+.level-badge[data-level="5"] { background: #991b1b; }
+
+.lot-level {
+    display: inline-block;
+    width: 2.8em;
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+
 .lot-list { list-style: none; padding: 0; }
 .lot-item {
     display: flex;
+    align-items: center;
+    gap: 6px;
     justify-content: space-between;
     padding: 6px 0;
     border-bottom: 1px solid var(--border);

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -110,6 +110,8 @@ h2 { font-size: 1.1rem; margin-bottom: 8px; color: var(--text-muted); }
     flex-shrink: 0;
 }
 
+.lot-detail { flex-grow: 1; }
+
 .lot-list { list-style: none; padding: 0; }
 .lot-item {
     display: flex;

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -79,12 +79,20 @@
             card.className = 'card';
 
             const lots = info.lots || [];
+            const maxLevel = lots.length > 0 ? Math.max(...lots.map((l) => l.level || 0)) : null;
+            const levelAttr = maxLevel !== null ? Math.min(maxLevel, 5) : 0;
+            const levelBadge = maxLevel !== null
+                ? `<span class="level-badge" data-level="${levelAttr}">Lv${maxLevel}</span>`
+                : '';
+
             let lotsHtml = '';
             for (const lot of lots) {
                 const pctClass = lot.pct_change >= 0 ? 'pct-positive' : 'pct-negative';
                 const pctStr = (lot.pct_change >= 0 ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const lvLabel = lot.level != null ? `<span class="lot-level">Lv${lot.level}</span>` : '<span class="lot-level"></span>';
                 lotsHtml += `
                     <li class="lot-item">
+                        ${lvLabel}
                         <span>${lot.buy_date} | ${lot.quantity}shares @$${lot.buy_price.toFixed(2)}</span>
                         <span class="${pctClass}">${pctStr}</span>
                     </li>`;
@@ -92,7 +100,7 @@
 
             card.innerHTML = `
                 <div class="card-header">
-                    <span class="ticker">${ticker}</span>
+                    <span class="ticker">${ticker} ${levelBadge}</span>
                     <span class="price">${info.total_qty} shares | ${info.lot_count} lots</span>
                 </div>
                 <ul class="lot-list">${lotsHtml}</ul>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -93,7 +93,7 @@
                 lotsHtml += `
                     <li class="lot-item">
                         ${lvLabel}
-                        <span>${lot.buy_date} | ${lot.quantity}shares @$${lot.buy_price.toFixed(2)}</span>
+                        <span class="lot-detail">${lot.buy_date} | ${lot.quantity}shares @$${lot.buy_price.toFixed(2)}</span>
                         <span class="${pctClass}">${pctStr}</span>
                     </li>`;
             }


### PR DESCRIPTION
## Summary
- 카드 헤더에 최대 level 뱃지(`Lv{N}`) 추가 — 레벨에 따라 색상 그라데이션 (Lv1 연초록 → Lv5+ 진빨강)
- 각 lot 행 앞에 `Lv{N}` 레이블 표시하여 차수를 한눈에 확인 가능
- 빈 포지션(`lots = []`) 및 `lot.level` 누락 시 깨짐 없이 방어 처리

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `docs/js/main.js` | `maxLevel` 계산 후 카드 헤더 뱃지 삽입, lot 행에 레벨 prefix 추가 |
| `docs/css/style.css` | `.level-badge` pill 스타일 + `data-level` 기반 색상 5단계, `.lot-level` 고정폭 레이블 |

## Test plan
- [ ] `status.json`에 `lot.level` 값이 있는 경우 → 카드 헤더에 `Lv{N}` 뱃지, lot 행에 `Lv{N}` 표시 확인
- [ ] `lots` 배열이 비어 있는 경우 → 뱃지 미표시, 레이아웃 깨짐 없음 확인
- [ ] level 1/2/3/4/5+ 별로 색상이 다르게 표시되는지 확인

Closes #88

https://claude.ai/code/session_011Ad5CGqBkJSYnFqcf25wE6

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ad5CGqBkJSYnFqcf25wE6)_