### PR TITLE
feat(ui): 실현손익(realized_pnl) 및 포트폴리오 총손익 표시 (#90)

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -424,3 +424,31 @@ h2 { font-size: 1.1rem; margin-bottom: 8px; color: var(--text-muted); }
     font-size: 0.9rem;
 }
 .load-more-btn:hover { background: #eff6ff; }
+
+.portfolio-summary-title {
+    font-weight: 700;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin-bottom: 6px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.portfolio-summary-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px 8px;
+    font-size: 0.88rem;
+}
+
+.card-realized-pnl {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px 8px;
+    font-size: 0.88rem;
+    padding: 6px 0;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 6px;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MagicSplit Dashboard</title>
-    <link rel="stylesheet" href="css/style.css?v=20250425">
+    <link rel="stylesheet" href="css/style.css?v=20260425-1">
 </head>
 <body>
     <header class="page-header">
@@ -61,6 +61,6 @@
 
     <script src="js/charts.js?v=20250425"></script>
     <script src="js/history.js?v=20260425-1"></script>
-    <script src="js/main.js?v=20250425"></script>
+    <script src="js/main.js?v=20260425-1"></script>
 </body>
 </html>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -197,6 +197,31 @@
             return;
         }
 
+        let totalRealizedPnl = 0;
+        let totalUnrealizedPnl = 0;
+        for (const info of Object.values(positions)) {
+            if (info.realized_pnl != null) totalRealizedPnl += Number(info.realized_pnl);
+            if (info.unrealized_pnl != null) totalUnrealizedPnl += Number(info.unrealized_pnl);
+        }
+
+        const portRSign = totalRealizedPnl >= 0 ? '+' : '';
+        const portRClass = totalRealizedPnl >= 0 ? 'pct-positive' : 'pct-negative';
+        const portUSign = totalUnrealizedPnl >= 0 ? '+' : '';
+        const portUClass = totalUnrealizedPnl >= 0 ? 'pct-positive' : 'pct-negative';
+        const portfolioCard = document.createElement('div');
+        portfolioCard.className = 'card portfolio-summary';
+        portfolioCard.innerHTML = `
+            <div class="portfolio-summary-title">Portfolio</div>
+            <div class="portfolio-summary-row">
+                <span class="summary-label">총 실현손익:</span>
+                <span class="${portRClass}">${portRSign}${formatCurrency(totalRealizedPnl, mode)}</span>
+                <span class="summary-sep">|</span>
+                <span class="summary-label">총 평가손익:</span>
+                <span class="${portUClass}">${portUSign}${formatCurrency(totalUnrealizedPnl, mode)}</span>
+            </div>
+        `;
+        container.appendChild(portfolioCard);
+
         for (const [ticker, info] of Object.entries(positions)) {
             const card = document.createElement('div');
             card.className = 'card';
@@ -234,12 +259,36 @@
                     <span class="${pnlClass}">${pnlSign}${formatCurrency(info.unrealized_pnl, mode)} (${pnlSign}${Number(info.unrealized_pnl_pct).toFixed(2)}%)</span>
                 </div>` : '';
 
+            let realizedHtml = '';
+            if (info.realized_pnl != null) {
+                const rPnl = Number(info.realized_pnl);
+                const rClass = rPnl >= 0 ? 'pct-positive' : 'pct-negative';
+                const rSign = rPnl >= 0 ? '+' : '';
+                let totalPnlHtml = '';
+                if (info.total_pnl != null) {
+                    const tPnl = Number(info.total_pnl);
+                    const tClass = tPnl >= 0 ? 'pct-positive' : 'pct-negative';
+                    const tSign = tPnl >= 0 ? '+' : '';
+                    totalPnlHtml = `
+                        <span class="summary-sep">|</span>
+                        <span class="summary-label">총손익:</span>
+                        <span class="${tClass}">${tSign}${formatCurrency(tPnl, mode)}</span>`;
+                }
+                realizedHtml = `
+                    <div class="card-realized-pnl">
+                        <span class="summary-label">실현손익:</span>
+                        <span class="${rClass}">${rSign}${formatCurrency(rPnl, mode)}</span>
+                        ${totalPnlHtml}
+                    </div>`;
+            }
+
             card.innerHTML = `
                 <div class="card-header">
                     <span class="ticker">${ticker} ${levelBadge}</span>
                     <span class="price">${info.total_qty} shares | ${info.lot_count} lots</span>
                 </div>
                 ${summaryHtml}
+                ${realizedHtml}
                 <ul class="lot-list">${lotsHtml}</ul>
             `;
             container.appendChild(card);


### PR DESCRIPTION
## Summary
- 종목 카드에 `realized_pnl`(실현손익), `total_pnl`(총손익) 행 추가
- positions 목록 상단에 포트폴리오 전체 합계 카드 추가 (총 실현손익, 총 평가손익)
- 색상 규칙: `>= 0` 초록, `< 0` 빨강 / `realized_pnl = 0`도 `+$0.00` 형식으로 표시

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `docs/js/main.js` | `renderStatus()`에 포트폴리오 합계 카드 + 종목별 실현손익 행 추가 |
| `docs/css/style.css` | `.portfolio-summary-title`, `.portfolio-summary-row`, `.card-realized-pnl` 스타일 추가 |
| `docs/index.html` | `?v=` 버전 파라미터 `20260425-1`로 업데이트 (캐시 무효화) |

## Test plan
- [ ] `status.json`에 `realized_pnl` 필드가 있는 종목: 카드에 실현손익 행이 표시되는지 확인
- [ ] `realized_pnl = 0`인 종목: `+$0.00` 형식으로 표시되는지 확인
- [ ] `realized_pnl`이 없는 종목: 해당 행이 표시되지 않는지 확인
- [ ] 포트폴리오 요약 카드: 모든 종목 합계가 상단에 정확히 표시되는지 확인
- [ ] 기존 202개 테스트 통과 / 커버리지 93%

Closes #90

https://claude.ai/code/session_01C7f8U8r71FZxJXtSMpNNeX

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7f8U8r71FZxJXtSMpNNeX)_