### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and visual arrows to profit/loss indicators

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+# Palette's Journal
+- This project uses vanilla JavaScript and static HTML/CSS files.
+- Added ARIA labels and visual up/down arrows to improve accessibility for financial profit/loss numbers.

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
         <span id="total-value">-</span>
     </div>
 
-    <div id="loading">Loading positions...</div>
+    <div id="loading" aria-live="polite">Loading positions...</div>
     <div id="positions-container"></div>
 
     <script src="js/main.js"></script>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -54,12 +54,16 @@
             const lots = info.lots || [];
             let lotsHtml = '';
             for (const lot of lots) {
-                const pctClass = lot.pct_change >= 0 ? 'pct-positive' : 'pct-negative';
-                const pctStr = (lot.pct_change >= 0 ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const isPositive = lot.pct_change >= 0;
+                const pctClass = isPositive ? 'pct-positive' : 'pct-negative';
+                const pctStr = (isPositive ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const ariaLabel = isPositive ? `Profit of ${lot.pct_change.toFixed(1)}%` : `Loss of ${Math.abs(lot.pct_change).toFixed(1)}%`;
+                const arrow = isPositive ? '<span aria-hidden="true">▲</span>' : '<span aria-hidden="true">▼</span>';
+
                 lotsHtml += `
                     <li class="lot-item">
                         <span>${lot.buy_date} | ${lot.quantity}shares @$${lot.buy_price.toFixed(2)}</span>
-                        <span class="${pctClass}">${pctStr}</span>
+                        <span class="${pctClass}" aria-label="${ariaLabel}">${pctStr} ${arrow}</span>
                     </li>`;
             }
 


### PR DESCRIPTION
Added a micro-UX enhancement by implementing ARIA labels to the profit/loss span in the frontend table and marking the loading div with `aria-live="polite"`. This adds better accessibility support for screen readers, and visual clarity with explicit arrows without changing any backend Python logic.

---
*PR created automatically by Jules for task [9453610420973698996](https://jules.google.com/task/9453610420973698996) started by @Junghyun99*