### PR TITLE
🎨 Palette: [UX improvement] Apply KRX market conventions and enhance profit/loss accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+- The project uses a simple HTML/JS frontend that asynchronously loads data from a static `status.json` file.
+- It uses plain HTML strings inside JS for rendering the data, not a frontend framework.
+- Apply Korean market (KRX) conventions: Red = Up/Profit, Blue = Down/Loss.
+- Remember to use explicit ARIA labels and hidden arrows (▲, ▼) for better accessibility for visually impaired users.

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1,8 +1,8 @@
 /* MagicSplit Dashboard Style */
 :root {
     --primary: #2563eb;
-    --success: #16a34a;
-    --danger: #dc2626;
+    --success: #ef4444; /* KRX Convention: Red for Up/Profit */
+    --danger: #3b82f6;  /* KRX Convention: Blue for Down/Loss */
     --warning: #d97706;
     --bg: #f8fafc;
     --card-bg: #ffffff;

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -54,12 +54,18 @@
             const lots = info.lots || [];
             let lotsHtml = '';
             for (const lot of lots) {
-                const pctClass = lot.pct_change >= 0 ? 'pct-positive' : 'pct-negative';
-                const pctStr = (lot.pct_change >= 0 ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const isPositive = lot.pct_change >= 0;
+                const pctClass = isPositive ? 'pct-positive' : 'pct-negative';
+                const pctStr = (isPositive ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const ariaLabel = isPositive ? `Profit of ${lot.pct_change.toFixed(1)}%` : `Loss of ${Math.abs(lot.pct_change).toFixed(1)}%`;
+                const arrowIndicator = isPositive ? '▲' : '▼';
+
                 lotsHtml += `
                     <li class="lot-item">
                         <span>${lot.buy_date} | ${lot.quantity}shares @$${lot.buy_price.toFixed(2)}</span>
-                        <span class="${pctClass}">${pctStr}</span>
+                        <span class="${pctClass}" aria-label="${ariaLabel}">
+                            ${pctStr} <span aria-hidden="true">${arrowIndicator}</span>
+                        </span>
                     </li>`;
             }
 


### PR DESCRIPTION
**What:**
1. Applied Korean market (KRX) color conventions: Red for Up/Profit, Blue for Down/Loss.
2. Added `aria-label`s to profit/loss percentages to improve screen-reader accessibility (e.g., "Profit of 5.2%").
3. Added visual up/down arrows (▲/▼) hidden from screen readers to improve glanceability without relying solely on color.
4. Created `.jules/palette.md` to document project-specific UX/UI context.

**Why (Financial clarity):**
Consistent market color conventions and visual indicators prevent ambiguity and reduce cognitive load for traders, while explicit ARIA labels ensure the financial data is accessible to all users.

**Accessibility:**
- Improved colorblindness readability by avoiding the standard green/red combination and adding structural icons.
- Added explicit textual descriptions via `aria-label` for screen readers.

---
*PR created automatically by Jules for task [2808569995688608462](https://jules.google.com/task/2808569995688608462) started by @Junghyun99*