### PR TITLE
feat(history): SELL 기록에 매수가·수익금·수익률 컬럼 추가

### DIFF
--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -24,8 +24,8 @@ window.MagicSplitHistory = (function () {
                 const price = ex.price || 0;
                 const buyPrice = ex.buy_price != null ? ex.buy_price : null;
                 const realizedPnl = ex.realized_pnl != null ? ex.realized_pnl : null;
-                const profitRate = (action === 'SELL' && buyPrice != null && buyPrice > 0)
-                    ? ((price - buyPrice) / buyPrice) * 100
+                const profitRate = (action === 'SELL' && buyPrice != null && buyPrice > 0 && realizedPnl != null && (ex.quantity || 0) > 0)
+                    ? (realizedPnl / (buyPrice * ex.quantity)) * 100
                     : null;
                 rows.push({
                     date: ex.date || txDate,
@@ -116,13 +116,13 @@ window.MagicSplitHistory = (function () {
             buyPriceCell = formatAmount(row.buyPrice);
         }
         if (row.action === 'SELL' && row.realizedPnl != null) {
-            const sign = row.realizedPnl >= 0 ? '+' : '';
-            const cls = row.realizedPnl >= 0 ? 'pct-positive' : 'pct-negative';
+            const sign = row.realizedPnl > 0 ? '+' : '';
+            const cls = row.realizedPnl > 0 ? 'pct-positive' : (row.realizedPnl < 0 ? 'pct-negative' : '');
             pnlCell = `<span class="${cls}">${sign}${formatAmount(row.realizedPnl)}</span>`;
         }
         if (row.action === 'SELL' && row.profitRate != null) {
-            const sign = row.profitRate >= 0 ? '+' : '';
-            const cls = row.profitRate >= 0 ? 'pct-positive' : 'pct-negative';
+            const sign = row.profitRate > 0 ? '+' : '';
+            const cls = row.profitRate > 0 ? 'pct-positive' : (row.profitRate < 0 ? 'pct-negative' : '');
             rateCell = `<span class="${cls}">${sign}${row.profitRate.toFixed(2)}%</span>`;
         }
 

--- a/docs/js/history.js
+++ b/docs/js/history.js
@@ -20,15 +20,25 @@ window.MagicSplitHistory = (function () {
             const txReason = tx.reason || '';
             const executions = Array.isArray(tx.executions) ? tx.executions : [];
             for (const ex of executions) {
+                const action = (ex.action || '').toUpperCase();
+                const price = ex.price || 0;
+                const buyPrice = ex.buy_price != null ? ex.buy_price : null;
+                const realizedPnl = ex.realized_pnl != null ? ex.realized_pnl : null;
+                const profitRate = (action === 'SELL' && buyPrice != null && buyPrice > 0)
+                    ? ((price - buyPrice) / buyPrice) * 100
+                    : null;
                 rows.push({
                     date: ex.date || txDate,
                     ticker: ex.ticker || '',
-                    action: (ex.action || '').toUpperCase(),
+                    action,
                     level: ex.level != null ? ex.level : '',
                     quantity: ex.quantity || 0,
-                    price: ex.price || 0,
+                    price,
                     fee: ex.fee || 0,
-                    amount: (ex.quantity || 0) * (ex.price || 0),
+                    amount: (ex.quantity || 0) * price,
+                    buyPrice,
+                    realizedPnl,
+                    profitRate,
                     txReason: txReason,
                 });
             }
@@ -98,6 +108,24 @@ window.MagicSplitHistory = (function () {
         const lvDisplay = row.level !== ''
             ? `<span class="level-badge" data-level="${Math.min(Number(row.level), 5)}">Lv${escapeHtml(row.level)}</span>`
             : '-';
+
+        let buyPriceCell = '-';
+        let pnlCell = '-';
+        let rateCell = '-';
+        if (row.action === 'SELL' && row.buyPrice != null) {
+            buyPriceCell = formatAmount(row.buyPrice);
+        }
+        if (row.action === 'SELL' && row.realizedPnl != null) {
+            const sign = row.realizedPnl >= 0 ? '+' : '';
+            const cls = row.realizedPnl >= 0 ? 'pct-positive' : 'pct-negative';
+            pnlCell = `<span class="${cls}">${sign}${formatAmount(row.realizedPnl)}</span>`;
+        }
+        if (row.action === 'SELL' && row.profitRate != null) {
+            const sign = row.profitRate >= 0 ? '+' : '';
+            const cls = row.profitRate >= 0 ? 'pct-positive' : 'pct-negative';
+            rateCell = `<span class="${cls}">${sign}${row.profitRate.toFixed(2)}%</span>`;
+        }
+
         return `
             <tr class="history-row ${actionClass}" title="${escapeHtml(row.txReason)}">
                 <td>${escapeHtml(row.date)}</td>
@@ -106,8 +134,11 @@ window.MagicSplitHistory = (function () {
                 <td>${lvDisplay}</td>
                 <td>${escapeHtml(row.quantity)}</td>
                 <td>${formatAmount(row.price)}</td>
+                <td>${buyPriceCell}</td>
                 <td>${formatAmount(row.fee)}</td>
                 <td>${formatAmount(row.amount)}</td>
+                <td>${pnlCell}</td>
+                <td>${rateCell}</td>
             </tr>`;
     }
 
@@ -138,8 +169,11 @@ window.MagicSplitHistory = (function () {
                                 <th>차수</th>
                                 <th>수량</th>
                                 <th>가격</th>
+                                <th>매수가</th>
                                 <th>수수료</th>
                                 <th>금액</th>
+                                <th>수익금</th>
+                                <th>수익률</th>
                             </tr>
                         </thead>
                         <tbody id="history-tbody"></tbody>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- 거래내역 탭의 테이블에 **매수가**, **수익금**, **수익률** 3개 컬럼 추가
- `history.json` SELL execution에 이미 저장된 `buy_price`, `realized_pnl` 필드를 읽어 표시
- 수익률은 `(매도가 - 매수가) / 매수가 × 100` 으로 계산
- SELL 행에만 값 표시, BUY 행은 `-` 표시
- 수익 양수 시 초록색(`pct-positive`), 음수 시 빨간색(`pct-negative`) 강조

## Test plan

- [ ] 거래내역 탭 진입 → SELL 행에 매수가·수익금·수익률 표시 확인
- [ ] BUY 행은 매수가·수익금·수익률 모두 `-` 표시 확인
- [ ] 수익금/수익률 양수 → 초록, 음수 → 빨간 색상 확인
- [ ] 종목 필터 / BUY-SELL 필터 전환 후 컬럼 정상 표시 확인

https://claude.ai/code/session_016Cz5aaDviz1rUjMmMZtdnL
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016Cz5aaDviz1rUjMmMZtdnL)_