### PR TITLE
feat(docs): 종목별 차수(Level) 히트맵 추가 (#96)

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -101,6 +101,58 @@ h2 { font-size: 1.1rem; margin-bottom: 8px; color: var(--text-muted); }
 .level-badge[data-level="4"] { background: #ef4444; }
 .level-badge[data-level="5"] { background: #991b1b; }
 
+.heatmap-section { margin-bottom: 16px; }
+.heatmap-container {
+    display: grid;
+    gap: 2px;
+    overflow-x: auto;
+    padding: 4px;
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+}
+.heatmap-row { display: contents; }
+.heatmap-label {
+    font-size: 0.8rem;
+    font-weight: 700;
+    padding: 4px 8px;
+    background: var(--bg);
+    position: sticky;
+    left: 0;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+}
+.heatmap-cell {
+    min-width: 28px;
+    height: 24px;
+    border-radius: 4px;
+    cursor: pointer;
+    background: #e2e8f0;
+    transition: transform 0.1s;
+}
+.heatmap-cell:hover { transform: scale(1.15); }
+.heatmap-cell[data-level="1"] { background: #4ade80; }
+.heatmap-cell[data-level="2"] { background: #facc15; }
+.heatmap-cell[data-level="3"] { background: #fb923c; }
+.heatmap-cell[data-level="4"] { background: #ef4444; }
+.heatmap-cell[data-level="5"] { background: #991b1b; }
+.heatmap-cell[data-level="0"] {
+    background: transparent;
+    border: 1px dashed var(--border);
+    cursor: default;
+}
+.heatmap-cell[data-level="0"]:hover { transform: none; }
+.heatmap-axis {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    padding: 2px 4px;
+    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
 .lot-level {
     display: inline-block;
     width: 2.8em;

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,8 +36,15 @@
     <div id="reason-banner" class="reason-banner" style="display:none"></div>
 
     <div id="loading">Loading positions...</div>
+
+    <section id="level-heatmap-section" class="heatmap-section" style="display:none">
+        <h2>차수 흐름 (Level Heatmap)</h2>
+        <div id="level-heatmap" class="heatmap-container"></div>
+    </section>
+
     <div id="positions-container"></div>
 
+    <script src="js/charts.js"></script>
     <script src="js/main.js"></script>
 </body>
 </html>

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -1,0 +1,200 @@
+// MagicSplit Dashboard - charts.js
+// Level heatmap (per-ticker × time axis) rendered as a CSS grid.
+(function () {
+    'use strict';
+
+    const LEVEL_CAP = 5;
+
+    function monthKey(dateStr) {
+        return typeof dateStr === 'string' ? dateStr.slice(0, 7) : '';
+    }
+
+    function nextMonth(key) {
+        const [y, m] = key.split('-').map(Number);
+        const d = new Date(Date.UTC(y, m - 1, 1));
+        d.setUTCMonth(d.getUTCMonth() + 1);
+        const ny = d.getUTCFullYear();
+        const nm = String(d.getUTCMonth() + 1).padStart(2, '0');
+        return `${ny}-${nm}`;
+    }
+
+    function enumerateMonths(startKey, endKey) {
+        const months = [];
+        let cur = startKey;
+        while (cur <= endKey) {
+            months.push(cur);
+            cur = nextMonth(cur);
+        }
+        return months;
+    }
+
+    // Reconstruct per-month max active level per ticker from history.json.
+    // Walks executions in chronological order, maintaining a Set of open
+    // levels per ticker (BUY adds, SELL removes). For each month bucket,
+    // records the max level observed while open, plus a trade counter.
+    // Months with no trades inherit the previous month's open-level max
+    // (position still held).
+    function buildLevelBuckets(history) {
+        if (!Array.isArray(history) || history.length === 0) {
+            return { months: [], tickers: [], grid: {}, trades: {} };
+        }
+
+        const execs = [];
+        for (const tx of history) {
+            if (!tx || !Array.isArray(tx.executions)) continue;
+            for (const ex of tx.executions) {
+                if (!ex || !ex.ticker || !ex.date || ex.level == null) continue;
+                if (ex.status && ex.status !== 'FILLED') continue;
+                execs.push(ex);
+            }
+        }
+        if (execs.length === 0) {
+            return { months: [], tickers: [], grid: {}, trades: {} };
+        }
+
+        execs.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
+        const activeLevels = {};            // ticker -> Set<level>
+        const observedMax = {};              // ticker -> {month -> maxLevel}
+        const trades = {};                   // ticker -> {month -> count}
+        const tickersSeen = new Set();
+
+        for (const ex of execs) {
+            const t = ex.ticker;
+            tickersSeen.add(t);
+            if (!activeLevels[t]) activeLevels[t] = new Set();
+            if (!observedMax[t]) observedMax[t] = {};
+            if (!trades[t]) trades[t] = {};
+
+            if (ex.action === 'BUY') {
+                activeLevels[t].add(ex.level);
+            } else if (ex.action === 'SELL') {
+                activeLevels[t].delete(ex.level);
+            }
+
+            const mk = monthKey(ex.date);
+            const curMax = activeLevels[t].size > 0 ? Math.max(...activeLevels[t]) : 0;
+            const prev = observedMax[t][mk] || 0;
+            if (curMax > prev) observedMax[t][mk] = curMax;
+            trades[t][mk] = (trades[t][mk] || 0) + 1;
+        }
+
+        const firstMonth = monthKey(execs[0].date);
+        const lastMonth = monthKey(execs[execs.length - 1].date);
+        const months = enumerateMonths(firstMonth, lastMonth);
+
+        // Roll-forward: months without trades inherit prior month's open-level
+        // max. Tracked per ticker by replaying executions month-by-month.
+        const grid = {};
+        for (const t of tickersSeen) {
+            grid[t] = {};
+            const open = new Set();
+            // Pre-index executions by month for this ticker.
+            const byMonth = {};
+            for (const ex of execs) {
+                if (ex.ticker !== t) continue;
+                const mk = monthKey(ex.date);
+                if (!byMonth[mk]) byMonth[mk] = [];
+                byMonth[mk].push(ex);
+            }
+            for (const m of months) {
+                let monthMax = open.size > 0 ? Math.max(...open) : 0;
+                const list = byMonth[m] || [];
+                for (const ex of list) {
+                    if (ex.action === 'BUY') open.add(ex.level);
+                    else if (ex.action === 'SELL') open.delete(ex.level);
+                    const cur = open.size > 0 ? Math.max(...open) : 0;
+                    if (cur > monthMax) monthMax = cur;
+                }
+                grid[t][m] = monthMax;
+            }
+        }
+
+        const tickers = Array.from(tickersSeen).sort();
+        return { months, tickers, grid, trades };
+    }
+
+    function buildAxisRow(months) {
+        const row = document.createElement('div');
+        row.className = 'heatmap-row';
+
+        const corner = document.createElement('div');
+        corner.className = 'heatmap-label heatmap-axis';
+        corner.textContent = '';
+        row.appendChild(corner);
+
+        for (const m of months) {
+            const cell = document.createElement('div');
+            cell.className = 'heatmap-axis';
+            cell.textContent = m.slice(2);  // "25-01"
+            cell.title = m;
+            row.appendChild(cell);
+        }
+        return row;
+    }
+
+    function buildTickerRow(ticker, months, grid, trades) {
+        const row = document.createElement('div');
+        row.className = 'heatmap-row';
+
+        const label = document.createElement('div');
+        label.className = 'heatmap-label';
+        label.textContent = ticker;
+        row.appendChild(label);
+
+        for (const m of months) {
+            const cell = document.createElement('div');
+            cell.className = 'heatmap-cell';
+            const level = (grid[ticker] && grid[ticker][m]) || 0;
+            const count = (trades[ticker] && trades[ticker][m]) || 0;
+            const clamped = Math.min(level, LEVEL_CAP);
+            cell.dataset.level = String(clamped);
+            cell.dataset.ticker = ticker;
+            cell.dataset.month = m;
+            cell.dataset.rawLevel = String(level);
+            const levelLabel = level > 0 ? `Lv${level}` : '보유 없음';
+            const tradeLabel = count > 0 ? ` (거래 ${count}건)` : '';
+            cell.title = `${ticker} | ${m} | ${levelLabel}${tradeLabel}`;
+
+            cell.addEventListener('click', () => {
+                document.dispatchEvent(new CustomEvent('heatmap-select', {
+                    detail: { ticker, month: m, level },
+                }));
+            });
+
+            row.appendChild(cell);
+        }
+        return row;
+    }
+
+    function renderLevelHeatmap(historyData, mode) {
+        const container = document.getElementById('level-heatmap');
+        const section = document.getElementById('level-heatmap-section');
+        if (!container || !section) return;
+
+        container.textContent = '';
+
+        const data = buildLevelBuckets(historyData);
+        if (data.months.length === 0 || data.tickers.length === 0) {
+            section.style.display = 'none';
+            return;
+        }
+
+        const columnCount = data.months.length + 1;  // +1 for ticker label
+        container.style.gridTemplateColumns = `minmax(64px, auto) repeat(${data.months.length}, minmax(28px, 1fr))`;
+
+        container.appendChild(buildAxisRow(data.months));
+        for (const t of data.tickers) {
+            container.appendChild(buildTickerRow(t, data.months, data.grid, data.trades));
+        }
+
+        section.style.display = '';
+        section.dataset.mode = mode || '';
+        container.dataset.columns = String(columnCount);
+    }
+
+    window.MagicSplitCharts = {
+        renderLevelHeatmap,
+        _buildLevelBuckets: buildLevelBuckets,  // exposed for manual debugging
+    };
+})();

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -54,28 +54,20 @@
 
         execs.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
 
-        const activeLevels = {};            // ticker -> Set<level>
-        const observedMax = {};              // ticker -> {month -> maxLevel}
-        const trades = {};                   // ticker -> {month -> count}
+        // Single pass: group executions by ticker/month and count trades per
+        // ticker/month. This replaces an earlier O(T*E) per-ticker re-scan.
+        const execsByTicker = {};   // ticker -> {month -> [execs]}
+        const trades = {};          // ticker -> {month -> count}
         const tickersSeen = new Set();
 
         for (const ex of execs) {
             const t = ex.ticker;
-            tickersSeen.add(t);
-            if (!activeLevels[t]) activeLevels[t] = new Set();
-            if (!observedMax[t]) observedMax[t] = {};
-            if (!trades[t]) trades[t] = {};
-
-            if (ex.action === 'BUY') {
-                activeLevels[t].add(ex.level);
-            } else if (ex.action === 'SELL') {
-                activeLevels[t].delete(ex.level);
-            }
-
             const mk = monthKey(ex.date);
-            const curMax = activeLevels[t].size > 0 ? Math.max(...activeLevels[t]) : 0;
-            const prev = observedMax[t][mk] || 0;
-            if (curMax > prev) observedMax[t][mk] = curMax;
+            tickersSeen.add(t);
+            if (!execsByTicker[t]) execsByTicker[t] = {};
+            if (!execsByTicker[t][mk]) execsByTicker[t][mk] = [];
+            execsByTicker[t][mk].push(ex);
+            if (!trades[t]) trades[t] = {};
             trades[t][mk] = (trades[t][mk] || 0) + 1;
         }
 
@@ -84,19 +76,13 @@
         const months = enumerateMonths(firstMonth, lastMonth);
 
         // Roll-forward: months without trades inherit prior month's open-level
-        // max. Tracked per ticker by replaying executions month-by-month.
+        // max. For each ticker, replay its executions month-by-month tracking
+        // the set of open levels.
         const grid = {};
         for (const t of tickersSeen) {
             grid[t] = {};
             const open = new Set();
-            // Pre-index executions by month for this ticker.
-            const byMonth = {};
-            for (const ex of execs) {
-                if (ex.ticker !== t) continue;
-                const mk = monthKey(ex.date);
-                if (!byMonth[mk]) byMonth[mk] = [];
-                byMonth[mk].push(ex);
-            }
+            const byMonth = execsByTicker[t] || {};
             for (const m of months) {
                 let monthMax = open.size > 0 ? Math.max(...open) : 0;
                 const list = byMonth[m] || [];
@@ -155,13 +141,6 @@
             const levelLabel = level > 0 ? `Lv${level}` : '보유 없음';
             const tradeLabel = count > 0 ? ` (거래 ${count}건)` : '';
             cell.title = `${ticker} | ${m} | ${levelLabel}${tradeLabel}`;
-
-            cell.addEventListener('click', () => {
-                document.dispatchEvent(new CustomEvent('heatmap-select', {
-                    detail: { ticker, month: m, level },
-                }));
-            });
-
             row.appendChild(cell);
         }
         return row;
@@ -188,9 +167,30 @@
             container.appendChild(buildTickerRow(t, data.months, data.grid, data.trades));
         }
 
+        // Single delegated click listener on the container; survives re-renders
+        // because only cells (children) are replaced, not the container itself.
+        if (!container.dataset.listenersBound) {
+            container.addEventListener('click', onCellClick);
+            container.dataset.listenersBound = '1';
+        }
+
         section.style.display = '';
         section.dataset.mode = mode || '';
         container.dataset.columns = String(columnCount);
+    }
+
+    function onCellClick(e) {
+        const cell = e.target.closest('.heatmap-cell');
+        if (!cell) return;
+        const level = parseInt(cell.dataset.rawLevel || '0', 10);
+        if (level === 0) return;
+        document.dispatchEvent(new CustomEvent('heatmap-select', {
+            detail: {
+                ticker: cell.dataset.ticker,
+                month: cell.dataset.month,
+                level,
+            },
+        }));
     }
 
     window.MagicSplitCharts = {

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -36,6 +36,36 @@
         }
     }
 
+    async function loadHistory(mode) {
+        const url = `data/${mode}/history.json?t=${Date.now()}`;
+        try {
+            const res = await fetch(url);
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            return await res.json();
+        } catch (e) {
+            console.error(`Failed to load history (${mode}):`, e);
+            return null;
+        }
+    }
+
+    function hideHeatmap() {
+        const section = document.getElementById('level-heatmap-section');
+        if (section) section.style.display = 'none';
+    }
+
+    async function renderHeatmapForMode(mode) {
+        if (mode !== 'backtest' || !window.MagicSplitCharts) {
+            hideHeatmap();
+            return;
+        }
+        const history = await loadHistory(mode);
+        if (!history) {
+            hideHeatmap();
+            return;
+        }
+        window.MagicSplitCharts.renderLevelHeatmap(history, mode);
+    }
+
     function getRelativeTime(timestamp) {
         if (!timestamp) return '';
         const seconds = Math.floor((Date.now() - timestamp) / 1000);
@@ -248,6 +278,7 @@
             updateRefreshAge();
         }
         initRefreshControls();
+        await renderHeatmapForMode(currentMode);
     }
 
     init();


### PR DESCRIPTION
## Summary
- `history.json`의 BUY/SELL 이력을 월 단위로 재구성하여 종목별 최고 차수를 CSS Grid 히트맵으로 시각화한다.
- 외부 차트 라이브러리를 도입하지 않고 vanilla JS + 기존 `.level-badge` 팔레트를 그대로 재사용한다 (#88과 시각적 일관성).
- 백테스트 모드에서만 섹션을 노출하며, domestic/overseas에서는 자동으로 숨긴다.

## 변경 내역
| 파일 | 내용 |
|------|------|
| `docs/js/charts.js` *(신규)* | `buildLevelBuckets()` + `renderLevelHeatmap()`. 월별 open-level max 재구성, Lv6+는 Lv5 색상으로 clamp, 거래 없는 달은 직전 달 값 상속 |
| `docs/index.html` | `<section id="level-heatmap-section">` + `charts.js` 스크립트 태그 추가 |
| `docs/css/style.css` | `.heatmap-*` 블록 (CSS Grid, sticky label, data-level 색상) |
| `docs/js/main.js` | `loadHistory(mode)` + `renderHeatmapForMode()` 훅, `init()` 끝에서 호출 |

## 알고리즘
실행 이력을 날짜 순으로 순회하며 종목별 `Set<level>` 유지 — BUY는 add, SELL은 remove. 각 달마다 그 시점의 open-level max를 기록하고, 거래가 없는 달은 이전 달 값을 롤 포워드한다.

실제 백테스트 데이터(`docs/data/backtest/history.json`) 기준 검증:
- AAPL: `2 2 3 6 4 4 4 4 3 1` (Jan~Oct 2025, Lv6은 Lv5 색상)
- MSFT: `1 2 3 4 3 1 1 0 1 1` (8월에 0 = 완전 청산, 9월 재진입)

## 의도적 범위 밖
- **#94 cross-chart 연동 실동작**: 셀 클릭 시 `heatmap-select` CustomEvent만 dispatch. 리스너는 #94 작업 시 연결.
- **미실현 손익 툴팁**: `executions`에 미실현 PnL 필드가 없어 정확 재구성이 어려움 → 1차는 `ticker | YYYY-MM | Lv{N} | 거래 K건`만 노출.

## Test plan
- [x] `pytest --cov=src --cov-fail-under=80 tests/` → 202 passed, 92.53% coverage
- [x] `node` 스크립트로 `buildLevelBuckets()`를 실제 history.json에 실행 → 월×티커 그리드가 기대대로 생성됨
- [ ] `cd docs && python3 -m http.server 8000` 후 브라우저에서:
  - [ ] `?mode=backtest` — 히트맵 섹션 표시, AAPL/MSFT 행 렌더
  - [ ] 셀 hover 툴팁 (ticker | YYYY-MM | Lv | 거래수)
  - [ ] `?mode=domestic`, `?mode=overseas` — 히트맵 숨김
  - [ ] 모바일 뷰 (375px) — 가로 스크롤, ticker 라벨 sticky

Refs #96
Related: #88 (level 색상 팔레트 재사용), #94 (history.json 활용 예정)

https://claude.ai/code/session_015HwR2fdFou2DvGhAp2UmCx

---
_Generated by [Claude Code](https://claude.ai/code/session_015HwR2fdFou2DvGhAp2UmCx)_