### PR TITLE
🎨 Palette: Improve accessibility and visual readability for profit/loss indicators

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -54,12 +54,18 @@
             const lots = info.lots || [];
             let lotsHtml = '';
             for (const lot of lots) {
-                const pctClass = lot.pct_change >= 0 ? 'pct-positive' : 'pct-negative';
-                const pctStr = (lot.pct_change >= 0 ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const isPositive = lot.pct_change >= 0;
+                const pctClass = isPositive ? 'pct-positive' : 'pct-negative';
+                const pctStr = (isPositive ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const arrow = isPositive ? '▲' : '▼';
+                const ariaLabel = (isPositive ? 'Profit of ' : 'Loss of ') + Math.abs(lot.pct_change).toFixed(1) + '%';
+
                 lotsHtml += `
                     <li class="lot-item">
-                        <span>${lot.buy_date} | ${lot.quantity}shares @$${lot.buy_price.toFixed(2)}</span>
-                        <span class="${pctClass}">${pctStr}</span>
+                        <span>${lot.buy_date} | ${lot.quantity} shares @$${lot.buy_price.toFixed(2)}</span>
+                        <span class="${pctClass}" aria-label="${ariaLabel}">
+                            ${pctStr} <span aria-hidden="true">${arrow}</span>
+                        </span>
                     </li>`;
             }
 


### PR DESCRIPTION
🎨 **Palette's Daily Enhancement: Financial Readability & Accessibility**

**💡 What:**
Added visual arrows (▲/▼) to the profit and loss percentages in the portfolio table. 
Added robust ARIA labels ("Profit of 15.5%", "Loss of 5.2%") so screen reader users don't just hear isolated, potentially confusing negative/positive numbers.
Improved spacing (`50 shares` instead of `50shares`).

**🎯 Why (Financial clarity):**
Financial data should be instantly readable at a glance without having to parse the meaning of a minus sign versus positive space. The directional arrows support users with color vision deficiencies who cannot rely on red/green colors alone to parse up/down.

**♿ Accessibility:**
The arrows are wrapped in `aria-hidden="true"` so they aren't redundantly read out loud, and a custom `aria-label` clearly announces "Profit of..." or "Loss of...", making the data table explicitly clear for non-visual users.

---
*PR created automatically by Jules for task [15815617252177858122](https://jules.google.com/task/15815617252177858122) started by @Junghyun99*