### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and direction arrows for accessibility

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -56,10 +56,13 @@
             for (const lot of lots) {
                 const pctClass = lot.pct_change >= 0 ? 'pct-positive' : 'pct-negative';
                 const pctStr = (lot.pct_change >= 0 ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const ariaLabel = lot.pct_change >= 0 ? `Profit of ${lot.pct_change.toFixed(1)}%` : `Loss of ${Math.abs(lot.pct_change).toFixed(1)}%`;
+                const icon = lot.pct_change >= 0 ? '<span aria-hidden="true">▲</span>' : '<span aria-hidden="true">▼</span>';
+
                 lotsHtml += `
                     <li class="lot-item">
-                        <span>${lot.buy_date} | ${lot.quantity}shares @$${lot.buy_price.toFixed(2)}</span>
-                        <span class="${pctClass}">${pctStr}</span>
+                        <span>${lot.buy_date} | ${lot.quantity} shares @ $${lot.buy_price.toFixed(2)}</span>
+                        <span class="${pctClass}" aria-label="${ariaLabel}">${pctStr} ${icon}</span>
                     </li>`;
             }
 


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add ARIA labels and direction arrows for accessibility

💡 What:
- Added semantic `aria-label`s to profit/loss indicators ("Profit of X%" or "Loss of Y%").
- Appended `▲` or `▼` icons to the percentage text with `aria-hidden="true"`.
- Improved formatting slightly by adding spaces around `@` and `shares`.

🎯 Why (Financial clarity):
- Ensure screen reader compatibility for visually impaired users.
- Provide clear visual cues for colorblind users by not solely relying on red/blue or red/green colors for profit and loss differentiation.
- Enhances visual clarity of data presented.

♿ Accessibility:
- Screen readers now properly read out profit/loss states explicitly instead of just percentages.
- Colorblind individuals immediately understand profit vs loss via symbols.

---
*PR created automatically by Jules for task [9997702502569582196](https://jules.google.com/task/9997702502569582196) started by @Junghyun99*