### PR TITLE
🛡️ Sentinel: [Critical] Add strict timeouts to all KIS brokerage API calls

### DIFF
--- a/.claude/plugins/skill-creator/skills/skill-creator/eval-viewer/generate_review.py
+++ b/.claude/plugins/skill-creator/skills/skill-creator/eval-viewer/generate_review.py
@@ -447,8 +447,8 @@ def main() -> None:
         port = server.server_address[1]
 
     url = f"http://localhost:{port}"
-    print(f"\n  Eval Viewer")
-    print(f"  ─────────────────────────────────")
+    print("\n  Eval Viewer")
+    print("  ─────────────────────────────────")
     print(f"  URL:       {url}")
     print(f"  Workspace: {workspace}")
     print(f"  Feedback:  {feedback_path}")
@@ -456,7 +456,7 @@ def main() -> None:
         print(f"  Previous:  {args.previous_workspace} ({len(previous)} runs)")
     if benchmark_path:
         print(f"  Benchmark: {benchmark_path}")
-    print(f"\n  Press Ctrl+C to stop.\n")
+    print("\n  Press Ctrl+C to stop.\n")
 
     webbrowser.open(url)
 

--- a/.claude/plugins/skill-creator/skills/skill-creator/scripts/aggregate_benchmark.py
+++ b/.claude/plugins/skill-creator/skills/skill-creator/scripts/aggregate_benchmark.py
@@ -389,7 +389,7 @@ def main():
     configs = [k for k in run_summary if k != "delta"]
     delta = run_summary.get("delta", {})
 
-    print(f"\nSummary:")
+    print("\nSummary:")
     for config in configs:
         pr = run_summary[config]["pass_rate"]["mean"]
         label = config.replace("_", " ").title()

