### PR TITLE
[UI] 포트폴리오 요약 카드에 예수금·주식평가·손익% 추가 (#92)

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -442,6 +442,37 @@ h2 { font-size: 1.1rem; margin-bottom: 8px; color: var(--text-muted); }
     font-size: 0.88rem;
 }
 
+.ps-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.ps-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.88rem;
+}
+
+.ps-label {
+    color: var(--text-muted);
+    font-weight: 600;
+    width: 5em;
+    flex-shrink: 0;
+}
+
+.ps-value {
+    font-weight: 600;
+    min-width: 8em;
+    text-align: right;
+}
+
+.ps-pct {
+    font-size: 0.82rem;
+    color: var(--text-muted);
+}
+
 .card-realized-pnl {
     display: flex;
     flex-wrap: wrap;

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -473,6 +473,9 @@ h2 { font-size: 1.1rem; margin-bottom: 8px; color: var(--text-muted); }
     color: var(--text-muted);
 }
 
+.ps-pct.pct-positive { color: var(--success); }
+.ps-pct.pct-negative { color: var(--danger); }
+
 .card-realized-pnl {
     display: flex;
     flex-wrap: wrap;

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MagicSplit Dashboard</title>
-    <link rel="stylesheet" href="css/style.css?v=20260425-1">
+    <link rel="stylesheet" href="css/style.css?v=20260425-2">
 </head>
 <body>
     <header class="page-header">
@@ -61,6 +61,6 @@
 
     <script src="js/charts.js?v=20250425"></script>
     <script src="js/history.js?v=20260425-1"></script>
-    <script src="js/main.js?v=20260425-1"></script>
+    <script src="js/main.js?v=20260425-2"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MagicSplit Dashboard</title>
-    <link rel="stylesheet" href="css/style.css?v=20260425-2">
+    <link rel="stylesheet" href="css/style.css?v=20260425-3">
 </head>
 <body>
     <header class="page-header">
@@ -61,6 +61,6 @@
 
     <script src="js/charts.js?v=20250425"></script>
     <script src="js/history.js?v=20260425-1"></script>
-    <script src="js/main.js?v=20260425-2"></script>
+    <script src="js/main.js?v=20260425-3"></script>
 </body>
 </html>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -210,8 +210,8 @@
         const totalValue = Number(portfolio.total_value || 0);
         const cashBalance = portfolio.cash_balance != null ? Number(portfolio.cash_balance) : null;
         const stockValue = cashBalance != null ? totalValue - cashBalance : null;
-        const cashPct = totalValue > 0 && cashBalance != null ? cashBalance / totalValue * 100 : null;
-        const stockPct = cashPct != null ? 100 - cashPct : null;
+        const cashPct = (totalValue > 0 && cashBalance != null) ? cashBalance / totalValue * 100 : 0;
+        const stockPct = (totalValue > 0 && cashBalance != null) ? 100 - cashPct : 0;
         const unrealizedPct = totalInvested > 0 ? totalUnrealizedPnl / totalInvested * 100 : null;
 
         const portRSign = totalRealizedPnl >= 0 ? '+' : '';

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -199,25 +199,63 @@
 
         let totalRealizedPnl = 0;
         let totalUnrealizedPnl = 0;
+        let totalInvested = 0;
         for (const info of Object.values(positions)) {
             if (info.realized_pnl != null) totalRealizedPnl += Number(info.realized_pnl);
             if (info.unrealized_pnl != null) totalUnrealizedPnl += Number(info.unrealized_pnl);
+            if (info.total_invested != null) totalInvested += Number(info.total_invested);
         }
+
+        const portfolio = data.portfolio || {};
+        const totalValue = Number(portfolio.total_value || 0);
+        const cashBalance = portfolio.cash_balance != null ? Number(portfolio.cash_balance) : null;
+        const stockValue = cashBalance != null ? totalValue - cashBalance : null;
+        const cashPct = totalValue > 0 && cashBalance != null ? cashBalance / totalValue * 100 : null;
+        const stockPct = cashPct != null ? 100 - cashPct : null;
+        const unrealizedPct = totalInvested > 0 ? totalUnrealizedPnl / totalInvested * 100 : null;
 
         const portRSign = totalRealizedPnl >= 0 ? '+' : '';
         const portRClass = totalRealizedPnl >= 0 ? 'pct-positive' : 'pct-negative';
         const portUSign = totalUnrealizedPnl >= 0 ? '+' : '';
         const portUClass = totalUnrealizedPnl >= 0 ? 'pct-positive' : 'pct-negative';
+        const portUPctSign = unrealizedPct != null && unrealizedPct >= 0 ? '+' : '';
+        const portUPctClass = unrealizedPct != null ? (unrealizedPct >= 0 ? 'pct-positive' : 'pct-negative') : '';
+
+        const cashBalanceRows = cashBalance != null ? `
+            <div class="ps-row">
+                <span class="ps-label">예수금</span>
+                <span class="ps-value">${formatCurrency(cashBalance, mode)}</span>
+                <span class="ps-pct">(${cashPct.toFixed(1)}%)</span>
+            </div>
+            <div class="ps-row">
+                <span class="ps-label">주식평가</span>
+                <span class="ps-value">${formatCurrency(stockValue, mode)}</span>
+                <span class="ps-pct">(${stockPct.toFixed(1)}%)</span>
+            </div>` : '';
+
+        const unrealizedPctHtml = unrealizedPct != null
+            ? `<span class="ps-pct ${portUPctClass}">(${portUPctSign}${unrealizedPct.toFixed(2)}%)</span>`
+            : '';
+
         const portfolioCard = document.createElement('div');
         portfolioCard.className = 'card portfolio-summary';
         portfolioCard.innerHTML = `
-            <div class="portfolio-summary-title">Portfolio</div>
-            <div class="portfolio-summary-row">
-                <span class="summary-label">총 실현손익:</span>
-                <span class="${portRClass}">${portRSign}${formatCurrency(totalRealizedPnl, mode)}</span>
-                <span class="summary-sep">|</span>
-                <span class="summary-label">총 평가손익:</span>
-                <span class="${portUClass}">${portUSign}${formatCurrency(totalUnrealizedPnl, mode)}</span>
+            <div class="portfolio-summary-title">Portfolio Summary</div>
+            <div class="ps-rows">
+                <div class="ps-row">
+                    <span class="ps-label">총평가액</span>
+                    <span class="ps-value">${formatCurrency(totalValue, mode)}</span>
+                </div>
+                ${cashBalanceRows}
+                <div class="ps-row">
+                    <span class="ps-label">실현손익</span>
+                    <span class="ps-value ${portRClass}">${portRSign}${formatCurrency(totalRealizedPnl, mode)}</span>
+                </div>
+                <div class="ps-row">
+                    <span class="ps-label">평가손익</span>
+                    <span class="ps-value ${portUClass}">${portUSign}${formatCurrency(totalUnrealizedPnl, mode)}</span>
+                    ${unrealizedPctHtml}
+                </div>
             </div>
         `;
         container.appendChild(portfolioCard);


### PR DESCRIPTION
## Summary

- `portfolio.cash_balance`를 이용해 예수금 및 주식평가액(비중%)을 카드에 표시
- 평가손익 행에 `totalUnrealizedPnl / totalInvested × 100` 수익률(%) 추가
- `cash_balance`가 없을 때 예수금·주식평가 행을 조건부 숨김 처리
- CSS에 `.ps-rows / .ps-row / .ps-label / .ps-value / .ps-pct` 세로 목록형 레이아웃 추가

## Test plan

- [ ] 기존 테스트 202개 통과, 커버리지 92.53% (기준 80% 충족) 확인
- [ ] `status.json`에 `cash_balance` 있을 때: 총평가액·예수금·주식평가·실현손익·평가손익 5행 모두 표시
- [ ] `cash_balance` 없을 때: 총평가액·실현손익·평가손익 3행만 표시
- [ ] 모바일(≤600px) 레이아웃 깨짐 없음 확인

Closes #92

https://claude.ai/code/session_01JKip4kDMfzK4HErPBckb7X

---
_Generated by [Claude Code](https://claude.ai/code/session_01JKip4kDMfzK4HErPBckb7X)_