### PR TITLE
🎨 Palette: [UX improvement] Add KRX color standards and a11y enhancements to dashboard

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,8 +1,8 @@
 /* MagicSplit Dashboard Style */
 :root {
     --primary: #2563eb;
-    --success: #16a34a;
-    --danger: #dc2626;
+    --success: #dc2626;
+    --danger: #2563eb;
     --warning: #d97706;
     --bg: #f8fafc;
     --card-bg: #ffffff;

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -56,10 +56,12 @@
             for (const lot of lots) {
                 const pctClass = lot.pct_change >= 0 ? 'pct-positive' : 'pct-negative';
                 const pctStr = (lot.pct_change >= 0 ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const ariaLabel = lot.pct_change >= 0 ? 'Profit of ' + lot.pct_change.toFixed(1) + '%' : 'Loss of ' + Math.abs(lot.pct_change).toFixed(1) + '%';
+                const trendIcon = lot.pct_change >= 0 ? '<span aria-hidden="true">▲</span>' : '<span aria-hidden="true">▼</span>';
                 lotsHtml += `
                     <li class="lot-item">
-                        <span>${lot.buy_date} | ${lot.quantity}shares @$${lot.buy_price.toFixed(2)}</span>
-                        <span class="${pctClass}">${pctStr}</span>
+                        <span>${lot.buy_date} | ${lot.quantity.toLocaleString()} shares @$${lot.buy_price.toFixed(2)}</span>
+                        <span class="${pctClass}" aria-label="${ariaLabel}">${pctStr} ${trendIcon}</span>
                     </li>`;
             }
 


### PR DESCRIPTION
🎨 Palette: Update dashboard colors to KRX standards and improve a11y

### What
1. Swapped the CSS variables for `--success` to red (`#dc2626`) and `--danger` to blue (`#2563eb`) to match Korean standard practices for market values.
2. Injected ARIA labels containing string formats of profit/losses along with screen-reader hidden visual arrows indicating direction.
3. Formatted share count string by adding space characters and running `.toLocaleString()`.

### Why (Financial clarity)
- For Korean market standards, users visually identify profits with Red and losses with Blue.
- Number spacing and localization improves visual scannability for human beings.
- Adding explicit context through aria-labels ensures accessibility tools effectively parse and read data visually abstracted by text colors/symbols.

### Accessibility ♿
- Added contextually descriptive `aria-label` elements to indicate exact Profit or Loss explicitly since simple percentages lacking a visual context can cause confusion with screen readers. Hidden arrow icons visually reinforce this to normal sighted users without conflicting the text read.

---
*PR created automatically by Jules for task [6509180705354429943](https://jules.google.com/task/6509180705354429943) started by @Junghyun99*