### PR TITLE
docs: CLAUDE.md 최신화 및 CONFIG_JSON_PATH 기본값 변경

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,13 +11,12 @@
 - pytest + pytest-cov (테스트)
 
 ## 주요 명령어
-- 테스트: `pytest --cov=src --cov-report=term-missing --cov-fail-under=80 tests/`
-- 봇 실행 (해외): `CONFIG_JSON_PATH=config_overseas.json python -m src.main`
-- 봇 실행 (국내): `CONFIG_JSON_PATH=config_domestic.json python -m src.main`
-- 백테스트: `python -c "from src.backtest.runner import run_backtest; run_backtest(config_path='config_overseas.json', start_date='2023-01-01', end_date='2024-12-31', initial_cash=10000, market_type='overseas')"`
-- 수동 매매: `python scripts/manual_trade.py --ticker AAPL --action buy --qty 1`
-- 포지션 정합: `python scripts/reconcile_positions.py`
+운영성 작업(봇 실행/백테스트/수동매매/시세 다운로드)은 GitHub Actions 워크플로우로 실행한다 (CI/CD 섹션 참조).
+로컬에서 자주 쓰는 명령어:
 - 의존성 설치: `pip install -r requirements.txt`
+- 테스트: `pytest` (커버리지 게이트 포함 풀 실행은 `python-test.yml` 참조)
+- 봇 1회 실행: `python -m src.main` (`CONFIG_JSON_PATH`로 국내/해외 선택)
+- 포지션 정합: `python scripts/reconcile_positions.py`
 
 ## 프로젝트 구조
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,27 +2,32 @@
 
 ## 프로젝트 개요
 종목별 매수가 대비 %에 따라 분할 매수(물타기) 또는 매도(익절)를 자동 실행하는 Python 트레이딩 봇.
-차수(Level) 시스템으로 매수/매도를 계단식으로 관리한다.
+차수(Level) 시스템으로 매수/매도를 계단식으로 관리하며, 트레일링 스톱과 동적 재매수 기준으로 변동성에 대응한다.
 
 ## 기술 스택
 - Python 3.10
 - pandas, requests, python-dotenv, PyYAML
+- yfinance, pyarrow (백테스트 시세 캐시)
 - pytest + pytest-cov (테스트)
 
 ## 주요 명령어
 - 테스트: `pytest --cov=src --cov-report=term-missing --cov-fail-under=80 tests/`
-- 봇 실행: `python -m src.main`
+- 봇 실행 (해외): `CONFIG_JSON_PATH=config_overseas.json python -m src.main`
+- 봇 실행 (국내): `CONFIG_JSON_PATH=config_domestic.json python -m src.main`
+- 백테스트: `python -c "from src.backtest.runner import run_backtest; run_backtest(config_path='config_overseas.json', start_date='2023-01-01', end_date='2024-12-31', initial_cash=10000, market_type='overseas')"`
+- 수동 매매: `python scripts/manual_trade.py --ticker AAPL --action buy --qty 1`
+- 포지션 정합: `python scripts/reconcile_positions.py`
 - 의존성 설치: `pip install -r requirements.txt`
 
 ## 프로젝트 구조
 ```
 src/
-├── main.py              # MagicSplitBot 진입점 (단일 계좌, 국내/해외 독립 운용)
+├── main.py              # MagicSplitBot 진입점 (단일 계좌, CONFIG_JSON_PATH로 국내/해외 선택)
 ├── config.py            # 티커-거래소 매핑, 인프라 설정, KIS 인증
-├── strategy_config.py   # config.json 로더 → StockRule 리스트
+├── strategy_config.py   # config_*.json + presets.json 로더 → StockRule 리스트
 ├── core/
 │   ├── engine/          # base (MagicSplitEngine), registry
-│   ├── logic/           # split_evaluator (분할 매수/매도 판단)
+│   ├── logic/           # split_evaluator (분할 매수/매도, 트레일링 스톱, 동적 재매수)
 │   ├── interfaces.py    # 추상 인터페이스 정의
 │   └── models.py        # 도메인 모델 (PositionLot, StockRule, SplitSignal 등)
 ├── infra/
@@ -30,10 +35,16 @@ src/
 │   ├── data.py          # YFinanceLoader (선택적)
 │   ├── repo.py          # JsonRepository (positions.json, status.json, history.json)
 │   └── notifier.py      # SlackNotifier, TelegramNotifier
+├── backtest/            # runner, cache (parquet), fetcher (yfinance), components
 ├── utils/               # TradeLogger
+scripts/
+├── manual_trade.py      # Actions/CLI에서 수동 매수·매도 주문
+└── reconcile_positions.py  # 실계좌 잔고와 positions.json 정합
 tests/                   # 테스트 (80% 커버리지 요구)
-docs/                    # 웹 대시보드 및 데이터 저장
-config.json              # 종목별 매매 규칙 (GitHub Pages UI에서 수정)
+docs/                    # 웹 대시보드(GitHub Pages) + config-editor + data 저장
+config_domestic.json     # 국내 종목 매매 규칙
+config_overseas.json     # 해외 종목 매매 규칙
+presets.json             # 차수별 배열 공유 프리셋 (선택)
 ```
 
 ## 아키텍처 규칙
