### PR TITLE
feat: market_type-aware currency display for logs and dashboard

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -101,16 +101,16 @@
 
     <script src="js/utils/format-utils.js?v=20260505-2"></script>
     <script src="js/services/data-repository.js?v=20260505-2"></script>
-    <script src="js/models/dashboard-model.js?v=20260505-2"></script>
+    <script src="js/models/dashboard-model.js?v=20260508-1"></script>
     <script src="js/models/history-model.js?v=20260505-2"></script>
     <script src="js/models/decision-model.js?v=20260505-2"></script>
-    <script src="js/views/dashboard-view.js?v=20260505-2"></script>
+    <script src="js/views/dashboard-view.js?v=20260508-1"></script>
     <script src="js/views/history-view.js?v=20260505-2"></script>
     <script src="js/views/decision-view.js?v=20260505-2"></script>
-    <script src="js/views/charts-view.js?v=20260505-2"></script>
+    <script src="js/views/charts-view.js?v=20260508-1"></script>
     <script src="js/views/risk-view.js?v=20260506-1"></script>
-    <script src="js/controllers/dashboard-controller.js?v=20260505-2"></script>
-    <script src="js/controllers/risk-controller.js?v=20260506-1"></script>
+    <script src="js/controllers/dashboard-controller.js?v=20260508-1"></script>
+    <script src="js/controllers/risk-controller.js?v=20260508-1"></script>
     <script src="js/main.js?v=20260505-2"></script>
 </body>
 </html>

