### PR TITLE
🎨 Palette: [UX improvement] Apply KRX conventions and improve accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,1 @@
+- The site targets Korean users, so KRX color conventions (Red=Up, Blue=Down) are used for financial clarity.

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,8 +1,8 @@
 /* MagicSplit Dashboard Style */
 :root {
     --primary: #2563eb;
-    --success: #16a34a;
-    --danger: #dc2626;
+    --success: #dc2626;
+    --danger: #2563eb;
     --warning: #d97706;
     --bg: #f8fafc;
     --card-bg: #ffffff;

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -32,8 +32,21 @@
         document.getElementById('loading').style.display = 'none';
 
         // Status bar
-        document.getElementById('last-updated').textContent =
-            'Updated: ' + (data.last_updated || '-');
+        const updatedTime = data.last_updated || '-';
+        // Convert 'April 14, 2026 15:30 (KST)' into an ISO-like format if possible, otherwise use the string.
+        let isoTime = updatedTime;
+        try {
+            if (updatedTime !== '-') {
+                const parsedDate = new Date(updatedTime.replace(' (KST)', ' GMT+0900'));
+                if (!isNaN(parsedDate)) {
+                    isoTime = parsedDate.toISOString();
+                }
+            }
+        } catch (e) {
+            // fallback
+        }
+        document.getElementById('last-updated').innerHTML =
+            `Updated: <time datetime="${isoTime}">${updatedTime}</time>`;
         document.getElementById('total-value').textContent =
             formatCurrency(data.portfolio?.total_value || 0);
 
@@ -56,10 +69,12 @@
             for (const lot of lots) {
                 const pctClass = lot.pct_change >= 0 ? 'pct-positive' : 'pct-negative';
                 const pctStr = (lot.pct_change >= 0 ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const ariaLabel = lot.pct_change >= 0 ? `Profit of ${Math.abs(lot.pct_change).toFixed(1)}%` : `Loss of ${Math.abs(lot.pct_change).toFixed(1)}%`;
+                const arrow = lot.pct_change >= 0 ? '▲' : '▼';
                 lotsHtml += `
                     <li class="lot-item">
-                        <span>${lot.buy_date} | ${lot.quantity}shares @$${lot.buy_price.toFixed(2)}</span>
-                        <span class="${pctClass}">${pctStr}</span>
+                        <span>${lot.buy_date} | ${Number(lot.quantity).toLocaleString('en-US')} shares @$${lot.buy_price.toFixed(2)}</span>
+                        <span class="${pctClass}" aria-label="${ariaLabel}">${pctStr} <span aria-hidden="true">${arrow}</span></span>
                     </li>`;
             }
 


### PR DESCRIPTION
- Changed `--success` to Red (`#dc2626`) and `--danger` to Blue (`#2563eb`) in `style.css` to respect local KRX market conventions.
- Added localized comma formatting for share quantities in `main.js`.
- Added clear `aria-label` attributes indicating profit or loss in `main.js`.
- Added visually hidden arrow indicators to percentage elements for quick scannability.
- Added a `<time>` tag for the "Last Updated" timestamp, along with a valid ISO `datetime` format.
- Noted KRX color targeting in `.jules/palette.md` for future reference.

---
*PR created automatically by Jules for task [7058656712012518046](https://jules.google.com/task/7058656712012518046) started by @Junghyun99*