### PR TITLE
feat: ticker-map에서 ticker 파일 복사 워크플로우 추가

### DIFF
--- a/.github/workflows/copy-ticker-files.yml
+++ b/.github/workflows/copy-ticker-files.yml
@@ -1,0 +1,63 @@
+name: Copy Ticker Files from ticker-map
+
+on:
+  workflow_dispatch:
+    inputs:
+      ticker_map_ref:
+        description: 'ticker-map 브랜치 또는 태그 (기본: main)'
+        required: false
+        default: 'main'
+        type: string
+      skill_dest:
+        description: 'ticker-reader 스킬 복사 대상 경로'
+        required: false
+        default: '.claude/skills/ticker-reader'
+        type: string
+      utils_dest:
+        description: 'utils 파일 복사 대상 경로'
+        required: false
+        default: 'src/utils'
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  copy-ticker-files:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Create destination directories
+      run: |
+        mkdir -p "${{ inputs.skill_dest }}"
+        mkdir -p "${{ inputs.utils_dest }}"
+
+    - name: Download ticker-reader skill files
+      run: |
+        BASE="https://raw.githubusercontent.com/junghyun99/ticker-map/${{ inputs.ticker_map_ref }}"
+        curl -fsSL "$BASE/.claude/skills/ticker-reader/SKILL.md" \
+          -o "${{ inputs.skill_dest }}/SKILL.md"
+
+    - name: Download utils files
+      run: |
+        BASE="https://raw.githubusercontent.com/junghyun99/ticker-map/${{ inputs.ticker_map_ref }}"
+        curl -fsSL "$BASE/src/utils/ticker_reader.py" \
+          -o "${{ inputs.utils_dest }}/ticker_reader.py"
+        curl -fsSL "$BASE/src/utils/tickers.db" \
+          -o "${{ inputs.utils_dest }}/tickers.db"
+
+    - name: Commit and Push
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add "${{ inputs.skill_dest }}/SKILL.md"
+        git add "${{ inputs.utils_dest }}/ticker_reader.py"
+        git add "${{ inputs.utils_dest }}/tickers.db"
+        if git diff --cached --quiet; then
+          echo "변경 사항 없음 - 커밋 생략"
+        else
+          git commit -m "feat: sync ticker files from ticker-map@${{ inputs.ticker_map_ref }} [skip ci]"
+          git push
+        fi


### PR DESCRIPTION
## Summary\n\n- `ticker-map` 저장소의 파일을 MagicSplit으로 복사하는 수동 워크플로우 추가\n- 복사 대상: `.claude/skills/ticker-reader/SKILL.md`, `src/utils/ticker_reader.py`, `src/utils/tickers.db`\n\n## 사용법\n\nActions 탭 → **Copy Ticker Files from ticker-map** → **Run workflow**\n\n| 입력 | 기본값 | 설명 |\n|------|--------|------|\n| `ticker_map_ref` | `main` | ticker-map 브랜치 또는 태그 |\n| `skill_dest` | `.claude/skills/ticker-reader` | 스킬 파일 복사 대상 경로 |\n| `utils_dest` | `src/utils` | utils 파일 복사 대상 경로 |\n\n## Test plan\n\n- [ ] Actions 탭에서 워크플로우 수동 실행\n- [ ] 기본값으로 실행 시 파일 3개가 올바른 경로에 커밋되는지 확인\n- [ ] `skill_dest` / `utils_dest` 변경 시 지정 경로에 복사되는지 확인

---
_Generated by [Claude Code](https://claude.ai/code/session_011LXB5hEdqDhpPPhkT5u3Nc)_