--- a/docs/js/controllers/dashboard-controller.js
+++ b/docs/js/controllers/dashboard-controller.js
@@ -23,18 +23,21 @@ window.DashboardController = (function () {
         if (isRefreshing || document.visibilityState === 'hidden') return;
         isRefreshing = true;
         const mode = DashboardModel.getMode();
-        
+
         try {
             const data = await DataRepository.loadStatus(mode);
             DashboardModel.setStatusData(data);
-            
+
+            // setStatusData 호출 후에 결정해야 backtest 모드의 market_type이 반영된다.
+            const currencyMode = DashboardModel.getCurrencyMode();
+
             if (data) {
                 lastRefreshTime = Date.now();
                 DashboardView.updateRefreshAge(lastRefreshTime);
                 DashboardView.setOfflineBadge(false);
-                
+
                 const summary = DashboardModel.getPortfolioSummary();
-                DashboardView.renderStatus(data, mode, summary);
+                DashboardView.renderStatus(data, currencyMode, summary);
                 
                 const reasonType = DashboardModel.classifyReason(data.reason);
                 DashboardView.renderReasonBanner(data.reason, data.last_run_date, reasonType);
@@ -67,12 +70,12 @@ window.DashboardController = (function () {
     }
 
     function renderHistoryView() {
-        const mode = DashboardModel.getMode();
+        const currencyMode = DashboardModel.getCurrencyMode();
         const hasData = HistoryModel.getTotalCount() > 0;
-        
+
         if (hasData) {
             const pts = HistoryModel.buildEquityPoints(DashboardModel.getHistoryData());
-            ChartsView.renderEquityCurve(pts, mode, DashboardView.formatCurrency);
+            ChartsView.renderEquityCurve(pts, currencyMode, DashboardView.formatCurrency);
         } else {
             // Hide equity curve if no data
             const equitySection = document.getElementById('equity-curve-section');
@@ -81,7 +84,7 @@ window.DashboardController = (function () {
 
         HistoryModel.resetPagination();
         const firstPage = HistoryModel.getNextPage();
-        HistoryView.renderPage(firstPage, true, HistoryModel.hasMore(), DashboardView.formatCurrency, mode);
+        HistoryView.renderPage(firstPage, true, HistoryModel.hasMore(), DashboardView.formatCurrency, currencyMode);
     }
 
     function setAutoRefresh(intervalMs) {
@@ -119,7 +122,7 @@ window.DashboardController = (function () {
         if (moreBtn) {
             moreBtn.addEventListener('click', () => {
                 const page = HistoryModel.getNextPage();
-                HistoryView.renderPage(page, false, HistoryModel.hasMore(), DashboardView.formatCurrency, DashboardModel.getMode());
+                HistoryView.renderPage(page, false, HistoryModel.hasMore(), DashboardView.formatCurrency, DashboardModel.getCurrencyMode());
             });
         }
     }
@@ -134,7 +137,7 @@ window.DashboardController = (function () {
                     HistoryView.renderFilters(tickers, (type, value) => {
                         HistoryModel.setFilter(type, value);
                         const firstPage = HistoryModel.getNextPage();
-                        HistoryView.renderPage(firstPage, true, HistoryModel.hasMore(), DashboardView.formatCurrency, DashboardModel.getMode());
+                        HistoryView.renderPage(firstPage, true, HistoryModel.hasMore(), DashboardView.formatCurrency, DashboardModel.getCurrencyMode());
                     });
                     
                     renderHistoryView();
@@ -153,14 +156,14 @@ window.DashboardController = (function () {
         HistoryView.renderFilters(tickers, (type, value) => {
             HistoryModel.setFilter(type, value);
             const firstPage = HistoryModel.getNextPage();
-            HistoryView.renderPage(firstPage, true, HistoryModel.hasMore(), DashboardView.formatCurrency, DashboardModel.getMode());
+            HistoryView.renderPage(firstPage, true, HistoryModel.hasMore(), DashboardView.formatCurrency, DashboardModel.getCurrencyMode());
         });
         
         const tickerFilter = document.getElementById('history-ticker-filter');
         if (tickerFilter) tickerFilter.value = ticker;
         HistoryModel.setFilter('ticker', ticker);
         const firstPage = HistoryModel.getNextPage();
-        HistoryView.renderPage(firstPage, true, HistoryModel.hasMore(), DashboardView.formatCurrency, DashboardModel.getMode());
+        HistoryView.renderPage(firstPage, true, HistoryModel.hasMore(), DashboardView.formatCurrency, DashboardModel.getCurrencyMode());
         renderHistoryView();
     }
 

--- a/docs/js/controllers/risk-controller.js
+++ b/docs/js/controllers/risk-controller.js
@@ -4,8 +4,8 @@ window.RiskController = (function () {
 
     function renderRisk() {
         const metrics = window.DashboardModel.calculateRiskMetrics();
-        const mode = window.DashboardModel.getMode();
-        
+        const currencyMode = window.DashboardModel.getCurrencyMode();
+
         if (!metrics) {
             return;
         }
@@ -13,14 +13,14 @@ window.RiskController = (function () {
         window.RiskView.renderRiskHealth(metrics.riskSummary);
         window.RiskView.renderAlerts(metrics.riskSummary.alerts, metrics.riskSummary.sync_error);
 
-        window.RiskView.renderCashRatio(metrics.cashRatio, mode);
+        window.RiskView.renderCashRatio(metrics.cashRatio, currencyMode);
         window.RiskView.renderNextLevelNeeds(
-            metrics.nextLevelNeeds, 
-            metrics.maxPotentialExposure, 
+            metrics.nextLevelNeeds,
+            metrics.maxPotentialExposure,
             metrics.totalValue - (metrics.cashRatio * metrics.totalValue / 100),
-            mode
+            currencyMode
         );
-        window.RiskView.renderTickerConcentration(metrics.tickerConcentration, mode);
+        window.RiskView.renderTickerConcentration(metrics.tickerConcentration, currencyMode);
         window.RiskView.renderLevelDist(metrics.levelDist);
         window.RiskView.renderStalePositions(metrics.staleInfo);
     }

--- a/docs/js/manual-trade.js
+++ b/docs/js/manual-trade.js
@@ -26,6 +26,17 @@
 
     let activeOrderParams = null; // { ticker, alias, action, marketType }
 
+    /** market_type에 맞춰 통화 단위와 함께 금액을 포매팅한다. */
+    function formatAmount(value, marketType) {
+        const isDomestic = marketType === 'domestic';
+        return new Intl.NumberFormat(isDomestic ? 'ko-KR' : 'en-US', {
+            style: 'currency',
+            currency: isDomestic ? 'KRW' : 'USD',
+            minimumFractionDigits: isDomestic ? 0 : 2,
+            maximumFractionDigits: isDomestic ? 0 : 2,
+        }).format(Number(value));
+    }
+
     // Init
     async function init() {
         loadSettings();
@@ -224,7 +235,7 @@
             const lvAmount = tickerObj.config.buy_amounts && tickerObj.config.buy_amounts[nextLv - 1];
             const defaultAmt = lvAmount || tickerObj.config.buy_amount || 0;
             orderValue.value = defaultAmt;
-            inputHint.textContent = `현재 ${tickerObj.currentLevel}차 -> ${nextLv}차 매수 설정값: ${defaultAmt.toLocaleString()}`;
+            inputHint.textContent = `현재 ${tickerObj.currentLevel}차 -> ${nextLv}차 매수 설정값: ${formatAmount(defaultAmt, currentMarket)}`;
         } else {
             inputLabel.textContent = '매도 수량 (주)';
             // Find qty of highest level
@@ -247,8 +258,9 @@
             return;
         }
 
-        const unit = activeOrderParams.action === 'buy' ? (currentMarket === 'domestic' ? '원' : '$') : '주';
-        if (!confirm(`${activeOrderParams.alias} 종목을 ${val.toLocaleString()}${unit} ${activeOrderParams.action === 'buy' ? '매수' : '매도'} 하시겠습니까?`)) {
+        const isBuy = activeOrderParams.action === 'buy';
+        const valDisplay = isBuy ? formatAmount(val, currentMarket) : `${val.toLocaleString()}주`;
+        if (!confirm(`${activeOrderParams.alias} 종목을 ${valDisplay} ${isBuy ? '매수' : '매도'} 하시겠습니까?`)) {
             return;
         }
 

--- a/docs/js/models/dashboard-model.js
+++ b/docs/js/models/dashboard-model.js
@@ -21,6 +21,18 @@ window.DashboardModel = (function () {
         return currentMode;
     }
 
+    /**
+     * 금액 포매팅에 사용할 통화 모드.
+     * - domestic/overseas: 그대로 반환
+     * - backtest: status.json의 market_type 필드를 우선 사용 (없으면 'overseas')
+     */
+    function getCurrencyMode() {
+        if (currentMode === 'backtest') {
+            return (statusData && statusData.market_type) || 'overseas';
+        }
+        return currentMode;
+    }
+
     function setStatusData(data) {
         statusData = data;
     }
@@ -233,6 +245,7 @@ window.DashboardModel = (function () {
         getValidMode,
         setMode,
         getMode,
+        getCurrencyMode,
         setStatusData,
         getStatusData,
         setHistoryData,

--- a/docs/js/views/charts-view.js
+++ b/docs/js/views/charts-view.js
@@ -147,9 +147,18 @@ window.ChartsView = (function () {
         }).join('');
 
         const yTickValues = [rawMin, (rawMin + rawMax) / 2, rawMax];
+        // KRW는 자릿수가 커서 K/M 단위로 압축, USD는 통화 심볼 그대로 노출.
+        const compactLabel = (v) => {
+            const abs = Math.abs(v);
+            if (abs >= 1_000_000_000) return (v / 1_000_000_000).toFixed(1) + 'B';
+            if (abs >= 1_000_000) return (v / 1_000_000).toFixed(1) + 'M';
+            if (abs >= 1_000) return (v / 1_000).toFixed(1) + 'K';
+            return v.toFixed(mode === 'domestic' ? 0 : 2);
+        };
+        const currencySymbol = mode === 'domestic' ? '₩' : '$';
         const yLabelHtml = yTickValues.map(v => {
             const y = yScale(v).toFixed(1);
-            const label = Math.abs(v) >= 1000 ? (v / 1000).toFixed(1) + 'K' : v.toFixed(0);
+            const label = currencySymbol + compactLabel(v);
             return `<text x="${PAD.left - 5}" y="${y}" text-anchor="end" dominant-baseline="middle" class="ec-axis">${esc(label)}</text>`;
         }).join('');
 

--- a/docs/js/views/dashboard-view.js
+++ b/docs/js/views/dashboard-view.js
@@ -182,7 +182,7 @@ window.DashboardView = (function () {
                 lotsHtml += `
                     <li class="lot-item">
                         ${lvLabel}
-                        <span class="lot-detail">${lot.buy_date} | ${lot.quantity}shares @$${lot.buy_price.toFixed(2)}</span>
+                        <span class="lot-detail">${lot.buy_date} | ${lot.quantity}shares @${formatCurrency(lot.buy_price, mode)}</span>
                         <span class="${pctClass}">${pctStr}</span>
                     </li>`;
             }

--- a/docs/manual-trade.html
+++ b/docs/manual-trade.html
@@ -254,7 +254,7 @@
 
     <script src="js/services/data-repository.js?v=20260508-1"></script>
     <script src="js/services/github-api.js?v=20260508-1"></script>
-    <script src="js/manual-trade.js?v=20260508-1"></script>
+    <script src="js/manual-trade.js?v=20260508-2"></script>
 </body>
 
 </html>

--- a/scripts/manual_trade.py
+++ b/scripts/manual_trade.py
@@ -19,6 +19,7 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
 from src.config import Config
 from src.strategy_config import StrategyConfig
 from src.utils.logger import TradeLogger
+from src.utils.currency import format_money
 from src.core.models import Order, OrderAction, PositionLot, ExecutionStatus, SplitSignal
 from src.main import _create_broker
 from src.infra.repo import JsonRepository
@@ -77,7 +78,11 @@ def main():
         
         current_price = prices[args.ticker]
         order_qty = int(args.amount / current_price)
-        logger.info(f"금액 기반 수량 계산: {args.amount} / {current_price} = {order_qty}주")
+        logger.info(
+            f"금액 기반 수량 계산: "
+            f"{format_money(args.amount, market_type)} / "
+            f"{format_money(current_price, market_type)} = {order_qty}주"
+        )
         
         if order_qty <= 0:
             logger.error(f"계산된 수량이 0입니다. 금액({args.amount})이 너무 적습니다.")
@@ -142,7 +147,10 @@ def main():
         logger.error(f"알 수 없는 주문 상태({execution.status})입니다. 안전을 위해 장부를 업데이트하지 않습니다.")
         sys.exit(1)
 
-    logger.info(f"주문 체결 완료! (가격: {execution.price}, 수량: {execution.quantity})")
+    logger.info(
+        f"주문 체결 완료! "
+        f"(가격: {format_money(execution.price, market_type)}, 수량: {execution.quantity})"
+    )
 
     # 7. 포지션(positions.json) 업데이트
     updated_positions = list(positions)
@@ -159,7 +167,10 @@ def main():
             level=level,
         )
         updated_positions.append(new_lot)
-        logger.info(f"[Position] New lot 추가됨: Lv{level} / {execution.quantity}주 @ {execution.price}")
+        logger.info(
+            f"[Position] New lot 추가됨: Lv{level} / {execution.quantity}주 "
+            f"@ {format_money(execution.price, market_type)}"
+        )
     else:
         # 매도 처리 로직: 높은 차수(가장 최근에 물타기한 것)부터 우선적으로 팔도록 레벨 역순 정렬
         target_lots = sorted(

--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -9,6 +9,7 @@ from src.core.models import DayResult
 from src.core.engine.base import MagicSplitEngine
 from src.infra.repo import JsonRepository
 from src.utils.logger import TradeLogger
+from src.utils.currency import format_money
 from src.strategy_config import StrategyConfig
 from src.backtest.fetcher import download_historical_data
 from src.backtest.components import BacktestBroker
@@ -133,8 +134,8 @@ def run_backtest(
     if last_result:
         pf = last_result.final_portfolio
         logger.info(
-            f"최종: Cash=${pf.total_cash:,.0f}, "
-            f"Value=${pf.total_value:,.0f}"
+            f"최종: Cash={format_money(pf.total_cash, market_type)}, "
+            f"Value={format_money(pf.total_value, market_type)}"
         )
 
     return last_result

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -20,6 +20,7 @@ from src.core.models import (
 from src.core.logic import SplitEvaluator, detect_mismatches, build_dashboard_status
 from src.core.engine.registry import register_engine
 from src.utils.ticker_reader import display_ticker
+from src.utils.currency import format_money
 
 
 @register_engine(color="#1f77b4")
@@ -50,6 +51,8 @@ class MagicSplitEngine:
         self.all_tickers = [r.ticker for r in self.stock_rules]
         self.notifier = notifier
         self.is_live_trading = is_live_trading
+        # 한 사이클의 모든 종목은 동일 market_type. 로그 통화 분기에 사용.
+        self.market_type = self.stock_rules[0].market_type if self.stock_rules else "overseas"
 
     def run_one_cycle(self, sim_date: Optional[str] = None) -> DayResult:
         """하루치 매매 사이클 전체를 실행한다.
@@ -76,8 +79,8 @@ class MagicSplitEngine:
             self.logger.info(">>> Step 1: Portfolio & Price Fetch")
             portfolio = self.get_portfolio()
             self.logger.info(
-                f"Portfolio: Cash=${portfolio.total_cash:,.0f}, "
-                f"Value=${portfolio.total_value:,.0f}"
+                f"Portfolio: Cash={format_money(portfolio.total_cash, self.market_type)}, "
+                f"Value={format_money(portfolio.total_value, self.market_type)}"
             )
 
             # Step 2: 기존 분할 포지션 로드
@@ -207,7 +210,8 @@ class MagicSplitEngine:
             )
         elif portfolio is not None:
             self._notify_message(
-                f"모니터링 완료. 신호 없음 | ${portfolio.total_value:,.0f}"
+                f"모니터링 완료. 신호 없음 | "
+                f"{format_money(portfolio.total_value, self.market_type)}"
                 f"{reject_suffix}{fail_suffix}"
             )
         else:
@@ -316,14 +320,14 @@ class MagicSplitEngine:
         if not ticker_lots:
             msg = (
                 f"  [{disp}] 신호 없음 | 보유 없음, "
-                f"현재 ${current_price:,.2f} (1차 진입 대기)"
+                f"현재 {format_money(current_price, rule.market_type)} (1차 진입 대기)"
             )
             last_sell = last_sell_prices.get(ticker) if last_sell_prices else None
             if last_sell and last_sell > 0 and rule.reentry_guard_pct is not None:
                 pct_from_sell = (current_price - last_sell) / last_sell * 100
                 msg += (
-                    f" | 직전 매도가 ${last_sell:,.2f} 대비 {pct_from_sell:+.2f}% "
-                    f"(가드 {rule.reentry_guard_pct:+.2f}%)"
+                    f" | 직전 매도가 {format_money(last_sell, rule.market_type)} 대비 "
+                    f"{pct_from_sell:+.2f}% (가드 {rule.reentry_guard_pct:+.2f}%)"
                 )
             self.logger.info(msg)
             return
@@ -336,7 +340,8 @@ class MagicSplitEngine:
 
         msg = (
             f"  [{disp}] 신호 없음 | Lv{last_lot.level} "
-            f"매수 ${last_lot.buy_price:,.2f} -> 현재 ${current_price:,.2f} "
+            f"매수 {format_money(last_lot.buy_price, rule.market_type)} -> "
+            f"현재 {format_money(current_price, rule.market_type)} "
             f"({profit_pct:+.2f}%) | 익절 +{sell_threshold:.1f}% / "
             f"추매 {buy_threshold:.1f}%"
         )
@@ -425,13 +430,13 @@ class MagicSplitEngine:
                 if last_sell_prices is not None and exe.ticker in last_sell_prices:
                     self.logger.info(
                         f"[{disp}] 동적 재매수 기준 초기화 "
-                        f"(매도가 ${last_sell_prices[exe.ticker]:.2f} -> 소비됨)"
+                        f"(매도가 {format_money(last_sell_prices[exe.ticker], self.market_type)} -> 소비됨)"
                     )
                     del last_sell_prices[exe.ticker]
                 tag = " (PARTIAL)" if exe.status == ExecutionStatus.PARTIAL else ""
                 self.logger.info(
                     f"[Position] New lot{tag}: {lot_id} Lv{level} "
-                    f"{disp} {exe.quantity}주 @${exe.price:.2f}"
+                    f"{disp} {exe.quantity}주 @{format_money(exe.price, self.market_type)}"
                 )
 
             elif exe.action == OrderAction.SELL:
@@ -522,7 +527,8 @@ class MagicSplitEngine:
         last_trade_dates = self.repo.get_last_trade_dates()
         status_data = build_dashboard_status(
             portfolio, positions, reason, old_realized_pnl, executions,
-            self.all_tickers, sim_date, self.stock_rules, last_trade_dates
+            self.all_tickers, sim_date, self.stock_rules, last_trade_dates,
+            market_type=self.market_type,
         )
         self.repo.save_status(status_data)
 
@@ -558,16 +564,18 @@ class MagicSplitEngine:
                     if ticker in last_sell_prices:
                         old_val = last_sell_prices.pop(ticker)
                         self.logger.info(
-                            f"[{ticker}] OFF->ON 전환 감지: 0주 상태이므로 직전 매도가(${old_val:.2f}) 초기화"
+                            f"[{ticker}] OFF->ON 전환 감지: 0주 상태이므로 "
+                            f"직전 매도가({format_money(old_val, self.market_type)}) 초기화"
                         )
-                    
+
                     # 실현 손익 초기화 (새 시즌)
                     realized_pnls = prev_status.setdefault("realized_pnl_by_ticker", {})
                     if realized_pnls.get(ticker, 0.0) != 0.0:
                         old_pnl = realized_pnls[ticker]
                         realized_pnls[ticker] = 0.0
                         self.logger.info(
-                            f"[{ticker}] OFF->ON 전환 감지: 0주 상태이므로 누적 실현 손익(${old_pnl:,.2f}) 초기화"
+                            f"[{ticker}] OFF->ON 전환 감지: 0주 상태이므로 "
+                            f"누적 실현 손익({format_money(old_pnl, self.market_type)}) 초기화"
                         )
                 
                 # B. 보유 수량이 있는 경우 -> 트레일링 최고가 초기화 (현재가부터 다시 추적)

--- a/src/core/logic/split_evaluator.py
+++ b/src/core/logic/split_evaluator.py
@@ -11,6 +11,7 @@ from src.core.models import (
     OrderAction,
 )
 from src.utils.ticker_reader import display_ticker
+from src.utils.currency import format_money
 
 
 class SplitEvaluator:
@@ -167,25 +168,26 @@ class SplitEvaluator:
                                 f"[{display_ticker(rule.ticker)}] Lv{last_lot.level}: "
                                 f"트레일링 스톱 활성화 "
                                 f"(매도조건 +{sell_threshold:.0f}% 도달, "
-                                f"현재가 ${current_price:,.0f}, "
-                                f"스톱가 ${stop_price:,.0f}, "
+                                f"현재가 {format_money(current_price, rule.market_type)}, "
+                                f"스톱가 {format_money(stop_price, rule.market_type)}, "
                                 f"하락허용 {trailing_drop}%)"
                             )
                         else:
                             self._logger.info(
                                 f"[{display_ticker(rule.ticker)}] Lv{last_lot.level}: "
                                 f"트레일링 고점 갱신 "
-                                f"${old_highest:,.0f} -> ${current_price:,.0f} "
+                                f"{format_money(old_highest, rule.market_type)} -> "
+                                f"{format_money(current_price, rule.market_type)} "
                                 f"(매수가 대비 {pct_change:+.1f}%, "
-                                f"스톱가 ${stop_price:,.0f})"
+                                f"스톱가 {format_money(stop_price, rule.market_type)})"
                             )
                     # 최초 활성화 시 정보성 알림 신호 생성
                     if was_inactive:
                         info_reason = (
-                            f"Lv{last_lot.level}: 트레일링 스톱 활성화 — "
-                            f"현재가 ${current_price:,.0f} "
+                            f"Lv{last_lot.level}: 트레일링 스톱 활성화 - "
+                            f"현재가 {format_money(current_price, rule.market_type)} "
                             f"(매수가 대비 {pct_change:+.1f}%), "
-                            f"스톱가 ${stop_price:,.0f}"
+                            f"스톱가 {format_money(stop_price, rule.market_type)}"
                         )
                         self._trailing_info_signal = SplitSignal(
                             ticker=rule.ticker,
@@ -206,11 +208,11 @@ class SplitEvaluator:
                     if self._logger:
                         self._logger.info(
                             f"[{display_ticker(rule.ticker)}] Lv{last_lot.level}: "
-                            f"⏳ 트레일링 추적 중 "
-                            f"(현재가 ${current_price:,.0f}, "
-                            f"고점 ${last_lot.trailing_highest_price:,.0f}, "
+                            f"트레일링 추적 중 "
+                            f"(현재가 {format_money(current_price, rule.market_type)}, "
+                            f"고점 {format_money(last_lot.trailing_highest_price, rule.market_type)}, "
                             f"고점대비 -{drop_pct_now:.1f}%, "
-                            f"스톱가 ${stop_price:,.0f})"
+                            f"스톱가 {format_money(stop_price, rule.market_type)})"
                         )
 
                 # 3. 고점 대비 하락폭 계산
@@ -222,10 +224,10 @@ class SplitEvaluator:
                     if self._logger:
                         self._logger.info(
                             f"[{display_ticker(rule.ticker)}] Lv{last_lot.level}: "
-                            f"🔻 트레일링 스톱 매도 "
-                            f"(매수가 ${last_lot.buy_price:,.0f} -> "
-                            f"고점 ${last_lot.trailing_highest_price:,.0f} -> "
-                            f"현재가 ${current_price:,.0f}, "
+                            f"트레일링 스톱 매도 "
+                            f"(매수가 {format_money(last_lot.buy_price, rule.market_type)} -> "
+                            f"고점 {format_money(last_lot.trailing_highest_price, rule.market_type)} -> "
+                            f"현재가 {format_money(current_price, rule.market_type)}, "
                             f"고점대비 -{drop_pct:.1f}%, "
                             f"수익률 {profit_pct:+.1f}%)"
                         )
@@ -246,8 +248,10 @@ class SplitEvaluator:
             if pct_change >= sell_threshold:
                 if self._logger:
                     self._logger.info(
-                        f"[{display_ticker(rule.ticker)}] Lv{last_lot.level}: 매수가 ${last_lot.buy_price:.2f} -> "
-                        f"현재가 ${current_price:.2f} ({pct_change:+.1f}%) -> 익절 매도"
+                        f"[{display_ticker(rule.ticker)}] Lv{last_lot.level}: "
+                        f"매수가 {format_money(last_lot.buy_price, rule.market_type)} -> "
+                        f"현재가 {format_money(current_price, rule.market_type)} "
+                        f"({pct_change:+.1f}%) -> 익절 매도"
                     )
                 return SplitSignal(
                     ticker=rule.ticker,
@@ -288,8 +292,8 @@ class SplitEvaluator:
         buy_qty = math.floor(buy_amount / current_price)
         if buy_qty <= 0:
             reason = (
-                f"buy_amount(${buy_amount:.2f}) < "
-                f"현재가(${current_price:.2f}) -> 1주도 매수 불가. "
+                f"buy_amount({format_money(buy_amount, rule.market_type)}) < "
+                f"현재가({format_money(current_price, rule.market_type)}) -> 1주도 매수 불가. "
                 f"buy_amount 상향 조정 필요"
             )
             if self._logger:
@@ -342,7 +346,8 @@ class SplitEvaluator:
 
         if self._logger:
             self._logger.info(
-                f"[{display_ticker(rule.ticker)}] 보유 lot 없음 -> 초기 매수 Lv1 {buy_qty}주 @${current_price:.2f}"
+                f"[{display_ticker(rule.ticker)}] 보유 lot 없음 -> "
+                f"초기 매수 Lv1 {buy_qty}주 @{format_money(current_price, rule.market_type)}"
             )
         return SplitSignal(
             ticker=rule.ticker,
@@ -386,17 +391,18 @@ class SplitEvaluator:
         if abs(pct_from_sell) >= self.price_anomaly_threshold:
             reason = (
                 f"가격 이격 과다({pct_from_sell:+.1f}%): 액면분할/병합 확인 필요 "
-                f"(직전매도 ${last_sell_price:.2f} vs 현재 ${current_price:.2f})"
+                f"(직전매도 {format_money(last_sell_price, rule.market_type)} "
+                f"vs 현재 {format_money(current_price, rule.market_type)})"
             )
             if self._logger:
-                self._logger.warning(f"[{rule.ticker}] ⚠️ {reason}")
+                self._logger.warning(f"[{rule.ticker}] {reason}")
             return False, reason
 
         if pct_from_sell <= rule.reentry_guard_pct:
             return True, ""
 
         reason = (
-            f"재진입 가드: 직전 매도가 ${last_sell_price:.2f} 대비 "
+            f"재진입 가드: 직전 매도가 {format_money(last_sell_price, rule.market_type)} 대비 "
             f"{pct_from_sell:+.2f}% > 임계 {rule.reentry_guard_pct:+.2f}% -> 진입 대기 중"
         )
         if self._logger:
@@ -470,13 +476,19 @@ class SplitEvaluator:
 
         # 1. 1주도 살 수 없는 경우
         if portfolio.total_cash < current_price:
-            reason = f"현금 부족: 보유 현금 ${portfolio.total_cash:,.2f} < 현재가 ${current_price:,.2f} (1주도 매수 불가)"
+            reason = (
+                f"현금 부족: 보유 현금 {format_money(portfolio.total_cash, rule.market_type)} "
+                f"< 현재가 {format_money(current_price, rule.market_type)} (1주도 매수 불가)"
+            )
             return False, reason
 
         # 2. 계획된 수량을 살 현금이 부족한 경우
         required_cash = buy_qty * current_price
         if portfolio.total_cash < required_cash:
-            reason = f"현금 부족: 보유 현금 ${portfolio.total_cash:,.2f} < 매수 예정 금액 ${required_cash:,.2f} ({buy_qty}주)"
+            reason = (
+                f"현금 부족: 보유 현금 {format_money(portfolio.total_cash, rule.market_type)} "
+                f"< 매수 예정 금액 {format_money(required_cash, rule.market_type)} ({buy_qty}주)"
+            )
             return False, reason
 
         return True, ""
@@ -504,7 +516,7 @@ class SplitEvaluator:
             pct_from_buy = (current_price - last_lot.buy_price) / last_lot.buy_price * 100
             reason = (
                 f"max_lots({rule.max_lots}) 도달: "
-                f"현재가 ${current_price:,.2f} "
+                f"현재가 {format_money(current_price, rule.market_type)} "
                 f"(Lv{last_lot.level} 대비 {pct_from_buy:+.1f}%) "
                 f"-> 추가 하락 대응 불가"
             )
@@ -527,8 +539,8 @@ class SplitEvaluator:
         buy_qty = math.floor(buy_amount / current_price)
         if buy_qty <= 0:
             reason = (
-                f"buy_amount(${buy_amount:.2f}) < "
-                f"현재가(${current_price:.2f}) -> 1주도 매수 불가. "
+                f"buy_amount({format_money(buy_amount, rule.market_type)}) < "
+                f"현재가({format_money(current_price, rule.market_type)}) -> 1주도 매수 불가. "
                 f"buy_amount 상향 조정 필요"
             )
             if self._logger:
@@ -595,17 +607,22 @@ class SplitEvaluator:
             if self._logger:
                 if is_dynamic:
                     self._logger.info(
-                        f"[{display_ticker(rule.ticker)}] 🔄 동적 재매수: 매도가 ${last_sell_price:.2f} 대비 "
-                        f"{pct_from_ref:+.1f}% -> 추가 매수 Lv{next_level} {buy_qty}주 @${current_price:.2f} "
-                        f"(원래 기준 Lv{last_lot.level} ${last_lot.buy_price:.2f})"
+                        f"[{display_ticker(rule.ticker)}] 동적 재매수: "
+                        f"매도가 {format_money(last_sell_price, rule.market_type)} 대비 "
+                        f"{pct_from_ref:+.1f}% -> 추가 매수 Lv{next_level} {buy_qty}주 "
+                        f"@{format_money(current_price, rule.market_type)} "
+                        f"(원래 기준 Lv{last_lot.level} {format_money(last_lot.buy_price, rule.market_type)})"
                     )
                 else:
                     self._logger.info(
-                        f"[{display_ticker(rule.ticker)}] Lv{last_lot.level} 매수가 ${last_lot.buy_price:.2f} 대비 "
-                        f"{pct_from_ref:+.1f}% -> 추가 매수 Lv{next_level} {buy_qty}주 @${current_price:.2f}"
+                        f"[{display_ticker(rule.ticker)}] Lv{last_lot.level} "
+                        f"매수가 {format_money(last_lot.buy_price, rule.market_type)} 대비 "
+                        f"{pct_from_ref:+.1f}% -> 추가 매수 Lv{next_level} {buy_qty}주 "
+                        f"@{format_money(current_price, rule.market_type)}"
                     )
             reason_detail = (
-                f"동적 재매수 Lv{next_level} (매도가 ${last_sell_price:.0f} 대비 {pct_from_ref:+.1f}%)"
+                f"동적 재매수 Lv{next_level} "
+                f"(매도가 {format_money(last_sell_price, rule.market_type)} 대비 {pct_from_ref:+.1f}%)"
                 if is_dynamic
                 else f"추가 매수 Lv{next_level} (Lv{last_lot.level} 대비 {pct_from_ref:+.1f}%)"
             )

--- a/src/core/logic/status_builder.py
+++ b/src/core/logic/status_builder.py
@@ -13,9 +13,13 @@ def build_dashboard_status(
     enabled_tickers: List[str],
     sim_date: Optional[str] = None,
     stock_rules: Optional[List[StockRule]] = None,
-    last_trade_dates: Optional[Dict[str, str]] = None
+    last_trade_dates: Optional[Dict[str, str]] = None,
+    market_type: str = "overseas",
 ) -> dict:
-    """대시보드 렌더링에 필요한 상태 데이터 구조(JSON)를 조립한다."""
+    """대시보드 렌더링에 필요한 상태 데이터 구조(JSON)를 조립한다.
+
+    market_type은 status.json에 기록되어 프런트가 통화(KRW/USD)를 결정할 때 사용된다.
+    """
     last_updated = sim_date or datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     last_run_date = sim_date or datetime.now().strftime("%Y-%m-%d")
 
@@ -176,6 +180,7 @@ def build_dashboard_status(
     status = {
         "last_updated": last_updated,
         "last_run_date": last_run_date,
+        "market_type": market_type,
         "reason": reason,
         "portfolio": {
             "total_value": portfolio.total_value,

--- a/src/utils/currency.py
+++ b/src/utils/currency.py
@@ -1,0 +1,27 @@
+# src/utils/currency.py
+"""시장(market_type)에 따라 금액 문자열을 통화 단위(KRW/USD)에 맞춰 포매팅한다.
+
+로그/알림용 ASCII 표기를 사용한다 (CLAUDE.md 인코딩 규칙).
+- domestic -> "KRW 1,234,567"
+- overseas -> "USD 1,234.56"
+"""
+from typing import Optional
+
+
+def currency_code_for(market_type: str) -> str:
+    """market_type -> 통화 코드 (KRW/USD)."""
+    return "KRW" if market_type == "domestic" else "USD"
+
+
+def format_money(value: Optional[float], market_type: str) -> str:
+    """금액을 통화 단위와 함께 ASCII 문자열로 포매팅한다.
+
+    domestic은 소수점 없이, overseas는 소수점 2자리로 출력한다.
+    None은 "-"로 표시한다.
+    """
+    if value is None:
+        return "-"
+    code = currency_code_for(market_type)
+    if market_type == "domestic":
+        return f"{code} {value:,.0f}"
+    return f"{code} {value:,.2f}"

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -628,8 +628,8 @@ class TestNoSignalLog:
         assert "[AAPL]" in msg
         assert "신호 없음" in msg
         assert "Lv2" in msg
-        assert "$95.00" in msg
-        assert "$97.00" in msg
+        assert "USD 95.00" in msg
+        assert "USD 97.00" in msg
         assert "+2.11%" in msg
         assert "익절 +10.0%" in msg
         assert "추매 -5.0%" in msg
@@ -646,7 +646,7 @@ class TestNoSignalLog:
         msgs = [c.args[0] for c in mock_logger.info.call_args_list]
         assert len(msgs) == 1
         assert "보유 없음" in msgs[0]
-        assert "$100.00" in msgs[0]
+        assert "USD 100.00" in msgs[0]
         assert "1차 진입 대기" in msgs[0]
 
     def test_logs_reentry_guard_distance_when_active(self, engine, mock_logger):
@@ -661,7 +661,7 @@ class TestNoSignalLog:
         last_sell_prices = {"AAPL": 100.0}
         engine._log_no_signal_status(rule, [], portfolio, last_sell_prices)
         msg = mock_logger.info.call_args_list[0].args[0]
-        assert "직전 매도가 $100.00" in msg
+        assert "직전 매도가 USD 100.00" in msg
         assert "-0.50%" in msg
         assert "가드 -1.00%" in msg
 
@@ -712,6 +712,6 @@ class TestNoSignalLog:
         msgs = [c.args[0] for c in mock_logger.info.call_args_list]
         assert any(
             "[AAPL]" in m and "신호 없음" in m and "Lv1" in m
-            and "$99.00" in m and "$100.00" in m
+            and "USD 99.00" in m and "USD 100.00" in m
             for m in msgs
         )

--- a/tests/test_split_evaluator.py
+++ b/tests/test_split_evaluator.py
@@ -612,3 +612,42 @@ class TestMaxExposure:
         assert len(buy_signals) == 1
         assert buy_signals[0].level == 2
 
+
+
+class TestCurrencyAwareLogging:
+    """market_type에 따라 로그/reason 문자열의 통화 표기가 달라진다."""
+
+    def test_initial_buy_blocked_message_uses_usd(self, create_rule, create_portfolio):
+        captured = []
+
+        class _Logger:
+            def info(self, m): captured.append(m)
+            def warning(self, m): captured.append(m)
+            def error(self, m): captured.append(m)
+            def debug(self, m): captured.append(m)
+
+        evaluator = SplitEvaluator(logger=_Logger())
+        rules = [create_rule(
+            ticker="AAPL", buy_amount=50, market_type="overseas",
+        )]
+        portfolio = create_portfolio(prices={"AAPL": 100.0})
+        signals = evaluator.evaluate(rules, [], portfolio)
+        assert signals[0].is_blocked
+        assert "USD 50.00" in signals[0].reason
+        assert "USD 100.00" in signals[0].reason
+
+    def test_initial_buy_blocked_message_uses_krw_for_domestic(
+        self, create_rule, create_portfolio,
+    ):
+        evaluator = SplitEvaluator()
+        rules = [create_rule(
+            ticker="005930", buy_amount=50000, market_type="domestic",
+        )]
+        portfolio = create_portfolio(prices={"005930": 80000.0})
+        signals = evaluator.evaluate(rules, [], portfolio)
+        assert signals[0].is_blocked
+        # KRW는 소수점 없이 천단위 콤마.
+        assert "KRW 50,000" in signals[0].reason
+        assert "KRW 80,000" in signals[0].reason
+        # 해외 통화 표기가 섞이지 않아야 한다.
+        assert "USD" not in signals[0].reason

--- a/tests/test_status_builder.py
+++ b/tests/test_status_builder.py
@@ -1,0 +1,56 @@
+# tests/test_status_builder.py
+from src.core.logic.status_builder import build_dashboard_status
+from src.core.models import Portfolio, PositionLot
+
+
+def _empty_portfolio() -> Portfolio:
+    return Portfolio(total_cash=0.0, holdings={}, current_prices={})
+
+
+class TestStatusMarketType:
+    def test_default_market_type_is_overseas(self):
+        status = build_dashboard_status(
+            portfolio=_empty_portfolio(),
+            positions=[],
+            reason="-",
+            old_realized_pnl_by_ticker={},
+            recent_executions=[],
+            enabled_tickers=[],
+            sim_date="2026-04-10",
+        )
+        assert status["market_type"] == "overseas"
+
+    def test_market_type_propagates_when_domestic(self):
+        status = build_dashboard_status(
+            portfolio=_empty_portfolio(),
+            positions=[],
+            reason="-",
+            old_realized_pnl_by_ticker={},
+            recent_executions=[],
+            enabled_tickers=[],
+            sim_date="2026-04-10",
+            market_type="domestic",
+        )
+        assert status["market_type"] == "domestic"
+
+    def test_status_keeps_existing_keys(self):
+        """기존 필드(portfolio/positions/risk_summary)는 유지된다."""
+        status = build_dashboard_status(
+            portfolio=Portfolio(
+                total_cash=1000.0, holdings={"AAPL": 1},
+                current_prices={"AAPL": 150.0},
+            ),
+            positions=[
+                PositionLot("lot_1", "AAPL", 140.0, 1, "2026-04-01", level=1),
+            ],
+            reason="모니터링 - 신호 없음",
+            old_realized_pnl_by_ticker={},
+            recent_executions=[],
+            enabled_tickers=["AAPL"],
+            sim_date="2026-04-10",
+            market_type="overseas",
+        )
+        assert "portfolio" in status
+        assert "positions" in status
+        assert "risk_summary" in status
+        assert status["market_type"] == "overseas"

--- a/tests/test_utils_currency.py
+++ b/tests/test_utils_currency.py
@@ -1,0 +1,44 @@
+# tests/test_utils_currency.py
+import pytest
+
+from src.utils.currency import currency_code_for, format_money
+
+
+class TestCurrencyCode:
+    def test_domestic_returns_krw(self):
+        assert currency_code_for("domestic") == "KRW"
+
+    def test_overseas_returns_usd(self):
+        assert currency_code_for("overseas") == "USD"
+
+    def test_unknown_defaults_to_usd(self):
+        assert currency_code_for("anything-else") == "USD"
+
+
+class TestFormatMoney:
+    def test_domestic_no_decimals_with_thousand_separator(self):
+        assert format_money(1234567, "domestic") == "KRW 1,234,567"
+
+    def test_domestic_rounds_to_zero_decimals(self):
+        assert format_money(100700.6, "domestic") == "KRW 100,701"
+
+    def test_overseas_two_decimals(self):
+        assert format_money(1234.5, "overseas") == "USD 1,234.50"
+
+    def test_overseas_thousand_separator(self):
+        assert format_money(1234567.89, "overseas") == "USD 1,234,567.89"
+
+    def test_zero(self):
+        assert format_money(0, "domestic") == "KRW 0"
+        assert format_money(0, "overseas") == "USD 0.00"
+
+    def test_negative(self):
+        assert format_money(-500, "domestic") == "KRW -500"
+        assert format_money(-1.25, "overseas") == "USD -1.25"
+
+    def test_none_returns_dash(self):
+        assert format_money(None, "domestic") == "-"
+        assert format_money(None, "overseas") == "-"
+
+    def test_unknown_market_type_treated_as_overseas(self):
+        assert format_money(10, "futures") == "USD 10.00"


### PR DESCRIPTION
## Summary

- 국내(KRW) 매매 시에도 모든 로그/알림이 `$402,802.40` 처럼 USD로 잘못 표시되던 문제를 해결합니다.
- 새 헬퍼 `src.utils.currency.format_money` 로 백엔드를 `KRW 1,234,567` / `USD 1,234.56` 형식(ASCII)으로 통일하고, GitHub Pages 대시보드는 `Intl.NumberFormat({style:'currency'})` 분기를 모든 금액 표시 지점에 일관되게 적용합니다.
- `status.json` 에 `market_type` 필드를 추가하여 backtest 모드 UI 도 어느 통화인지 자동 인식합니다.

## Changes

### Backend
- **`src/utils/currency.py` 신규**: `format_money(value, market_type)` (`KRW`/`USD` 분기, None/0/음수 처리), `currency_code_for(...)`.
- **`src/core/logic/split_evaluator.py`**: 모든 로그/`SplitSignal.reason` 의 하드코딩 `$` 제거 → `format_money(..., rule.market_type)` 호출. 트레일링 활성화/추적/스톱 매도, 익절, 초기 매수, 추가 매수(동적 재매수 포함), 재진입 가드, 현금 부족, max_lots 도달 메시지 모두 통일.
- **`src/core/engine/base.py`**: `self.market_type` 도입 (`stock_rules[0].market_type`). Portfolio 요약, 모니터링 알림, `_log_no_signal_status`, `_update_positions`, `_handle_state_transitions` 의 모든 가격 출력에 헬퍼 적용.
- **`src/backtest/runner.py`**: 백테스트 최종 결과 로그.
- **`scripts/manual_trade.py`**: 금액 기반 수량 계산, 체결 완료, 신규 lot 로그.
- **`src/core/logic/status_builder.py`**: `market_type` 인자 추가하여 `status.json["market_type"]` 으로 노출.

### Frontend (`docs/js/`)
- **`models/dashboard-model.js`**: `getCurrencyMode()` 신규 — `mode==='backtest'` 일 때 `statusData.market_type` 우선 사용.
- **`views/dashboard-view.js`**: lot 라인의 하드코딩 `@$${...}` 제거 → `formatCurrency`.
- **`views/charts-view.js`**: equity curve Y축 라벨에 통화 심볼(`₩`/`$`)과 K/M/B 스케일.
- **`controllers/dashboard-controller.js`**, **`controllers/risk-controller.js`**: 라우팅용 `getMode()` 와 분리하여 금액 포매팅용은 `getCurrencyMode()` 위임.
- **`manual-trade.js`**: `formatAmount(value, marketType)` 헬퍼 추가, 매수 입력 힌트와 확인 다이얼로그에 적용.
- **`docs/index.html`, `docs/manual-trade.html`**: 변경된 js 파일 캐시버스터 `?v=20260508-1/2` 갱신.

## Tests

- `tests/test_utils_currency.py` 신규: 11 케이스 (KRW/USD, 0/음수/None, 알 수 없는 market_type fallback).
- `tests/test_status_builder.py` 신규: `status["market_type"]` 키 포함 검증, default `overseas`, 기존 키(portfolio/positions/risk_summary) 유지.
- `tests/test_split_evaluator.py`: `TestCurrencyAwareLogging` — domestic/overseas 각각 reason 문자열에 올바른 통화 코드만 포함되는지 검증.
- `tests/test_core_engine.py`: 기존 `$` 패턴 검사를 새 `USD ...` 포맷으로 갱신.

## Test plan

- [x] `pytest --cov=src tests/` — 263 passed, 16 skipped, **coverage 88%** (목표 80% 이상).
- [x] `grep '\$' src/core/ src/backtest/ scripts/manual_trade.py` — 통화 관련 하드코딩 `$` 0건.
- [ ] 국내 모의 실행 (`config_overseas.json_PATH=config_domestic.json python -m src.main`) 로그에 `KRW ...` 만 표시되는지 수동 확인.
- [ ] `python -m http.server 8000 -d docs` 후 `?mode=domestic` / `?mode=overseas` / `?mode=backtest` 페이지의 Portfolio Summary, lot 라인, equity curve Y축, history 테이블 통화 일치 확인.
- [ ] DevTools Network 탭에서 새 `?v=20260508-1/2` 적용 확인.

https://claude.ai/code/session_019munxHzv35rVJBxKUfVfKq

---
_Generated by [Claude Code](https://claude.ai/code/session_019munxHzv35rVJBxKUfVfKq)_