### PR TITLE
feat(heatmap): 차수흐름 셀에 레벨 숫자 표시

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -133,14 +133,14 @@ h2 { font-size: 1.1rem; margin-bottom: 8px; color: var(--text-muted); }
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 0.65rem;
+    font-size: 0.75rem;
     font-weight: 700;
 }
 .heatmap-cell:hover { transform: scale(1.15); }
 .heatmap-cell[data-level="1"] { background: #4ade80; color: #14532d; }
 .heatmap-cell[data-level="2"] { background: #facc15; color: #713f12; }
 .heatmap-cell[data-level="3"] { background: #fb923c; color: #431407; }
-.heatmap-cell[data-level="4"] { background: #ef4444; color: #fff; }
+.heatmap-cell[data-level="4"] { background: #dc2626; color: #fff; }
 .heatmap-cell[data-level="5"] { background: #991b1b; color: #fff; }
 .heatmap-cell[data-level="0"] {
     background: transparent;

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -130,13 +130,18 @@ h2 { font-size: 1.1rem; margin-bottom: 8px; color: var(--text-muted); }
     cursor: pointer;
     background: #e2e8f0;
     transition: transform 0.1s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.65rem;
+    font-weight: 700;
 }
 .heatmap-cell:hover { transform: scale(1.15); }
-.heatmap-cell[data-level="1"] { background: #4ade80; }
-.heatmap-cell[data-level="2"] { background: #facc15; }
-.heatmap-cell[data-level="3"] { background: #fb923c; }
-.heatmap-cell[data-level="4"] { background: #ef4444; }
-.heatmap-cell[data-level="5"] { background: #991b1b; }
+.heatmap-cell[data-level="1"] { background: #4ade80; color: #14532d; }
+.heatmap-cell[data-level="2"] { background: #facc15; color: #713f12; }
+.heatmap-cell[data-level="3"] { background: #fb923c; color: #431407; }
+.heatmap-cell[data-level="4"] { background: #ef4444; color: #fff; }
+.heatmap-cell[data-level="5"] { background: #991b1b; color: #fff; }
 .heatmap-cell[data-level="0"] {
     background: transparent;
     border: 1px dashed var(--border);

--- a/docs/js/charts.js
+++ b/docs/js/charts.js
@@ -141,6 +141,7 @@
             const levelLabel = level > 0 ? `Lv${level}` : '보유 없음';
             const tradeLabel = count > 0 ? ` (거래 ${count}건)` : '';
             cell.title = `${ticker} | ${m} | ${levelLabel}${tradeLabel}`;
+            if (level > 0) cell.textContent = String(level);
             row.appendChild(cell);
         }
         return row;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- 차수흐름(Level Heatmap) 각 셀에 레벨 숫자(1~N)를 함께 표시
- 색상만으로는 직관적으로 알기 어려운 문제 해결
- 레벨 5 초과 시 실제 레벨 숫자 표시 (색상은 5단계로 캡)
- 레벨별 텍스트 색상 대비 적용 (1~3: 어두운 텍스트, 4~5: 흰 텍스트)

## Test plan

- [ ] 차수흐름 셀에 숫자가 정상 표시되는지 확인
- [ ] 레벨 0(보유 없음) 셀은 숫자 없이 빈 상태인지 확인
- [ ] 레벨별 텍스트 가독성 확인 (배경색 대비)
- [ ] hover 시 scale 애니메이션이 정상 동작하는지 확인

https://claude.ai/code/session_01FzoxATntck6KASL5QZdkQV
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzoxATntck6KASL5QZdkQV)_