@@ -41,15 +52,29 @@ config.json              # 종목별 매매 규칙 (GitHub Pages UI에서 수정
 - core/interfaces.py에 정의된 추상 인터페이스를 통해 의존성 주입
 - 엔진 레지스트리 패턴: `@register_engine` 데코레이터로 엔진 등록
 - 단일 계좌: .env의 KIS 인증으로 국내/해외 브로커 각각 생성
-- 국내/해외 독립 운용: 별도 브로커, 저장소, 엔진 인스턴스로 완전 분리
+- 국내/해외 독립 운용: `CONFIG_JSON_PATH`로 어느 마켓을 돌릴지 선택, 별도 브로커·저장소·엔진 인스턴스로 완전 분리
 - 종목별 순차 실행: 평가 → 주문 → 포지션 반영 → 다음 종목
 
 ## 핵심 알고리즘 (MagicSplit)
-- 종목별 `config.json`에 정의된 매매 규칙(StockRule)에 따라 동작
-- 차수(Level) 시스템: 각 매수 건(PositionLot)에 level(1~100)을 부여하여 추적
+- 종목별 `config_domestic.json` / `config_overseas.json`에 정의된 매매 규칙(StockRule)에 따라 동작
+- 차수(Level) 시스템: 각 매수 건(PositionLot)에 level(1~max_lots)을 부여하여 추적
 - **마지막 차수만 평가**: 가장 높은 level의 매수가 대비 현재가 %로 판단
   - 상승 M% 이상 → 마지막 차수 매도 (차수 감소, 예: Lv3→Lv2가 마지막)
   - 하락 N% 이하 → 다음 차수 매수 (차수 증가, 예: Lv3→Lv4 추가)
