### PR TITLE
feat(ui): 수동 새로고침 버튼 및 자동 refresh 기능 추가 (#101)

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -180,3 +180,49 @@ h2 { font-size: 1.1rem; margin-bottom: 8px; color: var(--text-muted); }
 .reason-banner.success { background: #f0fdf4; color: var(--success);    border-color: #bbf7d0; }
 .reason-banner.danger  { background: #fef2f2; color: var(--danger);     border-color: #fecaca; }
 .reason-date { font-size: 0.78rem; color: var(--text-muted); margin-left: 4px; }
+
+.refresh-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.refresh-btn {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    font-size: 1rem;
+    padding: 0 2px;
+    line-height: 1;
+    opacity: 0.85;
+    transition: opacity 0.15s;
+}
+.refresh-btn:hover { opacity: 1; }
+
+.auto-refresh-select {
+    background: rgba(255, 255, 255, 0.15);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    color: white;
+    font-size: 0.75rem;
+    padding: 2px 4px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+.auto-refresh-select option { background: var(--primary); color: white; }
+
+.refresh-age {
+    font-size: 0.75rem;
+    opacity: 0.8;
+    min-width: 3.5em;
+    text-align: right;
+}
+
+.offline-badge {
+    font-size: 0.75rem;
+    background: var(--danger);
+    color: white;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-weight: 600;
+    white-space: nowrap;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,6 +20,17 @@
         <span id="mode-badge" class="mode-badge">-</span>
         <span id="last-updated">Loading...</span>
         <span id="total-value">-</span>
+        <span id="offline-badge" class="offline-badge" style="display:none">⚠️ 실패</span>
+        <span class="refresh-controls">
+            <span id="refresh-age" class="refresh-age"></span>
+            <button id="refresh-btn" class="refresh-btn" title="새로고침">🔄</button>
+            <select id="auto-refresh-select" class="auto-refresh-select" title="자동 새로고침">
+                <option value="0">Off</option>
+                <option value="30000">30초</option>
+                <option value="60000">1분</option>
+                <option value="300000">5분</option>
+            </select>
+        </span>
     </div>
 
     <div id="reason-banner" class="reason-banner" style="display:none"></div>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -5,10 +5,20 @@
     const VALID_MODES = ['domestic', 'overseas', 'backtest'];
     const DEFAULT_MODE = 'domestic';
 
+    let currentMode = DEFAULT_MODE;
+    let lastData = null;
+    let lastRefreshTime = null;
+    let refreshTimer = null;
+
     function resolveMode() {
         const params = new URLSearchParams(window.location.search);
         const requested = (params.get('mode') || '').toLowerCase();
         return VALID_MODES.includes(requested) ? requested : DEFAULT_MODE;
+    }
+
+    function setOfflineBadge(show) {
+        const badge = document.getElementById('offline-badge');
+        if (badge) badge.style.display = show ? '' : 'none';
     }
 
     async function loadStatus(mode) {
@@ -16,10 +26,45 @@
         try {
             const res = await fetch(url);
             if (!res.ok) throw new Error(`HTTP ${res.status}`);
-            return await res.json();
+            const data = await res.json();
+            setOfflineBadge(false);
+            lastData = data;
+            return data;
         } catch (e) {
             console.error(`Failed to load status (${mode}):`, e);
-            return null;
+            setOfflineBadge(true);
+            return lastData;
+        }
+    }
+
+    function getRelativeTime(timestamp) {
+        if (!timestamp) return '';
+        const seconds = Math.floor((Date.now() - timestamp) / 1000);
+        if (seconds < 10) return '방금 전';
+        if (seconds < 60) return `${seconds}초 전`;
+        const minutes = Math.floor(seconds / 60);
+        if (minutes < 60) return `${minutes}분 전`;
+        return `${Math.floor(minutes / 60)}시간 전`;
+    }
+
+    function updateRefreshAge() {
+        const ageEl = document.getElementById('refresh-age');
+        if (ageEl) ageEl.textContent = getRelativeTime(lastRefreshTime);
+    }
+
+    async function doRefresh() {
+        if (document.visibilityState === 'hidden') return;
+        const data = await loadStatus(currentMode);
+        renderStatus(data, currentMode);
+        lastRefreshTime = Date.now();
+        updateRefreshAge();
+    }
+
+    function setAutoRefresh(intervalMs) {
+        clearInterval(refreshTimer);
+        refreshTimer = null;
+        if (intervalMs > 0) {
+            refreshTimer = setInterval(doRefresh, intervalMs);
         }
     }
 
@@ -163,11 +208,38 @@
         }
     }
 
+    function initRefreshControls() {
+        const refreshBtn = document.getElementById('refresh-btn');
+        if (refreshBtn) {
+            refreshBtn.addEventListener('click', doRefresh);
+        }
+
+        const selectEl = document.getElementById('auto-refresh-select');
+        if (selectEl) {
+            const saved = parseInt(localStorage.getItem('autoRefreshInterval') || '0', 10);
+            const validValues = ['0', '30000', '60000', '300000'];
+            selectEl.value = validValues.includes(String(saved)) ? String(saved) : '0';
+
+            selectEl.addEventListener('change', () => {
+                const intervalMs = parseInt(selectEl.value, 10);
+                localStorage.setItem('autoRefreshInterval', intervalMs);
+                setAutoRefresh(intervalMs);
+            });
+
+            setAutoRefresh(parseInt(selectEl.value, 10));
+        }
+
+        setInterval(updateRefreshAge, 10000);
+    }
+
     async function init() {
-        const mode = resolveMode();
-        applyModeUI(mode);
-        const data = await loadStatus(mode);
-        renderStatus(data, mode);
+        currentMode = resolveMode();
+        applyModeUI(currentMode);
+        const data = await loadStatus(currentMode);
+        renderStatus(data, currentMode);
+        lastRefreshTime = Date.now();
+        updateRefreshAge();
+        initRefreshControls();
     }
 
     init();

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -6,7 +6,7 @@
     const DEFAULT_MODE = 'domestic';
 
     let currentMode = DEFAULT_MODE;
-    let lastData = null;
+    let isRefreshing = false;
     let lastRefreshTime = null;
     let refreshTimer = null;
 
@@ -28,12 +28,11 @@
             if (!res.ok) throw new Error(`HTTP ${res.status}`);
             const data = await res.json();
             setOfflineBadge(false);
-            lastData = data;
             return data;
         } catch (e) {
             console.error(`Failed to load status (${mode}):`, e);
             setOfflineBadge(true);
-            return lastData;
+            return null;
         }
     }
 
@@ -53,11 +52,18 @@
     }
 
     async function doRefresh() {
-        if (document.visibilityState === 'hidden') return;
-        const data = await loadStatus(currentMode);
-        renderStatus(data, currentMode);
-        lastRefreshTime = Date.now();
-        updateRefreshAge();
+        if (isRefreshing || document.visibilityState === 'hidden') return;
+        isRefreshing = true;
+        try {
+            const data = await loadStatus(currentMode);
+            if (data) {
+                renderStatus(data, currentMode);
+                lastRefreshTime = Date.now();
+                updateRefreshAge();
+            }
+        } finally {
+            isRefreshing = false;
+        }
     }
 
     function setAutoRefresh(intervalMs) {
@@ -237,8 +243,10 @@
         applyModeUI(currentMode);
         const data = await loadStatus(currentMode);
         renderStatus(data, currentMode);
-        lastRefreshTime = Date.now();
-        updateRefreshAge();
+        if (data) {
+            lastRefreshTime = Date.now();
+            updateRefreshAge();
+        }
         initRefreshControls();
     }
 


### PR DESCRIPTION
## Summary

- `docs/index.html` status-bar에 🔄 수동 새로고침 버튼 및 자동 갱신 주기 선택 UI 추가
- `docs/js/main.js`에 `doRefresh()`, `setAutoRefresh()`, `getRelativeTime()` 함수 추가 — 탭 숨김 시 refresh 건너뜀, fetch 실패 시 기존 데이터 유지 + 오프라인 배지 표시, localStorage로 선택값 영속
- `docs/css/style.css`에 새로고침 버튼·select·오프라인 배지 스타일 추가

Closes #101

## Test plan

- [ ] 페이지 로드 후 🔄 버튼 클릭 시 데이터 재fetch 및 "방금 전" 표시 확인
- [ ] 자동 갱신 주기 선택 후 페이지 리로드 시 localStorage에서 값 복원 확인
- [ ] 탭을 다른 탭으로 전환한 상태에서 자동 갱신 타이머가 건너뜀 확인
- [ ] 네트워크 오류 시 기존 데이터 유지 + ⚠️ 실패 배지 표시 확인

https://claude.ai/code/session_018ZDLo8ih6UkDdKu9vt9724

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZDLo8ih6UkDdKu9vt9724)_