--- a/.claude/plugins/skill-creator/skills/skill-creator/scripts/quick_validate.py
+++ b/.claude/plugins/skill-creator/skills/skill-creator/scripts/quick_validate.py
@@ -4,7 +4,6 @@ Quick validation script for skills - minimal version
 """
 
 import sys
-import os
 import re
 import yaml
 from pathlib import Path

--- a/.claude/plugins/skill-creator/skills/skill-creator/scripts/run_loop.py
+++ b/.claude/plugins/skill-creator/skills/skill-creator/scripts/run_loop.py
@@ -191,7 +191,7 @@ def run_loop(
 
         # Improve the description based on train results
         if verbose:
-            print(f"\nImproving description...", file=sys.stderr)
+            print("\nImproving description...", file=sys.stderr)
 
         t0 = time.time()
         # Strip test scores from history so improvement model can't see them

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+# Sentinel's Journal
+
+## Critical Learnings
+- **API Call Timeouts**: `requests` module needs strict timeouts (e.g., `timeout=10`) when talking to KIS APIs to prevent bot freezing during market volatility. Unhandled infinite timeouts can lead to frozen scripts that miss trades.

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -1,7 +1,7 @@
 # src/core/engine/base.py
 import time
 from datetime import datetime
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from src.core.interfaces import IBrokerAdapter, IRepository, ILogger, INotifier
 from src.core.models import (
@@ -11,7 +11,6 @@ from src.core.models import (
     Order,
     OrderAction,
     TradeExecution,
-    TradeSignal,
     SplitSignal,
     DayResult,
 )

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -1,5 +1,5 @@
 # src/core/models.py
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, Optional
 

--- a/src/infra/broker/kis_base.py
+++ b/src/infra/broker/kis_base.py
@@ -60,7 +60,7 @@ class KisBrokerCommon(IBrokerAdapter):
             "appsecret": self.app_secret,
         }
         try:
-            res = _pkg.requests.post(url, json=payload)
+            res = _pkg.requests.post(url, json=payload, timeout=10)
             res.raise_for_status()
             data = res.json()
             if 'access_token' not in data:

--- a/src/infra/broker/kis_domestic.py
+++ b/src/infra/broker/kis_domestic.py
@@ -47,7 +47,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
             headers = self._get_header(tr_id)
             try:
                 time.sleep(0.1)
-                res = _pkg.requests.get(url, headers=headers, params=params)
+                res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
                 res.raise_for_status()
                 data = res.json()
 
@@ -89,7 +89,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
 
         try:
             time.sleep(0.2)
-            res = _pkg.requests.get(url, headers=headers, params=params)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
             res.raise_for_status()
             data = res.json()
 
@@ -156,7 +156,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
 
         try:
             headers = self._get_header(tr_id, data)
-            res = _pkg.requests.post(url, headers=headers, json=data)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
             res.raise_for_status()
             resp_data = res.json()
 
@@ -239,7 +239,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
             "INQR_DVSN_2": "0"
         }
         headers = self._get_header(tr_id)
-        res = _pkg.requests.get(url, headers=headers, params=params)
+        res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
         res.raise_for_status()
         data = res.json()
         if data['rt_cd'] == '0':
@@ -283,7 +283,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
         }
         try:
             headers = self._get_header(self.FILL_TR_ID)
-            res = _pkg.requests.get(url, headers=headers, params=params)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
             res.raise_for_status()
             data = res.json()
             if data['rt_cd'] != '0':
@@ -320,7 +320,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
         }
         try:
             headers = self._get_header(self.CANCEL_TR_ID, data)
-            res = _pkg.requests.post(url, headers=headers, json=data)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
             res.raise_for_status()
             resp_data = res.json()
             if resp_data['rt_cd'] == '0':
@@ -346,7 +346,7 @@ class KisDomesticBrokerBase(KisBrokerCommon):
         headers = self._get_header(self.ASKING_PRICE_TR_ID)
         try:
             time.sleep(0.1)
-            res = _pkg.requests.get(url, headers=headers, params=params)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
             res.raise_for_status()
             data = res.json()
 

--- a/src/infra/broker/kis_http.py
+++ b/src/infra/broker/kis_http.py
@@ -41,6 +41,7 @@ def fetch_hashkey(base_url: str, app_key: str, app_secret: str, data: dict, logg
                 "appsecret": app_secret,
             },
             json=data,
+            timeout=10,
         )
         res.raise_for_status()
         return res.json()["HASH"]

--- a/src/infra/broker/kis_overseas.py
+++ b/src/infra/broker/kis_overseas.py
@@ -27,7 +27,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
             headers = self._get_header(tr_id)
             try:
                 time.sleep(0.1)
-                res = _pkg.requests.get(url, headers=headers, params=params)
+                res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
                 res.raise_for_status()
                 data = res.json()
 
@@ -72,7 +72,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
             headers = self._get_header(tr_id)
             try:
                 time.sleep(0.2)
-                res = _pkg.requests.get(url, headers=headers, params=params)
+                res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
                 res.raise_for_status()
                 data = res.json()
 
@@ -139,7 +139,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
 
         try:
             headers = self._get_header(tr_id, data)
-            res = _pkg.requests.post(url, headers=headers, json=data)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
             res.raise_for_status()
             resp_data = res.json()
 
@@ -206,7 +206,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
 
         try:
             headers = self._get_header(tr_id, data)
-            res = _pkg.requests.post(url, headers=headers, json=data)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
             res.raise_for_status()
             resp_data = res.json()
 
@@ -289,7 +289,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
             "CTX_AREA_NK200": ""
         }
         headers = self._get_header(tr_id)
-        res = _pkg.requests.get(url, headers=headers, params=params)
+        res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
         res.raise_for_status()
         data = res.json()
         if data['rt_cd'] == '0':
@@ -317,7 +317,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
         }
         try:
             headers = self._get_header(self.FILL_TR_ID)
-            res = _pkg.requests.get(url, headers=headers, params=params)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
             res.raise_for_status()
             data = res.json()
             if data['rt_cd'] != '0':
@@ -357,7 +357,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
         }
         try:
             headers = self._get_header(self.CANCEL_TR_ID, data)
-            res = _pkg.requests.post(url, headers=headers, json=data)
+            res = _pkg.requests.post(url, headers=headers, json=data, timeout=10)
             res.raise_for_status()
             resp_data = res.json()
             if resp_data['rt_cd'] == '0':
@@ -396,7 +396,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
 
             try:
                 time.sleep(0.2)
-                res = _pkg.requests.get(url, headers=headers, params=params)
+                res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
                 res.raise_for_status()
                 data = res.json()
 
@@ -422,7 +422,7 @@ class KisOverseasBrokerBase(KisBrokerCommon):
         headers = self._get_header(self.ASKING_PRICE_TR_ID)
         try:
             time.sleep(0.1)
-            res = _pkg.requests.get(url, headers=headers, params=params)
+            res = _pkg.requests.get(url, headers=headers, params=params, timeout=10)
             res.raise_for_status()
             data = res.json()
 

--- a/src/infra/broker/mock.py
+++ b/src/infra/broker/mock.py
@@ -1,6 +1,5 @@
 # src/infra/broker/mock.py
 from typing import List, Dict, Optional
-import time
 from datetime import datetime
 
 from src.core.interfaces import IBrokerAdapter, ILogger

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,7 @@
 # tests/conftest.py
 import pytest
 from src.core.models import (
-    StockRule, PositionLot, Portfolio, Order, OrderAction,
-    TradeExecution, ExecutionStatus, SplitSignal,
+    StockRule, PositionLot, Portfolio,
 )
 
 

--- a/tests/test_backtest_cache.py
+++ b/tests/test_backtest_cache.py
@@ -1,8 +1,7 @@
 # tests/test_backtest_cache.py
 import pandas as pd
 import pytest
-from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from src.backtest.cache import BacktestDataCache
 
 

--- a/tests/test_backtest_components.py
+++ b/tests/test_backtest_components.py
@@ -1,7 +1,7 @@
 # tests/test_backtest_components.py
 import pandas as pd
 import pytest
-from src.core.models import Order, OrderAction, ExecutionStatus
+from src.core.models import Order, OrderAction
 from src.backtest.components import BacktestBroker
 
 

--- a/tests/test_backtest_runner.py
+++ b/tests/test_backtest_runner.py
@@ -3,7 +3,6 @@ import json
 import os
 import pandas as pd
 import pytest
-from pathlib import Path
 from unittest.mock import patch
 
 from src.backtest.runner import run_backtest, _validate_tickers

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,4 @@
 # tests/test_config.py
-import pytest
 from src.config import Config, TICKER_EXCHANGE_MAP, EXCHANGE_CODE_SHORT_TO_FULL
 
 

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -1,9 +1,9 @@
 # tests/test_core_engine.py
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from src.core.engine.base import MagicSplitEngine
 from src.core.models import (
-    StockRule, PositionLot, Portfolio, Order, OrderAction,
+    StockRule, PositionLot, Portfolio, OrderAction,
     TradeExecution, ExecutionStatus, SplitSignal,
 )
 

--- a/tests/test_core_models.py
+++ b/tests/test_core_models.py
@@ -1,8 +1,7 @@
 # tests/test_core_models.py
-import pytest
 from src.core.models import (
     StockRule, PositionLot, Portfolio, Order, OrderAction,
-    TradeExecution, ExecutionStatus, SplitSignal, TradeSignal, DayResult,
+    ExecutionStatus, SplitSignal, TradeSignal,
 )
 
 

--- a/tests/test_infra_broker.py
+++ b/tests/test_infra_broker.py
@@ -1,5 +1,4 @@
 # tests/test_infra_broker.py
-import pytest
 from src.infra.broker.mock import MockBroker
 from src.core.models import Order, OrderAction, ExecutionStatus
 

--- a/tests/test_infra_data.py
+++ b/tests/test_infra_data.py
@@ -1,5 +1,4 @@
 # tests/test_infra_data.py
-import pytest
 from unittest.mock import MagicMock, patch
 from src.infra.data import YFinanceLoader
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,5 @@
 # tests/test_main.py
 """MagicSplitBot 초기화/실행 테스트 — KIS 브로커는 목으로 대체."""
-import os
 import json
 import pytest
 from unittest.mock import patch, MagicMock

--- a/tests/test_main_integration.py
+++ b/tests/test_main_integration.py
@@ -1,10 +1,9 @@
 # tests/test_main_integration.py
 """MagicSplitBot 통합 테스트 — MockBroker를 사용한 전체 플로우."""
-import json
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock
 from src.core.engine.base import MagicSplitEngine
-from src.core.models import StockRule, Portfolio
+from src.core.models import StockRule
 from src.infra.broker.mock import MockBroker
 from src.infra.repo import JsonRepository
 

--- a/tests/test_split_evaluator.py
+++ b/tests/test_split_evaluator.py
@@ -2,7 +2,7 @@
 import pytest
 from src.core.logic.split_evaluator import SplitEvaluator
 from src.core.models import (
-    StockRule, PositionLot, Portfolio, OrderAction, SplitSignal,
+    OrderAction,
 )
 
 


### PR DESCRIPTION
🚨 **Severity:** Critical

💡 **Vulnerability/Risk:** 
Missing timeouts on external API calls (`requests` module). Brokerage APIs can become sluggish or completely unresponsive during market volatility. Without a timeout, a request might block the execution thread indefinitely, completely freezing the bot.

🎯 **Financial Impact:** 
An unresponsive bot might fail to execute critical split sale signals, leaving open profitable positions at risk, or it might get stuck on a buy order, exhausting available cash while waiting for an API response. Missing out on trades or freezing with open orders poses a tangible financial risk. 

🔧 **Fix:** 
Added explicit `timeout=10` constraints to all `requests.get` and `requests.post` API calls across the broker API implementations (`src/infra/broker/kis_base.py`, `src/infra/broker/kis_domestic.py`, `src/infra/broker/kis_overseas.py`, `src/infra/broker/kis_http.py`). A failure will now raise a timeout exception instead of silently hanging.

✅ **Verification:**
*   Verified that `python -m pytest` passes completely.
*   Verified that lint checks are running smoothly.
*   Documented learning in `.jules/sentinel.md` as requested.

---
*PR created automatically by Jules for task [2568220036785942177](https://jules.google.com/task/2568220036785942177) started by @Junghyun99*