### PR TITLE
"신호 없음" 로그에 마지막 차수 현황 표시

### DIFF
--- a/logs/backtest/2026-04-28_155807_overseas.log
+++ b/logs/backtest/2026-04-28_155807_overseas.log
@@ -1,0 +1,287 @@
+2026-04-28 15:58:07,926 [INFO] --- 데이터 다운로드: ['AAPL'] (2024-01-02 ~ 2024-01-15) ---
+2026-04-28 15:58:07,927 [INFO] --- 백테스트 시작 (10 거래일) ---
+2026-04-28 15:58:07,927 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,927 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,928 [INFO] Portfolio: Cash=$10,000, Value=$10,000
+2026-04-28 15:58:07,928 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,928 [INFO] Loaded 0 position lot(s)
+2026-04-28 15:58:07,928 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,928 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,928 [INFO] [AAPL] 보유 lot 없음 → 초기 매수 Lv1 5주 @$100.00
+2026-04-28 15:58:07,928 [INFO] Executing 1 order(s)...
+2026-04-28 15:58:07,928 [INFO] [FILLED] BUY AAPL: 5 @ $100.10 (Fee: $1.25)
+2026-04-28 15:58:07,928 [INFO] [Position] New lot: lot_20260428_155807_AAPL_001 Lv1 AAPL 5주 @$100.10
+2026-04-28 15:58:07,928 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,930 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,931 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,931 [INFO] Portfolio: Cash=$9,498, Value=$9,988
+2026-04-28 15:58:07,931 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,931 [INFO] Loaded 1 position lot(s)
+2026-04-28 15:58:07,931 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,931 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,931 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $98.00 (-2.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,931 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,932 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,933 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,933 [INFO] Portfolio: Cash=$9,498, Value=$9,978
+2026-04-28 15:58:07,933 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,933 [INFO] Loaded 1 position lot(s)
+2026-04-28 15:58:07,933 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,933 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,933 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $96.00 (-4.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,933 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,934 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,934 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,934 [INFO] Portfolio: Cash=$9,498, Value=$9,968
+2026-04-28 15:58:07,935 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,935 [INFO] Loaded 1 position lot(s)
+2026-04-28 15:58:07,935 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,935 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,935 [INFO] [AAPL] Lv1 매수가 $100.10 대비 -6.1% → 추가 매수 Lv2 5주 @$94.00
+2026-04-28 15:58:07,935 [INFO] Executing 1 order(s)...
+2026-04-28 15:58:07,935 [INFO] [FILLED] BUY AAPL: 5 @ $94.09 (Fee: $1.18)
+2026-04-28 15:58:07,935 [INFO] [Position] New lot: lot_20260428_155807_AAPL_002 Lv2 AAPL 5주 @$94.09
+2026-04-28 15:58:07,935 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,937 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,937 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,937 [INFO] Portfolio: Cash=$9,027, Value=$9,947
+2026-04-28 15:58:07,937 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,937 [INFO] Loaded 2 position lot(s)
+2026-04-28 15:58:07,937 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,937 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,937 [INFO]   [AAPL] 신호 없음 | Lv2 매수 $94.09 → 현재 $92.00 (-2.22%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,937 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,939 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,939 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,939 [INFO] Portfolio: Cash=$9,027, Value=$9,927
+2026-04-28 15:58:07,939 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,939 [INFO] Loaded 2 position lot(s)
+2026-04-28 15:58:07,939 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,939 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,939 [INFO]   [AAPL] 신호 없음 | Lv2 매수 $94.09 → 현재 $90.00 (-4.35%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,939 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,940 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,941 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,941 [INFO] Portfolio: Cash=$9,027, Value=$9,907
+2026-04-28 15:58:07,941 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,941 [INFO] Loaded 2 position lot(s)
+2026-04-28 15:58:07,941 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,941 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,941 [INFO] [AAPL] Lv2 매수가 $94.09 대비 -6.5% → 추가 매수 Lv3 5주 @$88.00
+2026-04-28 15:58:07,941 [INFO] Executing 1 order(s)...
+2026-04-28 15:58:07,941 [INFO] [FILLED] BUY AAPL: 5 @ $88.09 (Fee: $1.10)
+2026-04-28 15:58:07,941 [INFO] [Position] New lot: lot_20260428_155807_AAPL_003 Lv3 AAPL 5주 @$88.09
+2026-04-28 15:58:07,942 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,943 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,943 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,943 [INFO] Portfolio: Cash=$8,585, Value=$9,875
+2026-04-28 15:58:07,944 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,944 [INFO] Loaded 3 position lot(s)
+2026-04-28 15:58:07,944 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,944 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,944 [INFO]   [AAPL] 신호 없음 | Lv3 매수 $88.09 → 현재 $86.00 (-2.37%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,944 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,945 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,945 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,945 [INFO] Portfolio: Cash=$8,585, Value=$9,845
+2026-04-28 15:58:07,945 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,946 [INFO] Loaded 3 position lot(s)
+2026-04-28 15:58:07,946 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,946 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,946 [INFO]   [AAPL] 신호 없음 | Lv3 매수 $88.09 → 현재 $84.00 (-4.64%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,946 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,947 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,947 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,947 [INFO] Portfolio: Cash=$8,585, Value=$9,815
+2026-04-28 15:58:07,947 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,947 [INFO] Loaded 3 position lot(s)
+2026-04-28 15:58:07,948 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,948 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,948 [INFO] [AAPL] Lv3 매수가 $88.09 대비 -6.9% → 추가 매수 Lv4 6주 @$82.00
+2026-04-28 15:58:07,948 [INFO] Executing 1 order(s)...
+2026-04-28 15:58:07,948 [INFO] [FILLED] BUY AAPL: 6 @ $82.08 (Fee: $1.23)
+2026-04-28 15:58:07,948 [INFO] [Position] New lot: lot_20260428_155807_AAPL_004 Lv4 AAPL 6주 @$82.08
+2026-04-28 15:58:07,948 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,950 [INFO] --- 백테스트 완료 ---
+2026-04-28 15:58:07,950 [INFO] 최종: Cash=$8,091, Value=$9,813
+2026-04-28 15:58:07,953 [INFO] --- 데이터 다운로드: ['AAPL'] (2024-01-02 ~ 2024-01-08) ---
+2026-04-28 15:58:07,954 [INFO] --- 백테스트 시작 (5 거래일) ---
+2026-04-28 15:58:07,954 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,954 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,954 [INFO] Portfolio: Cash=$10,000, Value=$10,000
+2026-04-28 15:58:07,955 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,955 [INFO] Loaded 0 position lot(s)
+2026-04-28 15:58:07,955 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,955 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,955 [INFO] [AAPL] 보유 lot 없음 → 초기 매수 Lv1 5주 @$100.00
+2026-04-28 15:58:07,955 [INFO] Executing 1 order(s)...
+2026-04-28 15:58:07,955 [INFO] [FILLED] BUY AAPL: 5 @ $100.10 (Fee: $1.25)
+2026-04-28 15:58:07,955 [INFO] [Position] New lot: lot_20260428_155807_AAPL_001 Lv1 AAPL 5주 @$100.10
+2026-04-28 15:58:07,955 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,956 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,956 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,957 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-28 15:58:07,957 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,957 [INFO] Loaded 1 position lot(s)
+2026-04-28 15:58:07,957 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,957 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,957 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $100.00 (-0.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,957 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,958 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,958 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,958 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-28 15:58:07,958 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,958 [INFO] Loaded 1 position lot(s)
+2026-04-28 15:58:07,959 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,959 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,959 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $100.00 (-0.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,959 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,960 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,960 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,960 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-28 15:58:07,960 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,960 [INFO] Loaded 1 position lot(s)
+2026-04-28 15:58:07,960 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,961 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,961 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $100.00 (-0.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,961 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,962 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,962 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,962 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-28 15:58:07,962 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,962 [INFO] Loaded 1 position lot(s)
+2026-04-28 15:58:07,962 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,962 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,962 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $100.00 (-0.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,963 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,963 [INFO] --- 백테스트 완료 ---
+2026-04-28 15:58:07,963 [INFO] 최종: Cash=$9,498, Value=$9,998
+2026-04-28 15:58:07,966 [WARNING] 'overseas' 마켓에 해당하는 종목이 없습니다.
+2026-04-28 15:58:07,969 [INFO] --- 데이터 다운로드: ['AAPL', 'MSFT'] (2024-01-02 ~ 2024-01-15) ---
+2026-04-28 15:58:07,970 [INFO] --- 백테스트 시작 (10 거래일) ---
+2026-04-28 15:58:07,970 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,970 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,970 [INFO] Portfolio: Cash=$10,000, Value=$10,000
+2026-04-28 15:58:07,970 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,970 [INFO] Loaded 0 position lot(s)
+2026-04-28 15:58:07,970 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,970 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,971 [INFO] [AAPL] 보유 lot 없음 → 초기 매수 Lv1 3주 @$100.00
+2026-04-28 15:58:07,971 [INFO] Executing 1 order(s)...
+2026-04-28 15:58:07,971 [INFO] [FILLED] BUY AAPL: 3 @ $100.10 (Fee: $0.75)
+2026-04-28 15:58:07,971 [INFO] [Position] New lot: lot_20260428_155807_AAPL_001 Lv1 AAPL 3주 @$100.10
+2026-04-28 15:58:07,971 [INFO] >>> Processing MSFT
+2026-04-28 15:58:07,971 [INFO] [MSFT] 보유 lot 없음 → 초기 매수 Lv1 3주 @$100.00
+2026-04-28 15:58:07,971 [INFO] Executing 1 order(s)...
+2026-04-28 15:58:07,971 [INFO] [FILLED] BUY MSFT: 3 @ $100.10 (Fee: $0.75)
+2026-04-28 15:58:07,971 [INFO] [Position] New lot: lot_20260428_155807_MSFT_001 Lv1 MSFT 3주 @$100.10
+2026-04-28 15:58:07,971 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,973 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,973 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,973 [INFO] Portfolio: Cash=$9,398, Value=$9,992
+2026-04-28 15:58:07,973 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,973 [INFO] Loaded 2 position lot(s)
+2026-04-28 15:58:07,973 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,973 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,973 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $99.00 (-1.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,974 [INFO] >>> Processing MSFT
+2026-04-28 15:58:07,974 [INFO]   [MSFT] 신호 없음 | Lv1 매수 $100.10 → 현재 $99.00 (-1.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,974 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,975 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,975 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,975 [INFO] Portfolio: Cash=$9,398, Value=$9,986
+2026-04-28 15:58:07,975 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,975 [INFO] Loaded 2 position lot(s)
+2026-04-28 15:58:07,976 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,976 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,976 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $98.00 (-2.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,976 [INFO] >>> Processing MSFT
+2026-04-28 15:58:07,976 [INFO]   [MSFT] 신호 없음 | Lv1 매수 $100.10 → 현재 $98.00 (-2.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,976 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,977 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,977 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,977 [INFO] Portfolio: Cash=$9,398, Value=$9,980
+2026-04-28 15:58:07,978 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,978 [INFO] Loaded 2 position lot(s)
+2026-04-28 15:58:07,978 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,978 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,978 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $97.00 (-3.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,978 [INFO] >>> Processing MSFT
+2026-04-28 15:58:07,978 [INFO]   [MSFT] 신호 없음 | Lv1 매수 $100.10 → 현재 $97.00 (-3.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,978 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,979 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,979 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,980 [INFO] Portfolio: Cash=$9,398, Value=$9,974
+2026-04-28 15:58:07,980 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,980 [INFO] Loaded 2 position lot(s)
+2026-04-28 15:58:07,980 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,980 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,980 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $96.00 (-4.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,980 [INFO] >>> Processing MSFT
+2026-04-28 15:58:07,980 [INFO]   [MSFT] 신호 없음 | Lv1 매수 $100.10 → 현재 $96.00 (-4.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,980 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,981 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,981 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,982 [INFO] Portfolio: Cash=$9,398, Value=$9,968
+2026-04-28 15:58:07,982 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,982 [INFO] Loaded 2 position lot(s)
+2026-04-28 15:58:07,982 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,982 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,982 [INFO] [AAPL] Lv1 매수가 $100.10 대비 -5.1% → 추가 매수 Lv2 3주 @$95.00
+2026-04-28 15:58:07,982 [INFO] Executing 1 order(s)...
+2026-04-28 15:58:07,982 [INFO] [FILLED] BUY AAPL: 3 @ $95.09 (Fee: $0.71)
+2026-04-28 15:58:07,982 [INFO] [Position] New lot: lot_20260428_155807_AAPL_002 Lv2 AAPL 3주 @$95.09
+2026-04-28 15:58:07,983 [INFO] >>> Processing MSFT
+2026-04-28 15:58:07,983 [INFO] [MSFT] Lv1 매수가 $100.10 대비 -5.1% → 추가 매수 Lv2 3주 @$95.00
+2026-04-28 15:58:07,983 [INFO] Executing 1 order(s)...
+2026-04-28 15:58:07,983 [INFO] [FILLED] BUY MSFT: 3 @ $95.09 (Fee: $0.71)
+2026-04-28 15:58:07,983 [INFO] [Position] New lot: lot_20260428_155807_MSFT_002 Lv2 MSFT 3주 @$95.09
+2026-04-28 15:58:07,983 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,985 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,985 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,985 [INFO] Portfolio: Cash=$8,826, Value=$9,954
+2026-04-28 15:58:07,985 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,985 [INFO] Loaded 4 position lot(s)
+2026-04-28 15:58:07,985 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,985 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,986 [INFO]   [AAPL] 신호 없음 | Lv2 매수 $95.09 → 현재 $94.00 (-1.15%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,986 [INFO] >>> Processing MSFT
+2026-04-28 15:58:07,986 [INFO]   [MSFT] 신호 없음 | Lv2 매수 $95.09 → 현재 $94.00 (-1.15%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,986 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,987 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,987 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,987 [INFO] Portfolio: Cash=$8,826, Value=$9,942
+2026-04-28 15:58:07,987 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,988 [INFO] Loaded 4 position lot(s)
+2026-04-28 15:58:07,988 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,988 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,988 [INFO]   [AAPL] 신호 없음 | Lv2 매수 $95.09 → 현재 $93.00 (-2.20%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,988 [INFO] >>> Processing MSFT
+2026-04-28 15:58:07,988 [INFO]   [MSFT] 신호 없음 | Lv2 매수 $95.09 → 현재 $93.00 (-2.20%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,988 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,989 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,990 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,990 [INFO] Portfolio: Cash=$8,826, Value=$9,930
+2026-04-28 15:58:07,990 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,990 [INFO] Loaded 4 position lot(s)
+2026-04-28 15:58:07,990 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,990 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,990 [INFO]   [AAPL] 신호 없음 | Lv2 매수 $95.09 → 현재 $92.00 (-3.25%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,990 [INFO] >>> Processing MSFT
+2026-04-28 15:58:07,991 [INFO]   [MSFT] 신호 없음 | Lv2 매수 $95.09 → 현재 $92.00 (-3.25%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,991 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,992 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 15:58:07,992 [INFO] Fetching real-time prices from Broker...
+2026-04-28 15:58:07,992 [INFO] Portfolio: Cash=$8,826, Value=$9,918
+2026-04-28 15:58:07,992 [INFO] >>> Step 2: Load Positions
+2026-04-28 15:58:07,992 [INFO] Loaded 4 position lot(s)
+2026-04-28 15:58:07,993 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 15:58:07,993 [INFO] >>> Processing AAPL
+2026-04-28 15:58:07,993 [INFO]   [AAPL] 신호 없음 | Lv2 매수 $95.09 → 현재 $91.00 (-4.30%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,993 [INFO] >>> Processing MSFT
+2026-04-28 15:58:07,993 [INFO]   [MSFT] 신호 없음 | Lv2 매수 $95.09 → 현재 $91.00 (-4.30%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 15:58:07,993 [INFO] >>> Step 6: Persist
+2026-04-28 15:58:07,995 [INFO] --- 백테스트 완료 ---
+2026-04-28 15:58:07,995 [INFO] 최종: Cash=$8,826, Value=$9,918
+2026-04-28 15:58:07,999 [INFO] --- 데이터 다운로드: ['AAPL'] (2024-01-02 ~ 2024-01-08) ---
+2026-04-28 15:58:07,999 [WARNING] 데이터 미수신 티커 ['AAPL'] — 백테스트를 중단합니다.

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -113,7 +113,9 @@ class MagicSplitEngine:
                     all_signals.extend(signals)
 
                     if not signals:
-                        self.logger.info(f"  [{rule.ticker}] 신호 없음. 스킵.")
+                        self._log_no_signal_status(
+                            rule, positions, portfolio, last_sell_prices,
+                        )
                         continue
 
                     # 3b. 주문 실행
@@ -284,6 +286,57 @@ class MagicSplitEngine:
         )
         self.logger.warning(msg)
         self._notify_alert(msg)
+
+    def _log_no_signal_status(
+        self,
+        rule: StockRule,
+        positions: List[PositionLot],
+        portfolio: Portfolio,
+        last_sell_prices: Optional[dict] = None,
+    ) -> None:
+        """신호 없음일 때 마지막 차수 현황을 한 줄로 요약 로깅한다.
+
+        매수가 대비 현재가/수익률과 매수·매도 임계치를 함께 보여주어
+        신호까지 얼마나 남았는지 직관적으로 파악할 수 있도록 한다.
+        """
+        ticker = rule.ticker
+        current_price = portfolio.current_prices.get(ticker, 0)
+        ticker_lots = [p for p in positions if p.ticker == ticker]
+
+        if current_price <= 0:
+            self.logger.info(f"  [{ticker}] 신호 없음 | 현재가 조회 실패")
+            return
+
+        if not ticker_lots:
+            msg = (
+                f"  [{ticker}] 신호 없음 | 보유 없음, "
+                f"현재 ${current_price:,.2f} (1차 진입 대기)"
+            )
+            last_sell = last_sell_prices.get(ticker) if last_sell_prices else None
+            if last_sell and last_sell > 0 and rule.reentry_guard_pct is not None:
+                pct_from_sell = (current_price - last_sell) / last_sell * 100
+                msg += (
+                    f" | 직전 매도가 ${last_sell:,.2f} 대비 {pct_from_sell:+.2f}% "
+                    f"(가드 {rule.reentry_guard_pct:+.2f}%)"
+                )
+            self.logger.info(msg)
+            return
+
+        last_lot = max(ticker_lots, key=lambda l: l.level)
+        profit_pct = (current_price - last_lot.buy_price) / last_lot.buy_price * 100
+        sell_threshold = rule.sell_threshold_at(last_lot.level)
+        buy_threshold = rule.buy_threshold_at(last_lot.level)
+        next_level = last_lot.level + 1
+
+        msg = (
+            f"  [{ticker}] 신호 없음 | Lv{last_lot.level} "
+            f"매수 ${last_lot.buy_price:,.2f} → 현재 ${current_price:,.2f} "
+            f"({profit_pct:+.2f}%) | 익절 +{sell_threshold:.1f}% / "
+            f"추매 {buy_threshold:.1f}%"
+        )
+        if next_level > rule.max_lots:
+            msg += f" (max_lots {rule.max_lots} 도달, 추매 불가)"
+        self.logger.info(msg)
 
     def _refresh_portfolio(self, old_portfolio: Portfolio) -> Portfolio:
         """종목 처리 후 포트폴리오(현금 잔고) 갱신."""

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -609,3 +609,113 @@ class TestUpdatePositionsOverFill:
         assert len(updated) == 0
         warns = [c.args[0] for c in mock_logger.warning.call_args_list]
         assert not any("Over-fill" in w for w in warns)
+
+
+class TestNoSignalLog:
+    """신호 없음 로그가 마지막 차수/매수가/현재가/수익률/임계치를 보여주는지 확인."""
+
+    def test_logs_last_level_status_with_thresholds(self, engine, mock_logger):
+        """보유 lot이 있을 때: Lv, 매수가, 현재가, 수익률, 익절·추매 임계치 표시."""
+        rule = StockRule("AAPL", -5.0, 10.0, 500, 10)
+        positions = [
+            PositionLot("lot_001", "AAPL", 100.0, 5, "2026-04-01", level=1),
+            PositionLot("lot_002", "AAPL", 95.0, 5, "2026-04-05", level=2),
+        ]
+        portfolio = Portfolio(
+            total_cash=1000.0, holdings={"AAPL": 10},
+            current_prices={"AAPL": 97.0},
+        )
+        engine._log_no_signal_status(rule, positions, portfolio)
+        msgs = [c.args[0] for c in mock_logger.info.call_args_list]
+        assert len(msgs) == 1
+        msg = msgs[0]
+        assert "[AAPL]" in msg
+        assert "신호 없음" in msg
+        assert "Lv2" in msg
+        assert "$95.00" in msg
+        assert "$97.00" in msg
+        assert "+2.11%" in msg
+        assert "익절 +10.0%" in msg
+        assert "추매 -5.0%" in msg
+
+    def test_logs_no_position_waiting_initial(self, engine, mock_logger):
+        """보유 lot이 없을 때: 보유 없음 + 현재가 + 1차 진입 대기 표시."""
+        rule = StockRule("AAPL", -5.0, 10.0, 500, 10)
+        positions = []
+        portfolio = Portfolio(
+            total_cash=1000.0, holdings={},
+            current_prices={"AAPL": 100.0},
+        )
+        engine._log_no_signal_status(rule, positions, portfolio)
+        msgs = [c.args[0] for c in mock_logger.info.call_args_list]
+        assert len(msgs) == 1
+        assert "보유 없음" in msgs[0]
+        assert "$100.00" in msgs[0]
+        assert "1차 진입 대기" in msgs[0]
+
+    def test_logs_reentry_guard_distance_when_active(self, engine, mock_logger):
+        """재진입 가드가 설정된 경우 직전 매도가 대비 거리도 함께 표시."""
+        rule = StockRule(
+            "AAPL", -5.0, 10.0, 500, 10, reentry_guard_pct=-1.0,
+        )
+        portfolio = Portfolio(
+            total_cash=1000.0, holdings={},
+            current_prices={"AAPL": 99.5},
+        )
+        last_sell_prices = {"AAPL": 100.0}
+        engine._log_no_signal_status(rule, [], portfolio, last_sell_prices)
+        msg = mock_logger.info.call_args_list[0].args[0]
+        assert "직전 매도가 $100.00" in msg
+        assert "-0.50%" in msg
+        assert "가드 -1.00%" in msg
+
+    def test_logs_max_lots_reached_hint(self, engine, mock_logger):
+        """max_lots 도달 시 추매 불가 힌트 추가."""
+        rule = StockRule("AAPL", -5.0, 10.0, 500, max_lots=2)
+        positions = [
+            PositionLot("lot_001", "AAPL", 100.0, 5, "2026-04-01", level=1),
+            PositionLot("lot_002", "AAPL", 95.0, 5, "2026-04-05", level=2),
+        ]
+        portfolio = Portfolio(
+            total_cash=1000.0, holdings={"AAPL": 10},
+            current_prices={"AAPL": 96.0},
+        )
+        engine._log_no_signal_status(rule, positions, portfolio)
+        msg = mock_logger.info.call_args_list[0].args[0]
+        assert "max_lots 2 도달" in msg
+
+    def test_logs_price_unavailable(self, engine, mock_logger):
+        """현재가 조회 실패(0) 시 짧은 메시지."""
+        rule = StockRule("AAPL", -5.0, 10.0, 500, 10)
+        portfolio = Portfolio(
+            total_cash=1000.0, holdings={}, current_prices={"AAPL": 0.0},
+        )
+        engine._log_no_signal_status(rule, [], portfolio)
+        msg = mock_logger.info.call_args_list[0].args[0]
+        assert "현재가 조회 실패" in msg
+
+    def test_run_one_cycle_emits_enriched_no_signal_log(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """run_one_cycle 통합: 신호 없음일 때 enriched 로그가 호출된다."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={"AAPL": 5},
+            current_prices={"AAPL": 100.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 100.0}
+        mock_repo.load_positions.return_value = [
+            PositionLot("lot_001", "AAPL", 99.0, 5, "2026-04-01", level=1),
+        ]
+        mock_repo.load_last_sell_prices.return_value = {}
+        eng = MagicSplitEngine(
+            broker=mock_broker, repo=mock_repo,
+            logger=mock_logger, stock_rules=rules,
+        )
+        eng.run_one_cycle(sim_date="2026-04-10")
+        msgs = [c.args[0] for c in mock_logger.info.call_args_list]
+        assert any(
+            "[AAPL]" in m and "신호 없음" in m and "Lv1" in m
+            and "$99.00" in m and "$100.00" in m
+            for m in msgs
+        )


### PR DESCRIPTION
## Summary

매매 사이클에서 신호가 발생하지 않을 때 단순히 `[TICKER] 신호 없음. 스킵.` 만 출력되어, 현재가가 매수/매도 임계치까지 얼마나 남았는지 알기 어려운 문제를 개선합니다.

이제 마지막 차수의 매수가, 현재가, 수익률, 매수·매도 임계치를 한 줄에 함께 표시합니다.

## Before / After

**Before:**
```
[AAPL] 신호 없음. 스킵.
```

**After (보유 lot 있을 때):**
```
[AAPL] 신호 없음 | Lv2 매수 $95.00 → 현재 $97.00 (+2.11%) | 익절 +10.0% / 추매 -5.0%
```

**After (보유 lot 없을 때):**
```
[AAPL] 신호 없음 | 보유 없음, 현재 $100.00 (1차 진입 대기)
```

**After (재진입 가드 활성):**
```
[AAPL] 신호 없음 | 보유 없음, 현재 $99.50 (1차 진입 대기) | 직전 매도가 $100.00 대비 -0.50% (가드 -1.00%)
```

**After (max_lots 도달):**
```
[AAPL] 신호 없음 | Lv2 매수 $95.00 → 현재 $96.00 (+1.05%) | 익절 +10.0% / 추매 -5.0% (max_lots 2 도달, 추매 불가)
```

## Changes

- `src/core/engine/base.py`: `_log_no_signal_status()` 헬퍼 추가 후 기존 한 줄 로그 대체
- `tests/test_core_engine.py`: `TestNoSignalLog` 클래스에 6개 테스트 추가 (보유 유무, 가드 거리, max_lots, 가격 조회 실패, 통합)

## Test plan

- [x] `pytest --cov=src --cov-report=term-missing --cov-fail-under=80 tests/` — 239 passed, 89.77% coverage
- [x] 신규 단위 테스트 5건 + 통합 테스트 1건 모두 통과
- [ ] 실제 봇 실행 시 로그 출력 형식 확인 (다음 사이클부터 자동 적용)

https://claude.ai/code/session_01H7c61ER1Jxwv5Mk4fQtabK

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7c61ER1Jxwv5Mk4fQtabK)_