### PR TITLE
🎨 Palette: [UX improvement] Apply KRX colors and A11y enhancements

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,8 +1,8 @@
 /* MagicSplit Dashboard Style */
 :root {
     --primary: #2563eb;
-    --success: #16a34a;
-    --danger: #dc2626;
+    --success: #dc2626;
+    --danger: #2563eb;
     --warning: #d97706;
     --bg: #f8fafc;
     --card-bg: #ffffff;

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -32,8 +32,9 @@
         document.getElementById('loading').style.display = 'none';
 
         // Status bar
-        document.getElementById('last-updated').textContent =
-            'Updated: ' + (data.last_updated || '-');
+        const updatedTime = data.last_updated || '-';
+        document.getElementById('last-updated').innerHTML =
+            `<time datetime="${updatedTime}">Updated: ${updatedTime}</time>`;
         document.getElementById('total-value').textContent =
             formatCurrency(data.portfolio?.total_value || 0);
 
@@ -54,12 +55,15 @@
             const lots = info.lots || [];
             let lotsHtml = '';
             for (const lot of lots) {
-                const pctClass = lot.pct_change >= 0 ? 'pct-positive' : 'pct-negative';
-                const pctStr = (lot.pct_change >= 0 ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const isPositive = lot.pct_change >= 0;
+                const pctClass = isPositive ? 'pct-positive' : 'pct-negative';
+                const arrow = isPositive ? '▲' : '▼';
+                const ariaLabel = isPositive ? `Profit of ${lot.pct_change.toFixed(1)}%` : `Loss of ${Math.abs(lot.pct_change).toFixed(1)}%`;
+                const pctStr = (isPositive ? '+' : '') + lot.pct_change.toFixed(1) + `% <span aria-hidden="true">${arrow}</span>`;
                 lotsHtml += `
                     <li class="lot-item">
-                        <span>${lot.buy_date} | ${lot.quantity}shares @$${lot.buy_price.toFixed(2)}</span>
-                        <span class="${pctClass}">${pctStr}</span>
+                        <span>${lot.buy_date} | ${lot.quantity} shares @$${lot.buy_price.toFixed(2)}</span>
+                        <span class="${pctClass}" aria-label="${ariaLabel}">${pctStr}</span>
                     </li>`;
             }
 


### PR DESCRIPTION
### 💡 What
This PR introduces ONE targeted micro-UX improvement centered around financial data readability and accessibility for the static dashboard.

### 🎯 Why (Financial clarity)
- Respects local market conventions (KRX: Red = Up/Profit, Blue = Down/Loss). This reduces cognitive friction for the target users of this repo (Korean users, utilizing `config_domestic.json` logic).
- Prevents ambiguity by complementing colors with distinct visual symbols (`▲` / `▼`) so users can parse profit/loss instantly without relying entirely on color vision.
- Using a semantic `<time>` tag correctly reflects the importance of timestamps for static, generated dashboards.

### 📸 Before/After Screenshots
*(Refer to frontend verification screenshots)*

### ♿ Accessibility
- Appended `aria-label` descriptions like "Profit of 15.5%" or "Loss of 1.2%" to ensure screen-readers properly communicate financial statuses instead of just raw positive/negative integers.
- Hid purely visual directional arrows (`▲` / `▼`) from screen readers with `aria-hidden="true"` to prevent stuttered reading behavior.

---
*PR created automatically by Jules for task [2433022237406645816](https://jules.google.com/task/2433022237406645816) started by @Junghyun99*