+- **트레일링 스톱** (`trailing_drop_pct` 설정 시):
+  - 매도 임계치(`sell_threshold_pct`) 도달 시 활성화 → `trailing_highest_price` 추적 시작
+  - 이후 고점 갱신을 따라가며, 고점 대비 `trailing_drop_pct`% 하락하면 매도
+  - 최소 익절을 보장하면서 추가 상승분도 가져가는 구조
+- **동적 재매수 기준 (기준가 상향)**:
+  - 직전 매도가(last_sell_price)가 마지막 차수 매수가보다 높으면 매도가를 매수 기준으로 사용
+  - 트레일링 스톱으로 평소보다 높게 매도된 뒤, 원래 그리드까지 기다리지 않고 매도가 대비 하락 시 즉시 재매수
+- **재진입 가드** (`reentry_guard_pct`):
+  - 전량 청산 후 직전 매도가 대비 X% 하락해야 1차수 재진입 허용 (음수, 예: -0.1)
+  - None이면 가드 비활성 (다음 사이클 즉시 재진입 가능)
+- **차수별 배열 + presets.json**:
+  - `buy_threshold_pcts` / `sell_threshold_pcts` / `buy_amounts` / `trailing_drop_pcts` 배열로 차수마다 다른 임계치/금액 지정 가능
+  - 배열 길이가 차수보다 짧으면 마지막 값으로 clamp
+  - `presets.json`에 공통 설정을 정의하고 종목에서 `"preset": "이름"`으로 참조 (종목 필드가 preset을 override)
 - **한 사이클에 한 종목당 매도 OR 매수 중 하나만** 실행 (매도 우선)
 - 종목별 순차 실행: 한 종목 평가→주문→반영 후 다음 종목
 - 여러 종목 간 매도 신호를 먼저 실행한 후 매수 진행 (자금 부족 방지)
@@ -61,12 +86,17 @@ config.json              # 종목별 매매 규칙 (GitHub Pages UI에서 수정
 - `KIS_ACC_NO` - KIS 계좌번호
 - `IS_LIVE` - 실거래 여부 ("true" / "false", 기본값: "false")
 - `SLACK_WEBHOOK_URL` - Slack 알림
-- `CONFIG_JSON_PATH` - config.json 경로 (기본값: "config.json")
+- `CONFIG_JSON_PATH` - 매매 규칙 파일 경로 (기본값: `config_overseas.json`. 국내는 `config_domestic.json` 지정)
+- `PRESETS_JSON_PATH` - 프리셋 파일 경로 (선택, 기본은 config 파일과 같은 디렉토리의 `presets.json`)
 
 ## CI/CD
 GitHub Actions 워크플로우:
-- `python-test.yml` - main 브랜치 Push/PR 시 단위 테스트 (80% 커버리지 필수)
-- `trading-bot.yml` - 크론 스케줄: 매매 봇 자동 실행
+- `python-test.yml` - main 브랜치 Push/PR 시 단위 테스트 (80% 커버리지 필수, 실패 시 Slack 알림)
+- `trading-bot.yml` - 해외 매매 봇 (현재 스케줄 비활성, manual dispatch). `CONFIG_JSON_PATH=config_overseas.json`
+- `trading-bot-domestic.yml` - 국내 매매 봇 (현재 스케줄 비활성, manual dispatch). `CONFIG_JSON_PATH=config_domestic.json`
+- `manual-trade.yml` - Actions UI에서 수동 매수/매도 주문 (market_type, ticker, action, quantity 입력)
+- `run-backtest.yml` - 백테스트 실행 (시작/종료일, 초기 자본, 마켓 타입 선택). 결과를 `docs/data/backtest/`에 커밋
+- `download-market-data.yml` - yfinance로 종목 시세를 받아 `src/backtest/cache/`에 parquet 캐시로 커밋
 
 ## 워크플로우 규칙
 - 코드 수정 요청 시 작업 브랜치를 생성하여 커밋하고 PR 생성까지 완료한다

