### PR TITLE
🎨 Palette: [UX improvement] Improve financial dashboard readability & accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,6 @@
+# Palette's Journal - Critical Learnings
+
+- **Vanilla JS**: The frontend for this dashboard is written in vanilla JavaScript (no React/Vue). Stick to standard DOM manipulation.
+- **Data Source**: It relies on pre-generated `status.json` and uses plain JavaScript `fetch`.
+- **Accessibility & UX**: Added ARIA labels (`aria-label="Profit of X%"`) to profit/loss indicators and visual markers like `▲`/`▼` to improve a11y and clarity beyond just colors. Always test colorblind-safe concepts or use extra semantic visual cues.
+- **Formatting**: Ensured proper spacing in quantities and prices for better readability.

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -55,11 +55,15 @@
             let lotsHtml = '';
             for (const lot of lots) {
                 const pctClass = lot.pct_change >= 0 ? 'pct-positive' : 'pct-negative';
-                const pctStr = (lot.pct_change >= 0 ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const isProfit = lot.pct_change >= 0;
+                const arrow = isProfit ? '<span aria-hidden="true">▲</span>' : '<span aria-hidden="true">▼</span>';
+                const ariaLabel = isProfit ? `Profit of ${lot.pct_change.toFixed(1)}%` : `Loss of ${Math.abs(lot.pct_change).toFixed(1)}%`;
+                const pctStr = (isProfit ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+
                 lotsHtml += `
                     <li class="lot-item">
-                        <span>${lot.buy_date} | ${lot.quantity}shares @$${lot.buy_price.toFixed(2)}</span>
-                        <span class="${pctClass}">${pctStr}</span>
+                        <span>${lot.buy_date} | ${lot.quantity} shares @ $${lot.buy_price.toFixed(2)}</span>
+                        <span class="${pctClass}" aria-label="${ariaLabel}">${pctStr} ${arrow}</span>
                     </li>`;
             }
 


### PR DESCRIPTION
This PR introduces a micro-UX improvement to the static trading dashboard in `docs/js/main.js`. It addresses accessibility by adding ARIA labels for screen readers indicating "Profit of X%" or "Loss of Y%". It also adds semantic arrows (`▲`/`▼`) with `aria-hidden="true"` alongside the percentage changes so positive/negative impact is legible even when colors are unreadable (improving colorblind friendliness). Additionally, string spacing in the purchase details was corrected to read cleanly (e.g. `X shares @ $Y`).

---
*PR created automatically by Jules for task [17502931130927465324](https://jules.google.com/task/17502931130927465324) started by @Junghyun99*