### PR TITLE
🎨 Palette: Enhance profit/loss visualization (KRX Colors & A11y)

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,2 @@
+- The site uses Korean market color conventions (Red = Up/Profit, Blue = Down/Loss).
+- Accessibility (ARIA labels) is crucial for financial data.

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,8 +1,8 @@
 /* MagicSplit Dashboard Style */
 :root {
     --primary: #2563eb;
-    --success: #16a34a;
-    --danger: #dc2626;
+    --success: #ef4444;
+    --danger: #3b82f6;
     --warning: #d97706;
     --bg: #f8fafc;
     --card-bg: #ffffff;

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -56,10 +56,17 @@
             for (const lot of lots) {
                 const pctClass = lot.pct_change >= 0 ? 'pct-positive' : 'pct-negative';
                 const pctStr = (lot.pct_change >= 0 ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const ariaLabel = lot.pct_change >= 0
+                    ? `Profit of ${lot.pct_change.toFixed(1)}%`
+                    : `Loss of ${Math.abs(lot.pct_change).toFixed(1)}%`;
+                const arrowIcon = lot.pct_change >= 0
+                    ? '<span aria-hidden="true">▲</span>'
+                    : '<span aria-hidden="true">▼</span>';
+
                 lotsHtml += `
                     <li class="lot-item">
                         <span>${lot.buy_date} | ${lot.quantity}shares @$${lot.buy_price.toFixed(2)}</span>
-                        <span class="${pctClass}">${pctStr}</span>
+                        <span class="${pctClass}" aria-label="${ariaLabel}">${pctStr} ${arrowIcon}</span>
                     </li>`;
             }
 


### PR DESCRIPTION
- Implements Korean market color conventions (KRX: Red = Up, Blue = Down) in the CSS (`docs/css/style.css`).
- Adds explicit directional arrow icons (`▲`/`▼`) inside the lot item template to improve data clarity at-a-glance.
- Introduces `aria-label`s for the profit/loss span tags in JS (`docs/js/main.js`) to provide robust accessibility for screen readers.
- Creates `.jules/palette.md` noting the newly adopted KRX UI conventions.

---
*PR created automatically by Jules for task [12006583083285613579](https://jules.google.com/task/12006583083285613579) started by @Junghyun99*