--- a/logs/backtest/2026-04-28_172104_overseas.log
+++ b/logs/backtest/2026-04-28_172104_overseas.log
@@ -1,0 +1,287 @@
+2026-04-28 17:21:04,627 [INFO] --- 데이터 다운로드: ['AAPL'] (2024-01-02 ~ 2024-01-15) ---
+2026-04-28 17:21:04,628 [INFO] --- 백테스트 시작 (10 거래일) ---
+2026-04-28 17:21:04,628 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,628 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,628 [INFO] Portfolio: Cash=$10,000, Value=$10,000
+2026-04-28 17:21:04,629 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,629 [INFO] Loaded 0 position lot(s)
+2026-04-28 17:21:04,629 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,629 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,629 [INFO] [AAPL] 보유 lot 없음 → 초기 매수 Lv1 5주 @$100.00
+2026-04-28 17:21:04,629 [INFO] Executing 1 order(s)...
+2026-04-28 17:21:04,629 [INFO] [FILLED] BUY AAPL: 5 @ $100.10 (Fee: $1.25)
+2026-04-28 17:21:04,629 [INFO] [Position] New lot: lot_20260428_172104_AAPL_001 Lv1 AAPL 5주 @$100.10
+2026-04-28 17:21:04,629 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,631 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,631 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,632 [INFO] Portfolio: Cash=$9,498, Value=$9,988
+2026-04-28 17:21:04,632 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,632 [INFO] Loaded 1 position lot(s)
+2026-04-28 17:21:04,632 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,632 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,632 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $98.00 (-2.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,632 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,633 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,633 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,634 [INFO] Portfolio: Cash=$9,498, Value=$9,978
+2026-04-28 17:21:04,634 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,634 [INFO] Loaded 1 position lot(s)
+2026-04-28 17:21:04,634 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,634 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,634 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $96.00 (-4.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,634 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,635 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,635 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,635 [INFO] Portfolio: Cash=$9,498, Value=$9,968
+2026-04-28 17:21:04,635 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,635 [INFO] Loaded 1 position lot(s)
+2026-04-28 17:21:04,636 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,636 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,636 [INFO] [AAPL] Lv1 매수가 $100.10 대비 -6.1% → 추가 매수 Lv2 5주 @$94.00
+2026-04-28 17:21:04,636 [INFO] Executing 1 order(s)...
+2026-04-28 17:21:04,636 [INFO] [FILLED] BUY AAPL: 5 @ $94.09 (Fee: $1.18)
+2026-04-28 17:21:04,636 [INFO] [Position] New lot: lot_20260428_172104_AAPL_002 Lv2 AAPL 5주 @$94.09
+2026-04-28 17:21:04,636 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,638 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,638 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,638 [INFO] Portfolio: Cash=$9,027, Value=$9,947
+2026-04-28 17:21:04,638 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,638 [INFO] Loaded 2 position lot(s)
+2026-04-28 17:21:04,638 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,639 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,639 [INFO]   [AAPL] 신호 없음 | Lv2 매수 $94.09 → 현재 $92.00 (-2.22%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,639 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,640 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,640 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,640 [INFO] Portfolio: Cash=$9,027, Value=$9,927
+2026-04-28 17:21:04,640 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,640 [INFO] Loaded 2 position lot(s)
+2026-04-28 17:21:04,640 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,640 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,641 [INFO]   [AAPL] 신호 없음 | Lv2 매수 $94.09 → 현재 $90.00 (-4.35%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,641 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,642 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,642 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,642 [INFO] Portfolio: Cash=$9,027, Value=$9,907
+2026-04-28 17:21:04,642 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,642 [INFO] Loaded 2 position lot(s)
+2026-04-28 17:21:04,642 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,642 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,642 [INFO] [AAPL] Lv2 매수가 $94.09 대비 -6.5% → 추가 매수 Lv3 5주 @$88.00
+2026-04-28 17:21:04,642 [INFO] Executing 1 order(s)...
+2026-04-28 17:21:04,643 [INFO] [FILLED] BUY AAPL: 5 @ $88.09 (Fee: $1.10)
+2026-04-28 17:21:04,643 [INFO] [Position] New lot: lot_20260428_172104_AAPL_003 Lv3 AAPL 5주 @$88.09
+2026-04-28 17:21:04,643 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,644 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,645 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,645 [INFO] Portfolio: Cash=$8,585, Value=$9,875
+2026-04-28 17:21:04,645 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,645 [INFO] Loaded 3 position lot(s)
+2026-04-28 17:21:04,645 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,645 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,645 [INFO]   [AAPL] 신호 없음 | Lv3 매수 $88.09 → 현재 $86.00 (-2.37%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,645 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,646 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,647 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,647 [INFO] Portfolio: Cash=$8,585, Value=$9,845
+2026-04-28 17:21:04,647 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,647 [INFO] Loaded 3 position lot(s)
+2026-04-28 17:21:04,647 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,647 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,647 [INFO]   [AAPL] 신호 없음 | Lv3 매수 $88.09 → 현재 $84.00 (-4.64%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,647 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,648 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,648 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,649 [INFO] Portfolio: Cash=$8,585, Value=$9,815
+2026-04-28 17:21:04,649 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,649 [INFO] Loaded 3 position lot(s)
+2026-04-28 17:21:04,649 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,649 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,649 [INFO] [AAPL] Lv3 매수가 $88.09 대비 -6.9% → 추가 매수 Lv4 6주 @$82.00
+2026-04-28 17:21:04,649 [INFO] Executing 1 order(s)...
+2026-04-28 17:21:04,649 [INFO] [FILLED] BUY AAPL: 6 @ $82.08 (Fee: $1.23)
+2026-04-28 17:21:04,649 [INFO] [Position] New lot: lot_20260428_172104_AAPL_004 Lv4 AAPL 6주 @$82.08
+2026-04-28 17:21:04,649 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,651 [INFO] --- 백테스트 완료 ---
+2026-04-28 17:21:04,651 [INFO] 최종: Cash=$8,091, Value=$9,813
+2026-04-28 17:21:04,654 [INFO] --- 데이터 다운로드: ['AAPL'] (2024-01-02 ~ 2024-01-08) ---
+2026-04-28 17:21:04,655 [INFO] --- 백테스트 시작 (5 거래일) ---
+2026-04-28 17:21:04,655 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,655 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,655 [INFO] Portfolio: Cash=$10,000, Value=$10,000
+2026-04-28 17:21:04,655 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,656 [INFO] Loaded 0 position lot(s)
+2026-04-28 17:21:04,656 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,656 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,656 [INFO] [AAPL] 보유 lot 없음 → 초기 매수 Lv1 5주 @$100.00
+2026-04-28 17:21:04,656 [INFO] Executing 1 order(s)...
+2026-04-28 17:21:04,656 [INFO] [FILLED] BUY AAPL: 5 @ $100.10 (Fee: $1.25)
+2026-04-28 17:21:04,656 [INFO] [Position] New lot: lot_20260428_172104_AAPL_001 Lv1 AAPL 5주 @$100.10
+2026-04-28 17:21:04,656 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,657 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,658 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,658 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-28 17:21:04,658 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,658 [INFO] Loaded 1 position lot(s)
+2026-04-28 17:21:04,658 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,658 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,658 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $100.00 (-0.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,658 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,659 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,660 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,660 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-28 17:21:04,660 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,660 [INFO] Loaded 1 position lot(s)
+2026-04-28 17:21:04,660 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,660 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,660 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $100.00 (-0.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,661 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,662 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,662 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,663 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-28 17:21:04,663 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,663 [INFO] Loaded 1 position lot(s)
+2026-04-28 17:21:04,663 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,663 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,663 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $100.00 (-0.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,663 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,664 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,664 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,664 [INFO] Portfolio: Cash=$9,498, Value=$9,998
+2026-04-28 17:21:04,664 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,664 [INFO] Loaded 1 position lot(s)
+2026-04-28 17:21:04,665 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,665 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,665 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $100.00 (-0.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,665 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,666 [INFO] --- 백테스트 완료 ---
+2026-04-28 17:21:04,666 [INFO] 최종: Cash=$9,498, Value=$9,998
+2026-04-28 17:21:04,668 [WARNING] 'overseas' 마켓에 해당하는 종목이 없습니다.
+2026-04-28 17:21:04,671 [INFO] --- 데이터 다운로드: ['AAPL', 'MSFT'] (2024-01-02 ~ 2024-01-15) ---
+2026-04-28 17:21:04,672 [INFO] --- 백테스트 시작 (10 거래일) ---
+2026-04-28 17:21:04,672 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,672 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,672 [INFO] Portfolio: Cash=$10,000, Value=$10,000
+2026-04-28 17:21:04,673 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,673 [INFO] Loaded 0 position lot(s)
+2026-04-28 17:21:04,673 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,673 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,673 [INFO] [AAPL] 보유 lot 없음 → 초기 매수 Lv1 3주 @$100.00
+2026-04-28 17:21:04,673 [INFO] Executing 1 order(s)...
+2026-04-28 17:21:04,673 [INFO] [FILLED] BUY AAPL: 3 @ $100.10 (Fee: $0.75)
+2026-04-28 17:21:04,673 [INFO] [Position] New lot: lot_20260428_172104_AAPL_001 Lv1 AAPL 3주 @$100.10
+2026-04-28 17:21:04,673 [INFO] >>> Processing MSFT
+2026-04-28 17:21:04,673 [INFO] [MSFT] 보유 lot 없음 → 초기 매수 Lv1 3주 @$100.00
+2026-04-28 17:21:04,673 [INFO] Executing 1 order(s)...
+2026-04-28 17:21:04,674 [INFO] [FILLED] BUY MSFT: 3 @ $100.10 (Fee: $0.75)
+2026-04-28 17:21:04,674 [INFO] [Position] New lot: lot_20260428_172104_MSFT_001 Lv1 MSFT 3주 @$100.10
+2026-04-28 17:21:04,674 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,676 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,676 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,676 [INFO] Portfolio: Cash=$9,398, Value=$9,992
+2026-04-28 17:21:04,676 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,676 [INFO] Loaded 2 position lot(s)
+2026-04-28 17:21:04,677 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,677 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,677 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $99.00 (-1.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,677 [INFO] >>> Processing MSFT
+2026-04-28 17:21:04,677 [INFO]   [MSFT] 신호 없음 | Lv1 매수 $100.10 → 현재 $99.00 (-1.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,677 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,678 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,678 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,678 [INFO] Portfolio: Cash=$9,398, Value=$9,986
+2026-04-28 17:21:04,679 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,679 [INFO] Loaded 2 position lot(s)
+2026-04-28 17:21:04,679 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,679 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,679 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $98.00 (-2.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,679 [INFO] >>> Processing MSFT
+2026-04-28 17:21:04,679 [INFO]   [MSFT] 신호 없음 | Lv1 매수 $100.10 → 현재 $98.00 (-2.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,679 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,680 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,681 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,681 [INFO] Portfolio: Cash=$9,398, Value=$9,980
+2026-04-28 17:21:04,681 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,681 [INFO] Loaded 2 position lot(s)
+2026-04-28 17:21:04,681 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,681 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,681 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $97.00 (-3.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,681 [INFO] >>> Processing MSFT
+2026-04-28 17:21:04,681 [INFO]   [MSFT] 신호 없음 | Lv1 매수 $100.10 → 현재 $97.00 (-3.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,681 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,683 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,683 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,683 [INFO] Portfolio: Cash=$9,398, Value=$9,974
+2026-04-28 17:21:04,683 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,683 [INFO] Loaded 2 position lot(s)
+2026-04-28 17:21:04,683 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,683 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,683 [INFO]   [AAPL] 신호 없음 | Lv1 매수 $100.10 → 현재 $96.00 (-4.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,684 [INFO] >>> Processing MSFT
+2026-04-28 17:21:04,684 [INFO]   [MSFT] 신호 없음 | Lv1 매수 $100.10 → 현재 $96.00 (-4.10%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,684 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,685 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,685 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,685 [INFO] Portfolio: Cash=$9,398, Value=$9,968
+2026-04-28 17:21:04,685 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,685 [INFO] Loaded 2 position lot(s)
+2026-04-28 17:21:04,685 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,685 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,686 [INFO] [AAPL] Lv1 매수가 $100.10 대비 -5.1% → 추가 매수 Lv2 3주 @$95.00
+2026-04-28 17:21:04,686 [INFO] Executing 1 order(s)...
+2026-04-28 17:21:04,686 [INFO] [FILLED] BUY AAPL: 3 @ $95.09 (Fee: $0.71)
+2026-04-28 17:21:04,686 [INFO] [Position] New lot: lot_20260428_172104_AAPL_002 Lv2 AAPL 3주 @$95.09
+2026-04-28 17:21:04,686 [INFO] >>> Processing MSFT
+2026-04-28 17:21:04,686 [INFO] [MSFT] Lv1 매수가 $100.10 대비 -5.1% → 추가 매수 Lv2 3주 @$95.00
+2026-04-28 17:21:04,686 [INFO] Executing 1 order(s)...
+2026-04-28 17:21:04,686 [INFO] [FILLED] BUY MSFT: 3 @ $95.09 (Fee: $0.71)
+2026-04-28 17:21:04,686 [INFO] [Position] New lot: lot_20260428_172104_MSFT_002 Lv2 MSFT 3주 @$95.09
+2026-04-28 17:21:04,687 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,688 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,689 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,689 [INFO] Portfolio: Cash=$8,826, Value=$9,954
+2026-04-28 17:21:04,689 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,689 [INFO] Loaded 4 position lot(s)
+2026-04-28 17:21:04,689 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,689 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,689 [INFO]   [AAPL] 신호 없음 | Lv2 매수 $95.09 → 현재 $94.00 (-1.15%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,689 [INFO] >>> Processing MSFT
+2026-04-28 17:21:04,689 [INFO]   [MSFT] 신호 없음 | Lv2 매수 $95.09 → 현재 $94.00 (-1.15%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,689 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,691 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,691 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,691 [INFO] Portfolio: Cash=$8,826, Value=$9,942
+2026-04-28 17:21:04,691 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,691 [INFO] Loaded 4 position lot(s)
+2026-04-28 17:21:04,691 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,691 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,691 [INFO]   [AAPL] 신호 없음 | Lv2 매수 $95.09 → 현재 $93.00 (-2.20%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,692 [INFO] >>> Processing MSFT
+2026-04-28 17:21:04,692 [INFO]   [MSFT] 신호 없음 | Lv2 매수 $95.09 → 현재 $93.00 (-2.20%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,692 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,693 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,693 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,693 [INFO] Portfolio: Cash=$8,826, Value=$9,930
+2026-04-28 17:21:04,693 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,693 [INFO] Loaded 4 position lot(s)
+2026-04-28 17:21:04,694 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,694 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,694 [INFO]   [AAPL] 신호 없음 | Lv2 매수 $95.09 → 현재 $92.00 (-3.25%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,694 [INFO] >>> Processing MSFT
+2026-04-28 17:21:04,694 [INFO]   [MSFT] 신호 없음 | Lv2 매수 $95.09 → 현재 $92.00 (-3.25%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,694 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,696 [INFO] >>> Step 1: Portfolio & Price Fetch
+2026-04-28 17:21:04,696 [INFO] Fetching real-time prices from Broker...
+2026-04-28 17:21:04,696 [INFO] Portfolio: Cash=$8,826, Value=$9,918
+2026-04-28 17:21:04,696 [INFO] >>> Step 2: Load Positions
+2026-04-28 17:21:04,696 [INFO] Loaded 4 position lot(s)
+2026-04-28 17:21:04,696 [INFO] >>> Step 2.5: Reconcile OK (수량 일치)
+2026-04-28 17:21:04,696 [INFO] >>> Processing AAPL
+2026-04-28 17:21:04,696 [INFO]   [AAPL] 신호 없음 | Lv2 매수 $95.09 → 현재 $91.00 (-4.30%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,696 [INFO] >>> Processing MSFT
+2026-04-28 17:21:04,696 [INFO]   [MSFT] 신호 없음 | Lv2 매수 $95.09 → 현재 $91.00 (-4.30%) | 익절 +10.0% / 추매 -5.0%
+2026-04-28 17:21:04,696 [INFO] >>> Step 6: Persist
+2026-04-28 17:21:04,698 [INFO] --- 백테스트 완료 ---
+2026-04-28 17:21:04,698 [INFO] 최종: Cash=$8,826, Value=$9,918
+2026-04-28 17:21:04,701 [INFO] --- 데이터 다운로드: ['AAPL'] (2024-01-02 ~ 2024-01-08) ---
+2026-04-28 17:21:04,702 [WARNING] 데이터 미수신 티커 ['AAPL'] — 백테스트를 중단합니다.

--- a/src/config.py
+++ b/src/config.py
@@ -39,8 +39,8 @@ class Config:
         # 알림
         self.SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL", "")
 
-        # 종목별 매매 규칙 설정 파일 경로
-        self.CONFIG_JSON_PATH = os.getenv("CONFIG_JSON_PATH", "config.json")
+        # 종목별 매매 규칙 설정 파일 경로 (국내/해외 분리: config_domestic.json | config_overseas.json)
+        self.CONFIG_JSON_PATH = os.getenv("CONFIG_JSON_PATH", "config_overseas.json")
 
         # 데이터 경로
         self.DATA_PATH = "docs/data"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,11 +4,13 @@ from src.config import Config, TICKER_EXCHANGE_MAP, EXCHANGE_CODE_SHORT_TO_FULL
 
 
 class TestConfig:
-    def test_default_values(self):
+    def test_default_values(self, monkeypatch):
+        monkeypatch.delenv("CONFIG_JSON_PATH", raising=False)
+        monkeypatch.delenv("IS_LIVE", raising=False)
         config = Config()
         assert config.DATA_PATH == "docs/data"
         assert config.LOG_PATH == "logs"
-        assert config.CONFIG_JSON_PATH == "config.json"
+        assert config.CONFIG_JSON_PATH == "config_overseas.json"
         assert config.MAX_HISTORY_RECORDS == 100000
         assert config.IS_LIVE is False
 


### PR DESCRIPTION
## Summary
- 트레일링 스톱, 동적 재매수(기준가 상향), 재진입 가드, 차수별 배열/`presets.json` 등 그동안 추가된 핵심 알고리즘 동작을 CLAUDE.md 알고리즘 섹션에 반영
- `config.json` 단일 파일 → `config_domestic.json` + `config_overseas.json` 분리 구조와 `CONFIG_JSON_PATH`로 어떤 마켓을 돌릴지 선택하는 운용 방식을 문서화
- CI/CD 섹션을 현재 워크플로우(test, trading-bot 국내/해외, manual-trade, run-backtest, download-market-data) 기준으로 갱신. `gdrive-sync.yml`은 코드와 무관해 제외
- 프로젝트 구조에 `src/backtest/`, `scripts/manual_trade.py`, `scripts/reconcile_positions.py`, `docs/config-editor.html` 등 추가
- 주요 명령어에 백테스트 / 수동 매매 / 포지션 정합 명령 추가
- `src/config.py`의 `CONFIG_JSON_PATH` 기본값을 더 이상 존재하지 않는 `config.json` → 실제 파일 `config_overseas.json` 으로 변경 (관련 테스트 갱신)
- 기술 스택에 `yfinance`, `pyarrow` 명시

## Test plan
- [x] `python -m pytest --cov=src --cov-report=term-missing --cov-fail-under=80 tests/` → 239 passed, coverage 89.77%
- [x] `tests/test_config.py::TestConfig::test_default_values` 가 새 기본값(`config_overseas.json`)을 검증


---
_Generated by [Claude Code](https://claude.ai/code/session_01LjsHfUtnaDng86L4F8on5y)_