### PR TITLE
[UI] reason 배너를 상단에 항상 표시 (#99)

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -163,3 +163,20 @@ h2 { font-size: 1.1rem; margin-bottom: 8px; color: var(--text-muted); }
 .btn-primary { background: var(--primary); color: white; }
 
 #loading { text-align: center; color: var(--text-muted); padding: 40px; }
+
+.reason-banner {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    font-size: 0.85rem;
+    margin-top: -8px;
+    margin-bottom: 12px;
+    border: 1px solid transparent;
+}
+.reason-banner.info    { background: #f1f5f9; color: var(--text-muted); border-color: var(--border); }
+.reason-banner.primary { background: #eff6ff; color: var(--primary);    border-color: #bfdbfe; }
+.reason-banner.success { background: #f0fdf4; color: var(--success);    border-color: #bbf7d0; }
+.reason-banner.danger  { background: #fef2f2; color: var(--danger);     border-color: #fecaca; }
+.reason-date { font-size: 0.78rem; color: var(--text-muted); margin-left: 4px; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,6 +22,8 @@
         <span id="total-value">-</span>
     </div>
 
+    <div id="reason-banner" class="reason-banner" style="display:none"></div>
+
     <div id="loading">Loading positions...</div>
     <div id="positions-container"></div>
 

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -63,11 +63,24 @@
         }
         const type = classifyReason(reason);
         const icons = { info: 'ℹ️', primary: '🔵', success: '✅', danger: '🔴' };
-        const dateStr = data.last_run_date
-            ? `<span class="reason-date">(${data.last_run_date})</span>`
-            : '';
         banner.className = `reason-banner ${type}`;
-        banner.innerHTML = `<span>${icons[type]}</span><span>최근 실행: ${reason}</span>${dateStr}`;
+        banner.textContent = '';
+
+        const iconSpan = document.createElement('span');
+        iconSpan.textContent = icons[type];
+        banner.appendChild(iconSpan);
+
+        const textSpan = document.createElement('span');
+        textSpan.textContent = '최근 실행: ' + reason;
+        banner.appendChild(textSpan);
+
+        if (data.last_run_date) {
+            const dateSpan = document.createElement('span');
+            dateSpan.className = 'reason-date';
+            dateSpan.textContent = '(' + data.last_run_date + ')';
+            banner.appendChild(dateSpan);
+        }
+
         banner.style.display = '';
     }
 

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -44,6 +44,33 @@
         });
     }
 
+    function classifyReason(reason) {
+        if (!reason) return 'info';
+        const lower = reason.toLowerCase();
+        if (lower.includes('에러') || lower.includes('오류') || lower.includes('error')) return 'danger';
+        if (reason.includes('매도')) return 'success';
+        if (reason.includes('매수')) return 'primary';
+        return 'info';
+    }
+
+    function renderReasonBanner(data) {
+        const banner = document.getElementById('reason-banner');
+        if (!banner) return;
+        const reason = data && data.reason;
+        if (!reason) {
+            banner.style.display = 'none';
+            return;
+        }
+        const type = classifyReason(reason);
+        const icons = { info: 'ℹ️', primary: '🔵', success: '✅', danger: '🔴' };
+        const dateStr = data.last_run_date
+            ? `<span class="reason-date">(${data.last_run_date})</span>`
+            : '';
+        banner.className = `reason-banner ${type}`;
+        banner.innerHTML = `<span>${icons[type]}</span><span>최근 실행: ${reason}</span>${dateStr}`;
+        banner.style.display = '';
+    }
+
     function renderStatus(data, mode) {
         const loading = document.getElementById('loading');
         const container = document.getElementById('positions-container');
@@ -52,6 +79,7 @@
         if (!data) {
             loading.textContent = `No ${mode} data available.`;
             loading.style.display = '';
+            renderReasonBanner(null);
             return;
         }
 
@@ -62,17 +90,13 @@
         document.getElementById('total-value').textContent =
             formatCurrency(data.portfolio?.total_value || 0, mode);
 
+        renderReasonBanner(data);
+
         const positions = data.positions || {};
         if (Object.keys(positions).length === 0) {
             const emptyCard = document.createElement('div');
             emptyCard.className = 'card';
             emptyCard.textContent = `No ${mode} positions yet.`;
-            if (data.reason) {
-                const reasonNode = document.createElement('span');
-                reasonNode.className = 'empty-reason';
-                reasonNode.textContent = ` (${data.reason})`;
-                emptyCard.appendChild(reasonNode);
-            }
             container.appendChild(emptyCard);
             return;
         }


### PR DESCRIPTION
## Summary
- `status.json`의 `reason` 필드를 status-bar 바로 아래 배너로 **항상** 표시 (포지션 유무 무관)
- reason 내용에 따라 색상 자동 분기: 매수→파랑, 매도→초록, 에러→빨강, 그 외→회색
- `last_run_date`가 있으면 날짜도 배너에 함께 표시
- `reason`이 없을 때는 배너를 숨김 처리 (graceful)

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `docs/index.html` | `#reason-banner` div 추가 (status-bar 아래) |
| `docs/js/main.js` | `classifyReason()` + `renderReasonBanner()` 함수 추가, 항상 호출, 빈 카드 inline reason 제거 |
| `docs/css/style.css` | `.reason-banner` 스타일 + info/primary/success/danger 색상 변형 추가 |

## Test plan
- [ ] 포지션이 있을 때 reason 배너가 status-bar 아래에 표시되는지 확인
- [ ] 포지션이 없을 때도 reason 배너가 표시되는지 확인
- [ ] reason에 "매수" 포함 시 파란색, "매도" 포함 시 초록색, "에러" 포함 시 빨간색, 그 외 회색 확인
- [ ] `last_run_date` 필드가 있을 때 날짜가 함께 표시되는지 확인
- [ ] `reason`이 null/없을 때 배너가 숨겨지는지 확인

Closes #99

https://claude.ai/code/session_01DGe4CevEBHpEYevBrmW92u

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGe4CevEBHpEYevBrmW92u)_