### PR TITLE
feat(ui): 거래 내역 탭 추가 — history.json 기반 매매 기록 표시 (#94)

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -278,3 +278,110 @@ h2 { font-size: 1.1rem; margin-bottom: 8px; color: var(--text-muted); }
     font-weight: 600;
     white-space: nowrap;
 }
+
+/* View switch (Positions / History) */
+.view-switch {
+    display: inline-flex;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    width: 100%;
+    margin-bottom: 12px;
+}
+.view-link {
+    flex: 1;
+    padding: 8px;
+    font-size: 0.85rem;
+    background: var(--card-bg);
+    border: none;
+    cursor: pointer;
+    color: var(--text-muted);
+    font-weight: 500;
+}
+.view-link + .view-link { border-left: 1px solid var(--border); }
+.view-link.active {
+    background: var(--primary);
+    color: white;
+    font-weight: 600;
+}
+
+/* History table */
+.history-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.85rem;
+}
+.history-table th {
+    text-align: left;
+    padding: 8px 10px;
+    border-bottom: 2px solid var(--border);
+    color: var(--text-muted);
+    font-size: 0.78rem;
+    white-space: nowrap;
+    background: var(--bg);
+}
+.history-row td {
+    padding: 7px 10px;
+    border-bottom: 1px solid var(--border);
+    vertical-align: middle;
+    white-space: nowrap;
+}
+.history-row:last-child td { border-bottom: none; }
+.history-row.buy { background: #fff5f5; }
+.history-row.sell { background: #f0fdf4; }
+.history-action { font-weight: 700; font-size: 0.82rem; }
+.history-action.buy { color: var(--danger); }
+.history-action.sell { color: var(--success); }
+
+/* Filter bar */
+.filter-bar {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+    margin-bottom: 10px;
+}
+.filter-select {
+    font-size: 0.82rem;
+    padding: 4px 8px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--card-bg);
+    color: var(--text);
+}
+.filter-chips {
+    display: inline-flex;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    overflow: hidden;
+}
+.filter-chip {
+    padding: 4px 12px;
+    font-size: 0.8rem;
+    background: var(--card-bg);
+    border: none;
+    cursor: pointer;
+    color: var(--text-muted);
+}
+.filter-chip + .filter-chip { border-left: 1px solid var(--border); }
+.filter-chip.active {
+    background: var(--primary);
+    color: white;
+    font-weight: 600;
+}
+
+/* Load more button */
+.load-more-btn {
+    display: block;
+    width: 100%;
+    padding: 10px;
+    margin-top: 10px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--card-bg);
+    cursor: pointer;
+    color: var(--primary);
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+.load-more-btn:hover { background: #eff6ff; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,6 +33,11 @@
         </span>
     </div>
 
+    <nav class="view-switch" id="view-switch">
+        <button class="view-link active" data-view="positions">Positions</button>
+        <button class="view-link" data-view="history">History</button>
+    </nav>
+
     <div id="reason-banner" class="reason-banner" style="display:none"></div>
 
     <div id="loading">Loading positions...</div>
@@ -44,7 +49,14 @@
 
     <div id="positions-container"></div>
 
+    <div id="history-section" style="display:none">
+        <div id="history-filters" class="filter-bar"></div>
+        <div id="history-list"></div>
+        <button id="load-more-btn" class="load-more-btn" style="display:none">더 보기</button>
+    </div>
+
     <script src="js/charts.js"></script>
+    <script src="js/history.js"></script>
     <script src="js/main.js"></script>
 </body>
 </html>

--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -1,0 +1,183 @@
+// MagicSplit Dashboard - history.js
+window.MagicSplitHistory = (function () {
+    'use strict';
+
+    const PAGE_SIZE = 30;
+
+    let allRows = [];
+    let filteredRows = [];
+    let visibleCount = 0;
+    let currentMode = 'domestic';
+    let formatCurrencyFn = null;
+    let activeFilters = { ticker: '', action: '' };
+
+    function buildRows(historyData) {
+        const rows = [];
+        if (!Array.isArray(historyData)) return rows;
+
+        for (const tx of historyData) {
+            const txDate = tx.date || '';
+            const txReason = tx.reason || '';
+            const executions = Array.isArray(tx.executions) ? tx.executions : [];
+            for (const ex of executions) {
+                rows.push({
+                    date: ex.date || txDate,
+                    ticker: ex.ticker || '',
+                    action: (ex.action || '').toUpperCase(),
+                    level: ex.level != null ? ex.level : '',
+                    quantity: ex.quantity || 0,
+                    price: ex.price || 0,
+                    fee: ex.fee || 0,
+                    amount: (ex.quantity || 0) * (ex.price || 0),
+                    txReason: txReason,
+                });
+            }
+        }
+
+        rows.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+        return rows;
+    }
+
+    function getUniqueTickers(rows) {
+        const set = new Set(rows.map((r) => r.ticker).filter(Boolean));
+        return Array.from(set).sort();
+    }
+
+    function renderFilters(tickers) {
+        const container = document.getElementById('history-filters');
+        if (!container) return;
+
+        const tickerOptions = ['<option value="">전체 종목</option>']
+            .concat(tickers.map((t) => `<option value="${t}">${t}</option>`))
+            .join('');
+
+        container.innerHTML = `
+            <select id="history-ticker-filter" class="filter-select">
+                ${tickerOptions}
+            </select>
+            <div class="filter-chips" role="group" aria-label="액션 필터">
+                <button class="filter-chip active" data-action="">전체</button>
+                <button class="filter-chip" data-action="BUY">BUY</button>
+                <button class="filter-chip" data-action="SELL">SELL</button>
+            </div>
+        `;
+
+        const tickerSelect = container.querySelector('#history-ticker-filter');
+        tickerSelect.addEventListener('change', () => {
+            activeFilters.ticker = tickerSelect.value;
+            applyFilters();
+        });
+
+        container.querySelectorAll('.filter-chip').forEach((btn) => {
+            btn.addEventListener('click', () => {
+                container.querySelectorAll('.filter-chip').forEach((b) => b.classList.remove('active'));
+                btn.classList.add('active');
+                activeFilters.action = btn.dataset.action;
+                applyFilters();
+            });
+        });
+    }
+
+    function applyFilters() {
+        filteredRows = allRows.filter((row) => {
+            if (activeFilters.ticker && row.ticker !== activeFilters.ticker) return false;
+            if (activeFilters.action && row.action !== activeFilters.action) return false;
+            return true;
+        });
+        visibleCount = 0;
+        renderPage();
+    }
+
+    function formatAmount(value) {
+        if (formatCurrencyFn) return formatCurrencyFn(value, currentMode);
+        return value.toFixed(2);
+    }
+
+    function renderPage() {
+        const listEl = document.getElementById('history-list');
+        const moreBtn = document.getElementById('load-more-btn');
+        if (!listEl) return;
+
+        if (filteredRows.length === 0) {
+            listEl.innerHTML = '<div class="card" style="text-align:center;color:var(--text-muted)">거래 내역이 없습니다.</div>';
+            if (moreBtn) moreBtn.style.display = 'none';
+            return;
+        }
+
+        const nextCount = visibleCount + PAGE_SIZE;
+        const pageRows = filteredRows.slice(0, nextCount);
+        visibleCount = nextCount;
+
+        const rowsHtml = pageRows.map((row) => {
+            const actionClass = row.action === 'SELL' ? 'sell' : 'buy';
+            const lvDisplay = row.level !== '' ? `<span class="level-badge" data-level="${Math.min(row.level, 5)}">Lv${row.level}</span>` : '-';
+            return `
+                <tr class="history-row ${actionClass}" title="${escapeHtml(row.txReason)}">
+                    <td>${escapeHtml(row.date)}</td>
+                    <td><strong>${escapeHtml(row.ticker)}</strong></td>
+                    <td><span class="history-action ${actionClass}">${escapeHtml(row.action)}</span></td>
+                    <td>${lvDisplay}</td>
+                    <td>${row.quantity}</td>
+                    <td>${formatAmount(row.price)}</td>
+                    <td>${formatAmount(row.fee)}</td>
+                    <td>${formatAmount(row.amount)}</td>
+                </tr>`;
+        }).join('');
+
+        listEl.innerHTML = `
+            <div class="card" style="padding:0;overflow:hidden">
+                <table class="history-table">
+                    <thead>
+                        <tr>
+                            <th>날짜</th>
+                            <th>종목</th>
+                            <th>구분</th>
+                            <th>차수</th>
+                            <th>수량</th>
+                            <th>가격</th>
+                            <th>수수료</th>
+                            <th>금액</th>
+                        </tr>
+                    </thead>
+                    <tbody>${rowsHtml}</tbody>
+                </table>
+            </div>`;
+
+        if (moreBtn) {
+            moreBtn.style.display = visibleCount < filteredRows.length ? '' : 'none';
+        }
+    }
+
+    function loadMore() {
+        renderPage();
+    }
+
+    function escapeHtml(str) {
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    function renderHistory(historyData, mode, formatFn) {
+        currentMode = mode || 'domestic';
+        formatCurrencyFn = formatFn || null;
+        activeFilters = { ticker: '', action: '' };
+
+        allRows = buildRows(historyData);
+        filteredRows = allRows.slice();
+        visibleCount = 0;
+
+        const tickers = getUniqueTickers(allRows);
+        renderFilters(tickers);
+        renderPage();
+
+        const moreBtn = document.getElementById('load-more-btn');
+        if (moreBtn) {
+            moreBtn.onclick = loadMore;
+        }
+    }
+
+    return { renderHistory };
+})();

--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -48,7 +48,7 @@ window.MagicSplitHistory = (function () {
         if (!container) return;
 
         const tickerOptions = ['<option value="">전체 종목</option>']
-            .concat(tickers.map((t) => `<option value="${t}">${t}</option>`))
+            .concat(tickers.map((t) => `<option value="${escapeHtml(t)}">${escapeHtml(t)}</option>`))
             .join('');
 
         container.innerHTML = `
@@ -93,6 +93,24 @@ window.MagicSplitHistory = (function () {
         return value.toFixed(2);
     }
 
+    function buildRowHtml(row) {
+        const actionClass = row.action === 'SELL' ? 'sell' : 'buy';
+        const lvDisplay = row.level !== ''
+            ? `<span class="level-badge" data-level="${Math.min(Number(row.level), 5)}">Lv${escapeHtml(row.level)}</span>`
+            : '-';
+        return `
+            <tr class="history-row ${actionClass}" title="${escapeHtml(row.txReason)}">
+                <td>${escapeHtml(row.date)}</td>
+                <td><strong>${escapeHtml(row.ticker)}</strong></td>
+                <td><span class="history-action ${actionClass}">${escapeHtml(row.action)}</span></td>
+                <td>${lvDisplay}</td>
+                <td>${escapeHtml(row.quantity)}</td>
+                <td>${formatAmount(row.price)}</td>
+                <td>${formatAmount(row.fee)}</td>
+                <td>${formatAmount(row.amount)}</td>
+            </tr>`;
+    }
+
     function renderPage() {
         const listEl = document.getElementById('history-list');
         const moreBtn = document.getElementById('load-more-btn');
@@ -104,44 +122,35 @@ window.MagicSplitHistory = (function () {
             return;
         }
 
-        const nextCount = visibleCount + PAGE_SIZE;
-        const pageRows = filteredRows.slice(0, nextCount);
-        visibleCount = nextCount;
+        const newRows = filteredRows.slice(visibleCount, visibleCount + PAGE_SIZE);
+        visibleCount += newRows.length;
 
-        const rowsHtml = pageRows.map((row) => {
-            const actionClass = row.action === 'SELL' ? 'sell' : 'buy';
-            const lvDisplay = row.level !== '' ? `<span class="level-badge" data-level="${Math.min(row.level, 5)}">Lv${row.level}</span>` : '-';
-            return `
-                <tr class="history-row ${actionClass}" title="${escapeHtml(row.txReason)}">
-                    <td>${escapeHtml(row.date)}</td>
-                    <td><strong>${escapeHtml(row.ticker)}</strong></td>
-                    <td><span class="history-action ${actionClass}">${escapeHtml(row.action)}</span></td>
-                    <td>${lvDisplay}</td>
-                    <td>${row.quantity}</td>
-                    <td>${formatAmount(row.price)}</td>
-                    <td>${formatAmount(row.fee)}</td>
-                    <td>${formatAmount(row.amount)}</td>
-                </tr>`;
-        }).join('');
+        if (visibleCount <= PAGE_SIZE) {
+            // First render: build full table structure
+            listEl.innerHTML = `
+                <div class="card" style="padding:0;overflow:hidden">
+                    <table class="history-table">
+                        <thead>
+                            <tr>
+                                <th>날짜</th>
+                                <th>종목</th>
+                                <th>구분</th>
+                                <th>차수</th>
+                                <th>수량</th>
+                                <th>가격</th>
+                                <th>수수료</th>
+                                <th>금액</th>
+                            </tr>
+                        </thead>
+                        <tbody id="history-tbody"></tbody>
+                    </table>
+                </div>`;
+        }
 
-        listEl.innerHTML = `
-            <div class="card" style="padding:0;overflow:hidden">
-                <table class="history-table">
-                    <thead>
-                        <tr>
-                            <th>날짜</th>
-                            <th>종목</th>
-                            <th>구분</th>
-                            <th>차수</th>
-                            <th>수량</th>
-                            <th>가격</th>
-                            <th>수수료</th>
-                            <th>금액</th>
-                        </tr>
-                    </thead>
-                    <tbody>${rowsHtml}</tbody>
-                </table>
-            </div>`;
+        const tbody = document.getElementById('history-tbody');
+        if (tbody) {
+            tbody.insertAdjacentHTML('beforeend', newRows.map(buildRowHtml).join(''));
+        }
 
         if (moreBtn) {
             moreBtn.style.display = visibleCount < filteredRows.length ? '' : 'none';
@@ -157,7 +166,8 @@ window.MagicSplitHistory = (function () {
             .replace(/&/g, '&amp;')
             .replace(/</g, '&lt;')
             .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;');
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
     }
 
     function renderHistory(historyData, mode, formatFn) {

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -6,6 +6,8 @@
     const DEFAULT_MODE = 'domestic';
 
     let currentMode = DEFAULT_MODE;
+    let currentView = 'positions';
+    let historyLoaded = false;
     let isRefreshing = false;
     let lastRefreshTime = null;
     let refreshTimer = null;
@@ -244,6 +246,47 @@
         }
     }
 
+    function showView(view) {
+        currentView = view;
+        const posEls = ['positions-container', 'level-heatmap-section', 'reason-banner'];
+        const histEls = ['history-section'];
+
+        const isPositions = view === 'positions';
+        posEls.forEach((id) => {
+            const el = document.getElementById(id);
+            if (el) el.style.display = isPositions ? '' : 'none';
+        });
+        histEls.forEach((id) => {
+            const el = document.getElementById(id);
+            if (el) el.style.display = isPositions ? 'none' : '';
+        });
+
+        document.querySelectorAll('.view-link').forEach((btn) => {
+            btn.classList.toggle('active', btn.dataset.view === view);
+        });
+    }
+
+    async function loadHistoryView(mode) {
+        if (!window.MagicSplitHistory) return;
+        if (!historyLoaded) {
+            const data = await loadHistory(mode);
+            window.MagicSplitHistory.renderHistory(data || [], mode, formatCurrency);
+            historyLoaded = true;
+        }
+    }
+
+    function initViewSwitch() {
+        document.querySelectorAll('.view-link').forEach((btn) => {
+            btn.addEventListener('click', async () => {
+                const view = btn.dataset.view;
+                showView(view);
+                if (view === 'history') {
+                    await loadHistoryView(currentMode);
+                }
+            });
+        });
+    }
+
     function initRefreshControls() {
         const refreshBtn = document.getElementById('refresh-btn');
         if (refreshBtn) {
@@ -270,6 +313,7 @@
 
     async function init() {
         currentMode = resolveMode();
+        historyLoaded = false;
         applyModeUI(currentMode);
         const data = await loadStatus(currentMode);
         renderStatus(data, currentMode);
@@ -278,6 +322,7 @@
             updateRefreshAge();
         }
         initRefreshControls();
+        initViewSwitch();
         await renderHeatmapForMode(currentMode);
     }
 


### PR DESCRIPTION
## Summary

- **Positions ↔ History 뷰 전환 탭** 추가 (`docs/index.html`)
- `docs/js/history.js` 신규 모듈 (`window.MagicSplitHistory`) — `charts.js` 패턴 동일
- `history.json` executions를 역순 정렬 테이블로 렌더링, 종목/BUY·SELL 필터, 30건 페이지네이션
- 스타일 추가 (`docs/css/style.css`): 뷰 탭, 히스토리 테이블, 필터 바, 더 보기 버튼

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `docs/index.html` | 뷰 전환 nav + `#history-section` HTML 추가, `history.js` script 태그 추가 |
| `docs/js/history.js` | 신규 — `buildRows`, `renderFilters`, `applyFilters`, `renderPage`, `loadMore`, `renderHistory` |
| `docs/js/main.js` | `showView()`, `loadHistoryView()`, `initViewSwitch()` 추가 및 `init()` 연결 |
| `docs/css/style.css` | `.view-switch`, `.history-table`, `.history-row`, `.filter-bar`, `.load-more-btn` 스타일 추가 |

## 수용 기준 체크

- [x] 뷰 전환 UI (Positions ↔ History)
- [x] history.json fetch 및 역순 정렬
- [x] 각 execution을 한 행으로 표시 (Date / Ticker / Action / Lv / Qty / Price / Fee / Amount)
- [x] 종목 필터 (select) + 액션 필터 (BUY/SELL/전체 칩)
- [x] 30건씩 페이지네이션 ("더 보기" 버튼)

Closes #94

https://claude.ai/code/session_01Wa3KtogwgmctLG1TLoQtEd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wa3KtogwgmctLG1TLoQtEd)_