### PR TITLE
refactor: route manual trade through MagicSplitEngine pipeline

### DIFF
--- a/.github/workflows/manual-trade.yml
+++ b/.github/workflows/manual-trade.yml
@@ -22,11 +22,11 @@ on:
           - buy
           - sell
       quantity:
-        description: 'Quantity (Optional if amount is set)'
+        description: 'Quantity (BUY only — SELL is always full highest-level lot)'
         required: false
         type: string
       amount:
-        description: 'Order Amount (Optional if quantity is set)'
+        description: 'Order Amount (BUY only — SELL is always full highest-level lot)'
         required: false
         type: string
 
@@ -58,6 +58,10 @@ jobs:
 
     - name: Execute Manual Trade
       env:
+        ACTION: ${{ github.event.inputs.action }}
+        TICKER: ${{ github.event.inputs.ticker }}
+        QUANTITY: ${{ github.event.inputs.quantity }}
+        AMOUNT: ${{ github.event.inputs.amount }}
         CONFIG_JSON_PATH: config_${{ github.event.inputs.market_type }}.json
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_LIVE }}
         KIS_APP_KEY: ${{ secrets.KIS_APP_KEY }}
@@ -65,11 +69,13 @@ jobs:
         KIS_ACC_NO: ${{ secrets.KIS_ACC_NO }}
         IS_LIVE: 'true'
       run: |
-        python scripts/manual_trade.py \
-          --ticker "${{ github.event.inputs.ticker }}" \
-          --action "${{ github.event.inputs.action }}" \
-          ${{ github.event.inputs.quantity != '' && format('--qty "{0}"', github.event.inputs.quantity) || '' }} \
-          ${{ github.event.inputs.amount != '' && format('--amount "{0}"', github.event.inputs.amount) || '' }}
+        # 매수만 qty/amount 전달. 매도는 최고 차수 lot 전량을 엔진이 자동 도출.
+        ARGS=(--ticker "$TICKER" --action "$ACTION")
+        if [ "$ACTION" = "buy" ]; then
+          [ -n "$QUANTITY" ] && ARGS+=(--qty "$QUANTITY")
+          [ -n "$AMOUNT" ] && ARGS+=(--amount "$AMOUNT")
+        fi
+        python scripts/manual_trade.py "${ARGS[@]}"
 
     - name: Save KIS token cache
       if: always()

--- a/.github/workflows/manual-trade.yml
+++ b/.github/workflows/manual-trade.yml
@@ -15,20 +15,12 @@ on:
         required: true
         type: string
       action:
-        description: 'Order Action'
+        description: 'Order Action (qty is auto-derived: BUY=rule.buy_amount, SELL=highest-level lot full)'
         required: true
         type: choice
         options:
           - buy
           - sell
-      quantity:
-        description: 'Quantity (BUY only — SELL is always full highest-level lot)'
-        required: false
-        type: string
-      amount:
-        description: 'Order Amount (BUY only — SELL is always full highest-level lot)'
-        required: false
-        type: string
 
 jobs:
   trade:
@@ -58,10 +50,6 @@ jobs:
 
     - name: Execute Manual Trade
       env:
-        ACTION: ${{ github.event.inputs.action }}
-        TICKER: ${{ github.event.inputs.ticker }}
-        QUANTITY: ${{ github.event.inputs.quantity }}
-        AMOUNT: ${{ github.event.inputs.amount }}
         CONFIG_JSON_PATH: config_${{ github.event.inputs.market_type }}.json
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_LIVE }}
         KIS_APP_KEY: ${{ secrets.KIS_APP_KEY }}
@@ -69,13 +57,9 @@ jobs:
         KIS_ACC_NO: ${{ secrets.KIS_ACC_NO }}
         IS_LIVE: 'true'
       run: |
-        # 매수만 qty/amount 전달. 매도는 최고 차수 lot 전량을 엔진이 자동 도출.
-        ARGS=(--ticker "$TICKER" --action "$ACTION")
-        if [ "$ACTION" = "buy" ]; then
-          [ -n "$QUANTITY" ] && ARGS+=(--qty "$QUANTITY")
-          [ -n "$AMOUNT" ] && ARGS+=(--amount "$AMOUNT")
-        fi
-        python scripts/manual_trade.py "${ARGS[@]}"
+        python scripts/manual_trade.py \
+          --ticker "${{ github.event.inputs.ticker }}" \
+          --action "${{ github.event.inputs.action }}"
 
     - name: Save KIS token cache
       if: always()

--- a/docs/js/manual-trade.js
+++ b/docs/js/manual-trade.js
@@ -249,17 +249,22 @@
     }
 
     function openOrderModal(tickerObj, action) {
-        activeOrderParams = { 
-            ticker: tickerObj.ticker, 
+        activeOrderParams = {
+            ticker: tickerObj.ticker,
             alias: tickerObj.alias,
             action: action,
-            marketType: currentMarket 
+            marketType: currentMarket,
+            sellQty: 0
         };
 
         modalTitle.textContent = `${tickerObj.alias} (${tickerObj.ticker}) ${action === 'buy' ? '매수' : '매도'}`;
         statusFeedback.style.display = 'none';
         confirmTradeBtn.disabled = false;
         confirmTradeBtn.textContent = '실행';
+
+        // 모달 매번 열 때 입력 영역 표시 상태 초기화 (sell -> buy 전환 대비)
+        inputLabel.style.display = '';
+        orderValue.style.display = '';
 
         if (action === 'buy') {
             inputLabel.textContent = currentMarket === 'domestic' ? '매수 금액 (원)' : '매수 금액 ($)';
@@ -269,10 +274,12 @@
             orderValue.value = defaultAmt;
             inputHint.textContent = `현재 ${tickerObj.currentLevel}차 -> ${nextLv}차 매수 설정값: ${formatAmount(defaultAmt, currentMarket)}`;
         } else {
-            inputLabel.textContent = '매도 수량 (주)';
-            const defaultQty = tickerObj.highestLvQty || 0;
-            orderValue.value = defaultQty;
-            inputHint.textContent = `현재 최상위(${tickerObj.currentLevel}차) 보유량: ${defaultQty}주 / 총 ${tickerObj.currentQty}주`;
+            // 매도: 자동매매와 동일하게 최고 차수 lot 전량 매도. 수량 입력 비활성화.
+            inputLabel.style.display = 'none';
+            orderValue.style.display = 'none';
+            const sellQty = tickerObj.highestLvQty || 0;
+            activeOrderParams.sellQty = sellQty;
+            inputHint.textContent = `Lv${tickerObj.currentLevel} 차수 lot ${sellQty}주 전량 매도 (자동매매와 동일 정책 - 수량 지정 불가)`;
         }
 
         orderModal.style.display = 'flex';
@@ -281,14 +288,22 @@
     async function executeTrade() {
         if (!activeOrderParams || !githubApi) return;
 
-        const val = parseFloat(orderValue.value);
-        if (isNaN(val) || val <= 0) {
-            showFeedback('올바른 값을 입력해 주세요.', 'error');
-            return;
+        const isBuy = activeOrderParams.action === 'buy';
+        let val = 0;
+        let valDisplay = '';
+
+        if (isBuy) {
+            val = parseFloat(orderValue.value);
+            if (isNaN(val) || val <= 0) {
+                showFeedback('올바른 값을 입력해 주세요.', 'error');
+                return;
+            }
+            valDisplay = formatAmount(val, currentMarket);
+        } else {
+            // 매도는 사용자 입력 없이 최고 차수 lot 전량 매도 (수량은 엔진이 자동 도출).
+            valDisplay = `최고 차수 lot ${activeOrderParams.sellQty}주 전량`;
         }
 
-        const isBuy = activeOrderParams.action === 'buy';
-        const valDisplay = isBuy ? formatAmount(val, currentMarket) : `${val.toLocaleString()}주`;
         if (!confirm(`${activeOrderParams.alias} 종목을 ${valDisplay} ${isBuy ? '매수' : '매도'} 하시겠습니까?`)) {
             return;
         }
@@ -300,16 +315,15 @@
             const inputs = {
                 market_type: activeOrderParams.marketType,
                 ticker: activeOrderParams.ticker,
-                action: activeOrderParams.action
+                action: activeOrderParams.action,
+                quantity: "",
+                amount: ""
             };
 
-            if (activeOrderParams.action === 'buy') {
+            if (isBuy) {
                 inputs.amount = val.toString();
-                inputs.quantity = "";
-            } else {
-                inputs.quantity = val.toString();
-                inputs.amount = "";
             }
+            // 매도는 quantity/amount 모두 빈 문자열 — 워크플로우가 --qty/--amount 생략.
 
             await githubApi.triggerWorkflow('manual-trade.yml', inputs);
 

--- a/docs/js/manual-trade.js
+++ b/docs/js/manual-trade.js
@@ -17,8 +17,7 @@
 
     const orderModal = document.getElementById('order-modal');
     const modalTitle = document.getElementById('modal-title');
-    const inputLabel = document.getElementById('input-label');
-    const orderValue = document.getElementById('order-value');
+    const orderSummary = document.getElementById('order-summary');
     const inputHint = document.getElementById('input-hint');
     const confirmTradeBtn = document.getElementById('confirm-trade-btn');
     const cancelTradeBtn = document.getElementById('cancel-trade-btn');
@@ -254,7 +253,6 @@
             alias: tickerObj.alias,
             action: action,
             marketType: currentMarket,
-            sellQty: 0
         };
 
         modalTitle.textContent = `${tickerObj.alias} (${tickerObj.ticker}) ${action === 'buy' ? '매수' : '매도'}`;
@@ -262,24 +260,21 @@
         confirmTradeBtn.disabled = false;
         confirmTradeBtn.textContent = '실행';
 
-        // 모달 매번 열 때 입력 영역 표시 상태 초기화 (sell -> buy 전환 대비)
-        inputLabel.style.display = '';
-        orderValue.style.display = '';
-
         if (action === 'buy') {
-            inputLabel.textContent = currentMarket === 'domestic' ? '매수 금액 (원)' : '매수 금액 ($)';
             const nextLv = tickerObj.currentLevel + 1;
             const lvAmount = tickerObj.config.buy_amounts && tickerObj.config.buy_amounts[nextLv - 1];
-            const defaultAmt = lvAmount || tickerObj.config.buy_amount || 0;
-            orderValue.value = defaultAmt;
-            inputHint.textContent = `현재 ${tickerObj.currentLevel}차 -> ${nextLv}차 매수 설정값: ${formatAmount(defaultAmt, currentMarket)}`;
+            const cfgAmount = lvAmount || tickerObj.config.buy_amount || 0;
+            orderSummary.innerHTML =
+                `현재 <b>Lv${tickerObj.currentLevel}</b> -> <b>Lv${nextLv}</b> 매수<br>` +
+                `1회 매수 금액(설정): <b>${formatAmount(cfgAmount, currentMarket)}</b>`;
+            inputHint.textContent =
+                '실제 주문 수량은 엔진이 [설정 금액 / 현재가]로 자동 계산합니다 (자동매매와 동일).';
         } else {
-            // 매도: 자동매매와 동일하게 최고 차수 lot 전량 매도. 수량 입력 비활성화.
-            inputLabel.style.display = 'none';
-            orderValue.style.display = 'none';
             const sellQty = tickerObj.highestLvQty || 0;
-            activeOrderParams.sellQty = sellQty;
-            inputHint.textContent = `Lv${tickerObj.currentLevel} 차수 lot ${sellQty}주 전량 매도 (자동매매와 동일 정책 - 수량 지정 불가)`;
+            orderSummary.innerHTML =
+                `<b>Lv${tickerObj.currentLevel}</b> 차수 lot <b>${sellQty}주</b> 전량 매도`;
+            inputHint.textContent =
+                '매도 수량은 엔진이 최고 차수 lot 전량으로 자동 결정합니다 (자동매매와 동일).';
         }
 
         orderModal.style.display = 'flex';
@@ -289,22 +284,9 @@
         if (!activeOrderParams || !githubApi) return;
 
         const isBuy = activeOrderParams.action === 'buy';
-        let val = 0;
-        let valDisplay = '';
+        const actionLabel = isBuy ? '매수' : '매도';
 
-        if (isBuy) {
-            val = parseFloat(orderValue.value);
-            if (isNaN(val) || val <= 0) {
-                showFeedback('올바른 값을 입력해 주세요.', 'error');
-                return;
-            }
-            valDisplay = formatAmount(val, currentMarket);
-        } else {
-            // 매도는 사용자 입력 없이 최고 차수 lot 전량 매도 (수량은 엔진이 자동 도출).
-            valDisplay = `최고 차수 lot ${activeOrderParams.sellQty}주 전량`;
-        }
-
-        if (!confirm(`${activeOrderParams.alias} 종목을 ${valDisplay} ${isBuy ? '매수' : '매도'} 하시겠습니까?`)) {
+        if (!confirm(`${activeOrderParams.alias} 종목을 ${actionLabel} 하시겠습니까?\n(수량은 자동매매 정책에 따라 엔진이 결정합니다)`)) {
             return;
         }
 
@@ -316,14 +298,7 @@
                 market_type: activeOrderParams.marketType,
                 ticker: activeOrderParams.ticker,
                 action: activeOrderParams.action,
-                quantity: "",
-                amount: ""
             };
-
-            if (isBuy) {
-                inputs.amount = val.toString();
-            }
-            // 매도는 quantity/amount 모두 빈 문자열 — 워크플로우가 --qty/--amount 생략.
 
             await githubApi.triggerWorkflow('manual-trade.yml', inputs);
 

--- a/docs/manual-trade.html
+++ b/docs/manual-trade.html
@@ -254,7 +254,7 @@
 
     <script src="js/services/data-repository.js?v=20260509-2"></script>
     <script src="js/services/github-api.js?v=20260509-2"></script>
-    <script src="js/manual-trade.js?v=20260509-2"></script>
+    <script src="js/manual-trade.js?v=20260510-1"></script>
 </body>
 
 </html>

--- a/docs/manual-trade.html
+++ b/docs/manual-trade.html
@@ -240,9 +240,8 @@
                 <h2 class="modal-title" id="modal-title">주문 실행</h2>
             </div>
             <div class="form-group">
-                <label id="input-label">매수 금액</label>
-                <input type="number" id="order-value" class="form-control" step="any">
-                <small id="input-hint" class="form-text"></small>
+                <p id="order-summary" style="margin: 0; line-height: 1.5;"></p>
+                <small id="input-hint" class="form-text" style="display:block; margin-top:8px; color: var(--text-muted);"></small>
             </div>
             <div style="display: flex; gap: 10px; margin-top: 24px;">
                 <button class="btn btn-primary" id="confirm-trade-btn" style="flex: 2;">실행</button>
@@ -254,7 +253,7 @@
 
     <script src="js/services/data-repository.js?v=20260509-2"></script>
     <script src="js/services/github-api.js?v=20260509-2"></script>
-    <script src="js/manual-trade.js?v=20260510-1"></script>
+    <script src="js/manual-trade.js?v=20260510-2"></script>
 </body>
 
 </html>

--- a/scripts/manual_trade.py
+++ b/scripts/manual_trade.py
@@ -11,7 +11,6 @@
 사용법:
     python scripts/manual_trade.py --ticker 005930 --action buy
     python scripts/manual_trade.py --ticker TSLA --action sell
-    python scripts/manual_trade.py --ticker AAPL --action buy --dry-run
 """
 import argparse
 import os
@@ -35,10 +34,6 @@ def parse_args():
     parser.add_argument(
         "--action", required=True, choices=["buy", "sell"],
         help="매수(buy) 또는 매도(sell). 수량은 자동 도출됨.",
-    )
-    parser.add_argument(
-        "--dry-run", action="store_true",
-        help="실제 주문 없이 신호 생성 단계까지만 시뮬레이션",
     )
     return parser.parse_args()
 
@@ -103,18 +98,10 @@ def main():
     action = OrderAction.BUY if args.action == "buy" else OrderAction.SELL
 
     try:
-        result = engine.run_manual_trade(
-            ticker=args.ticker,
-            action=action,
-            dry_run=args.dry_run,
-        )
+        result = engine.run_manual_trade(ticker=args.ticker, action=action)
     except Exception as e:
         logger.error(f"수동매매 중단: {e}")
         sys.exit(1)
-
-    if args.dry_run:
-        logger.info("=== Manual Trade (DRY RUN) 완료 ===")
-        sys.exit(0)
 
     if not result.executions:
         logger.error("주문이 실행되지 않았습니다.")

--- a/scripts/manual_trade.py
+++ b/scripts/manual_trade.py
@@ -3,12 +3,15 @@
 
 `MagicSplitEngine.run_manual_trade()`를 호출하여 자동매매와 동일한
 주문 -> 포지션 반영 -> 저장 파이프라인을 사용한다. 신호 평가(evaluate_stock)만
-우회하고, 사용자가 지정한 ticker/action/qty(또는 amount)로 즉시 매매를 강제한다.
+우회하고, 사용자가 지정한 ticker/action으로 즉시 매매를 강제한다.
+수량은 자동매매와 동일하게 엔진이 도출한다:
+  - BUY: rule.buy_amount_at(next_level) / 현재가
+  - SELL: 최고 차수 lot 전량
 
 사용법:
-    python scripts/manual_trade.py --ticker 005930 --action buy --qty 10
-    python scripts/manual_trade.py --ticker TSLA --action sell --qty 5
-    python scripts/manual_trade.py --ticker AAPL --action buy --amount 1000 --dry-run
+    python scripts/manual_trade.py --ticker 005930 --action buy
+    python scripts/manual_trade.py --ticker TSLA --action sell
+    python scripts/manual_trade.py --ticker AAPL --action buy --dry-run
 """
 import argparse
 import os
@@ -31,12 +34,7 @@ def parse_args():
     parser.add_argument("--ticker", required=True, help="종목 코드 (예: 005930, TSLA)")
     parser.add_argument(
         "--action", required=True, choices=["buy", "sell"],
-        help="매수(buy) 또는 매도(sell)",
-    )
-    parser.add_argument("--qty", type=int, help="주문 수량 (amount와 둘 중 하나 필수)")
-    parser.add_argument(
-        "--amount", type=float,
-        help="주문 금액 (매수 시 수량 대신 사용 가능, 현재가로 수량 계산)",
+        help="매수(buy) 또는 매도(sell). 수량은 자동 도출됨.",
     )
     parser.add_argument(
         "--dry-run", action="store_true",
@@ -47,17 +45,6 @@ def parse_args():
 
 def main():
     args = parse_args()
-    if args.action == "sell":
-        if args.qty is not None or args.amount is not None:
-            print(
-                "에러: 매도는 --qty/--amount 지정 불가. "
-                "최고 차수 lot 전량 매도만 지원합니다 (자동매매와 동일 정책)."
-            )
-            sys.exit(1)
-    else:  # buy
-        if not args.qty and not args.amount:
-            print("에러: 매수는 --qty 또는 --amount 중 하나가 필수입니다.")
-            sys.exit(1)
 
     config = Config()
     strategy = StrategyConfig(config.CONFIG_JSON_PATH)
@@ -71,10 +58,11 @@ def main():
             f"'{args.ticker}' 종목이 없습니다."
         )
         sys.exit(1)
-    if not target_rule.enabled:
+    # 매수만 비활성 종목 차단. 매도는 청산 목적으로 허용 (엔진과 동일 정책).
+    if args.action == "buy" and not target_rule.enabled:
         print(
             f"에러: '{args.ticker}'는 비활성화 상태입니다. "
-            f"매매하려면 설정 파일에서 enabled=true 로 변경하세요."
+            f"매수하려면 설정 파일에서 enabled=true 로 변경하세요."
         )
         sys.exit(1)
     market_type = target_rule.market_type
@@ -82,8 +70,7 @@ def main():
     log_dir = os.path.join(config.LOG_PATH, market_type)
     logger = TradeLogger(log_dir)
     logger.info(
-        f"=== Manual Trade CLI: {args.ticker} {args.action.upper()} "
-        f"(qty={args.qty}, amount={args.amount}) ==="
+        f"=== Manual Trade CLI: {args.ticker} {args.action.upper()} ==="
     )
 
     broker = _create_broker(
@@ -119,8 +106,6 @@ def main():
         result = engine.run_manual_trade(
             ticker=args.ticker,
             action=action,
-            qty=args.qty,
-            amount=args.amount,
             dry_run=args.dry_run,
         )
     except Exception as e:

--- a/scripts/manual_trade.py
+++ b/scripts/manual_trade.py
@@ -47,9 +47,17 @@ def parse_args():
 
 def main():
     args = parse_args()
-    if not args.qty and not args.amount:
-        print("에러: --qty 또는 --amount 중 하나는 반드시 입력해야 합니다.")
-        sys.exit(1)
+    if args.action == "sell":
+        if args.qty is not None or args.amount is not None:
+            print(
+                "에러: 매도는 --qty/--amount 지정 불가. "
+                "최고 차수 lot 전량 매도만 지원합니다 (자동매매와 동일 정책)."
+            )
+            sys.exit(1)
+    else:  # buy
+        if not args.qty and not args.amount:
+            print("에러: 매수는 --qty 또는 --amount 중 하나가 필수입니다.")
+            sys.exit(1)
 
     config = Config()
     strategy = StrategyConfig(config.CONFIG_JSON_PATH)

--- a/scripts/manual_trade.py
+++ b/scripts/manual_trade.py
@@ -1,60 +1,83 @@
 #!/usr/bin/env python3
-"""수동 매매(Manual Trade) 실행 및 상태 동기화 CLI 스크립트.
+"""수동 매매(Manual Trade) CLI.
 
-이 스크립트는 KIS 브로커 API를 직접 호출하여 매수/매도 주문을 실행하고,
-체결이 완료되면 즉시 `positions.json`, `history.json` 등 로컬 상태를 업데이트합니다.
-이를 통해 MTS에서 직접 매매하여 발생하는 불일치(Mismatch) 에러 없이 봇과 상태를 동기화할 수 있습니다.
+`MagicSplitEngine.run_manual_trade()`를 호출하여 자동매매와 동일한
+주문 -> 포지션 반영 -> 저장 파이프라인을 사용한다. 신호 평가(evaluate_stock)만
+우회하고, 사용자가 지정한 ticker/action/qty(또는 amount)로 즉시 매매를 강제한다.
 
 사용법:
-    python scripts/manual_trade.py --ticker 005930 --action buy --qty 10 --price 80000 --level 4
+    python scripts/manual_trade.py --ticker 005930 --action buy --qty 10
     python scripts/manual_trade.py --ticker TSLA --action sell --qty 5
+    python scripts/manual_trade.py --ticker AAPL --action buy --amount 1000 --dry-run
 """
 import argparse
 import os
 import sys
-from datetime import datetime
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/..")
 
 from src.config import Config
 from src.strategy_config import StrategyConfig
 from src.utils.logger import TradeLogger
-from src.utils.currency import format_money
-from src.core.models import Order, OrderAction, PositionLot, ExecutionStatus, SplitSignal
+from src.core.models import OrderAction, ExecutionStatus
+from src.core.engine.base import MagicSplitEngine
 from src.main import _create_broker
 from src.infra.repo import JsonRepository
+from src.infra.notifier import SlackNotifier
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="수동 매매 스크립트")
     parser.add_argument("--ticker", required=True, help="종목 코드 (예: 005930, TSLA)")
-    parser.add_argument("--action", required=True, choices=["buy", "sell"], help="매수(buy) 또는 매도(sell)")
-    parser.add_argument("--qty", type=int, help="주문 수량 (매도 시 필수 또는 매수 시 직접 지정)")
-    parser.add_argument("--amount", type=float, help="주문 금액 (매수 시 수량 대신 사용 가능)")
-    parser.add_argument("--dry-run", action="store_true", help="실제 주문을 넣지 않고 시뮬레이션만 수행")
+    parser.add_argument(
+        "--action", required=True, choices=["buy", "sell"],
+        help="매수(buy) 또는 매도(sell)",
+    )
+    parser.add_argument("--qty", type=int, help="주문 수량 (amount와 둘 중 하나 필수)")
+    parser.add_argument(
+        "--amount", type=float,
+        help="주문 금액 (매수 시 수량 대신 사용 가능, 현재가로 수량 계산)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="실제 주문 없이 신호 생성 단계까지만 시뮬레이션",
+    )
     return parser.parse_args()
+
 
 def main():
     args = parse_args()
     if not args.qty and not args.amount:
         print("에러: --qty 또는 --amount 중 하나는 반드시 입력해야 합니다.")
         sys.exit(1)
-    config = Config()
-    logger = TradeLogger(config.LOG_PATH)
-    logger.info(f"=== 수동 매매(Manual Trade) 시작: {args.ticker} {args.action.upper()} (Qty:{args.qty}, Amt:{args.amount}) ===")
 
+    config = Config()
     strategy = StrategyConfig(config.CONFIG_JSON_PATH)
 
-    # 1. 룰에서 티커 검색 (마켓 타입을 얻기 위함). 티커 표기는 정확히 일치해야 한다.
-    target_rule = next((r for r in strategy.rules if r.ticker == args.ticker), None)
-
-    if not target_rule:
-        logger.error(f"설정 파일({config.CONFIG_JSON_PATH})에 '{args.ticker}' 종목이 없습니다.")
+    target_rule = next(
+        (r for r in strategy.rules if r.ticker == args.ticker), None
+    )
+    if target_rule is None:
+        print(
+            f"에러: 설정 파일({config.CONFIG_JSON_PATH})에 "
+            f"'{args.ticker}' 종목이 없습니다."
+        )
         sys.exit(1)
-
+    if not target_rule.enabled:
+        print(
+            f"에러: '{args.ticker}'는 비활성화 상태입니다. "
+            f"매매하려면 설정 파일에서 enabled=true 로 변경하세요."
+        )
+        sys.exit(1)
     market_type = target_rule.market_type
-    logger.info(f"Market Type: {market_type}")
 
-    # 2. 브로커 및 저장소 초기화
+    log_dir = os.path.join(config.LOG_PATH, market_type)
+    logger = TradeLogger(log_dir)
+    logger.info(
+        f"=== Manual Trade CLI: {args.ticker} {args.action.upper()} "
+        f"(qty={args.qty}, amount={args.amount}) ==="
+    )
+
     broker = _create_broker(
         market_type=market_type,
         is_live=config.IS_LIVE,
@@ -67,159 +90,48 @@ def main():
         os.path.join(config.DATA_PATH, market_type),
         max_history_records=config.MAX_HISTORY_RECORDS,
     )
-
-    # 2.5 수량 결정 로직
-    order_qty = args.qty
-    if args.action == "buy" and args.amount:
-        prices = broker.fetch_current_prices([args.ticker])
-        if args.ticker not in prices or prices[args.ticker] <= 0:
-            logger.error(f"현재가 조회 실패: {args.ticker}")
-            sys.exit(1)
-        
-        current_price = prices[args.ticker]
-        order_qty = int(args.amount / current_price)
-        logger.info(
-            f"금액 기반 수량 계산: "
-            f"{format_money(args.amount, market_type)} / "
-            f"{format_money(current_price, market_type)} = {order_qty}주"
-        )
-        
-        if order_qty <= 0:
-            logger.error(f"계산된 수량이 0입니다. 금액({args.amount})이 너무 적습니다.")
-            sys.exit(1)
-    
-    if not order_qty or order_qty <= 0:
-        logger.error("유효한 주문 수량이 결정되지 않았습니다. --qty 또는 --amount를 확인하세요.")
-        sys.exit(1)
-
-    # 3. 기존 포지션 조회
-    positions = repo.load_positions()
-    ticker_lots = [lot for lot in positions if lot.ticker == args.ticker]
-    current_highest_level = max([lot.level for lot in ticker_lots]) if ticker_lots else 0
-
-    # 4. 차수(Level) 자동 할당
-    if args.action == "buy":
-        level = current_highest_level + 1
-    else: # sell
-        level = current_highest_level
-        if level == 0:
-            logger.error("매도할 포지션이 존재하지 않습니다.")
-            sys.exit(1)
-
-    # 5. 매도 전 수량 사전 검증 (안전 장치)
-    if args.action == "sell":
-        available_qty = sum([lot.quantity for lot in ticker_lots])
-            
-        if order_qty > available_qty:
-            logger.error(f"입력하신 매도 수량({order_qty}주)이 봇 장부상의 보유 수량({available_qty}주)보다 많습니다. 팻핑거(오타) 방지를 위해 주문을 취소합니다.")
-            sys.exit(1)
-
-    # 6. 주문 객체 생성
-    action_enum = OrderAction.BUY if args.action == "buy" else OrderAction.SELL
-    order = Order(
-        ticker=args.ticker,
-        action=action_enum,
-        quantity=order_qty,
-        price=0.0,
+    notifier = SlackNotifier(
+        webhook_url=config.SLACK_WEBHOOK_URL,
+        logger=logger,
+        bot_token=config.SLACK_BOT_TOKEN,
+        channel_id=config.SLACK_CHANNEL_ID,
     )
+    engine = MagicSplitEngine(
+        broker=broker,
+        repo=repo,
+        logger=logger,
+        stock_rules=strategy.rules,
+        notifier=notifier,
+        is_live_trading=config.IS_LIVE,
+    )
+
+    action = OrderAction.BUY if args.action == "buy" else OrderAction.SELL
+
+    try:
+        result = engine.run_manual_trade(
+            ticker=args.ticker,
+            action=action,
+            qty=args.qty,
+            amount=args.amount,
+            dry_run=args.dry_run,
+        )
+    except Exception as e:
+        logger.error(f"수동매매 중단: {e}")
+        sys.exit(1)
 
     if args.dry_run:
-        logger.info(f"[DRY RUN] 다음 주문이 실행될 예정입니다: {order}")
-        logger.info(f"[DRY RUN] 할당될 차수(Level): {level}")
+        logger.info("=== Manual Trade (DRY RUN) 완료 ===")
         sys.exit(0)
 
-    # 6. 매매 실행
-    logger.info(">>> 주문 실행 중...")
-    executions = broker.execute_orders([order])
-    
-    if not executions:
-        logger.error("주문 실행 실패: 브로커에서 응답을 받지 못했습니다.")
+    if not result.executions:
+        logger.error("주문이 실행되지 않았습니다.")
+        sys.exit(1)
+    if all(e.status == ExecutionStatus.REJECTED for e in result.executions):
+        logger.error("모든 주문이 거절(REJECTED)되었습니다.")
         sys.exit(1)
 
-    execution = executions[0]
-    if execution.status == ExecutionStatus.REJECTED:
-        logger.error("브로커에서 주문이 거절(REJECTED)되었습니다.")
-        sys.exit(1)
-    elif execution.status == ExecutionStatus.ORDERED:
-        logger.warning("주문이 접수(ORDERED)되었으나 지정된 대기 시간 내에 체결되지 않았습니다. 포지션 장부를 업데이트하지 않고 종료합니다.")
-        sys.exit(0)
-    elif execution.status not in [ExecutionStatus.FILLED, ExecutionStatus.PARTIAL]:
-        logger.error(f"알 수 없는 주문 상태({execution.status})입니다. 안전을 위해 장부를 업데이트하지 않습니다.")
-        sys.exit(1)
+    logger.info("=== Manual Trade 완료 ===")
 
-    logger.info(
-        f"주문 체결 완료! "
-        f"(가격: {format_money(execution.price, market_type)}, 수량: {execution.quantity})"
-    )
-
-    # 7. 포지션(positions.json) 업데이트
-    updated_positions = list(positions)
-    today_str = datetime.now().strftime("%Y-%m-%d")
-    
-    if args.action == "buy":
-        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-        new_lot = PositionLot(
-            lot_id=f"lot_{ts}_{args.ticker}_{level:03d}_manual",
-            ticker=execution.ticker,
-            buy_price=execution.price,
-            quantity=execution.quantity,
-            buy_date=today_str,
-            level=level,
-        )
-        updated_positions.append(new_lot)
-        logger.info(
-            f"[Position] New lot 추가됨: Lv{level} / {execution.quantity}주 "
-            f"@ {format_money(execution.price, market_type)}"
-        )
-    else:
-        # 매도 처리 로직: 높은 차수(가장 최근에 물타기한 것)부터 우선적으로 팔도록 레벨 역순 정렬
-        target_lots = sorted(
-            [lot for lot in updated_positions if lot.ticker == args.ticker], 
-            key=lambda x: x.level, 
-            reverse=True
-        )
-            
-        remaining_qty = execution.quantity
-        for target_lot in target_lots:
-            if remaining_qty <= 0:
-                break
-            
-            if target_lot.quantity <= remaining_qty:
-                # 해당 Lot 전량 매도
-                remaining_qty -= target_lot.quantity
-                updated_positions.remove(target_lot)
-                logger.info(f"[Position] Lot 제거됨: {target_lot.lot_id} (Lv{target_lot.level})")
-            else:
-                # 부분 매도
-                target_lot.quantity -= remaining_qty
-                remaining_qty = 0
-                logger.info(f"[Position] Lot 부분 매도됨: {target_lot.lot_id} (남은 수량: {target_lot.quantity})")
-                
-        if remaining_qty > 0:
-            logger.warning(f"매도 수량({execution.quantity})이 포지션 수량보다 많습니다. 초과분({remaining_qty})은 무시됩니다.")
-
-    # 8. 포트폴리오 상태 및 히스토리 업데이트
-    logger.info(">>> 상태 저장 중...")
-    portfolio = broker.get_portfolio()
-    repo.save_positions(updated_positions)
-    
-    # Fake Signal for history reason
-    reason_str = "수동 매매(Manual Trade)"
-    signals = [SplitSignal(
-        ticker=args.ticker,
-        lot_id=None,
-        action=action_enum,
-        quantity=execution.quantity,
-        price=execution.price,
-        reason=reason_str,
-        pct_change=0.0,
-        level=level
-    )]
-    
-    repo.save_trade_history(executions, portfolio, reason_str, signals=signals)
-    repo.update_status(portfolio, updated_positions, reason_str)
-    
-    logger.info("=== 수동 매매 및 상태 동기화 완료 ===")
 
 if __name__ == "__main__":
     main()

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -266,10 +266,18 @@ class MagicSplitEngine:
                 f"비활성화된 종목 매수 불가: {ticker}. "
                 f"config에서 enabled=true 설정 후 매수하세요. (매도는 청산 목적으로 허용됨)"
             )
-        if qty is None and amount is None:
-            raise ValueError("qty 또는 amount 중 하나는 반드시 지정해야 합니다.")
-        if action == OrderAction.SELL and qty is None:
-            raise ValueError("매도는 qty로 지정해야 합니다 (amount 미지원).")
+        # 매도는 자동매매와 동일하게 최고 차수 lot 전량 매도만 지원 — 사용자 수량 지정 불가.
+        if action == OrderAction.SELL:
+            if qty is not None or amount is not None:
+                raise ValueError(
+                    "매도는 최고 차수 lot 전량 매도만 지원합니다. "
+                    "qty/amount는 지정하지 마세요 (자동매매와 동일 정책)."
+                )
+        else:  # BUY
+            if qty is None and amount is None:
+                raise ValueError(
+                    "매수는 qty 또는 amount 중 하나가 필수입니다."
+                )
 
         all_signals: List[SplitSignal] = []
         all_executions: List[TradeExecution] = []
@@ -284,42 +292,40 @@ class MagicSplitEngine:
             if current_price <= 0:
                 raise RuntimeError(f"{disp} 현재가 조회 실패")
 
-            order_qty = qty
-            if action == OrderAction.BUY and qty is None and amount is not None:
-                order_qty = int(amount / current_price)
-                self.logger.info(
-                    f"금액 기반 수량 계산: "
-                    f"{format_money(amount, self.market_type)} / "
-                    f"{format_money(current_price, self.market_type)} = {order_qty}주"
-                )
-            if not order_qty or order_qty <= 0:
-                raise ValueError(
-                    f"{disp} 유효한 주문 수량이 결정되지 않았습니다 (qty={order_qty})."
-                )
-
             ticker_lots = [lot for lot in positions if lot.ticker == ticker]
             highest_level = max((lot.level for lot in ticker_lots), default=0)
             target_lot_id: Optional[str] = None
             target_buy_price: float = 0.0
+
             if action == OrderAction.BUY:
+                # 매수: 사용자가 qty 직접 지정 또는 amount/현재가로 환산.
+                order_qty = qty
+                if order_qty is None and amount is not None:
+                    order_qty = int(amount / current_price)
+                    self.logger.info(
+                        f"금액 기반 수량 계산: "
+                        f"{format_money(amount, self.market_type)} / "
+                        f"{format_money(current_price, self.market_type)} = {order_qty}주"
+                    )
+                if not order_qty or order_qty <= 0:
+                    raise ValueError(
+                        f"{disp} 유효한 매수 수량이 결정되지 않았습니다 (qty={order_qty})."
+                    )
                 level = highest_level + 1
             else:
-                # 다중 차수 매도는 지원하지 않음 — 자동매매와 동일하게 한 번에 한 차수(최고 차수)만
-                # 처리한다. 여러 차수를 매도하려면 차수마다 본 스크립트를 다시 실행한다.
+                # 매도: 자동매매와 동일하게 최고 차수 lot 전량 매도. 수량은 자동 도출.
                 if not ticker_lots:
                     raise RuntimeError(
                         f"{disp} 매도할 포지션이 존재하지 않습니다."
                     )
                 target_lot = max(ticker_lots, key=lambda l: l.level)
-                if order_qty > target_lot.quantity:
-                    raise RuntimeError(
-                        f"{disp} 매도 수량({order_qty}주)이 최고 차수(Lv{target_lot.level}) "
-                        f"lot 수량({target_lot.quantity}주)보다 많습니다. "
-                        f"한 번에 한 차수만 매도 가능 — 차수별로 나눠 실행하세요."
-                    )
+                order_qty = target_lot.quantity
                 level = target_lot.level
                 target_lot_id = target_lot.lot_id
                 target_buy_price = target_lot.buy_price
+                self.logger.info(
+                    f"매도 수량 자동 도출: Lv{level} lot {order_qty}주 전량"
+                )
 
             signal = SplitSignal(
                 ticker=ticker,
@@ -682,12 +688,8 @@ class MagicSplitEngine:
                 if target_lot is None:
                     continue
 
-                # 체결 수량이 lot 수량보다 적으면 차감(부분 매도). 상태(PARTIAL/FILLED)와
-                # 무관 — 자동은 신호 qty == lot.qty라서 FILLED+qty<lot.qty 조합이 안 나오지만,
-                # 수동 단일 차수 부분 매도(예: 5주 lot 중 3주 매도)에서는 FILLED인 채로
-                # exe.quantity < lot.quantity가 발생할 수 있다.
-                # last_sell_prices는 lot이 완전히 청산될 때만 갱신(재진입 가드 정책 유지).
-                if exe.quantity < target_lot.quantity:
+                if (exe.status == ExecutionStatus.PARTIAL
+                        and exe.quantity < target_lot.quantity):
                     new_qty = target_lot.quantity - exe.quantity
                     idx = updated.index(target_lot)
                     updated[idx] = replace(target_lot, quantity=new_qty)

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -229,7 +229,6 @@ class MagicSplitEngine:
         self,
         ticker: str,
         action: OrderAction,
-        dry_run: bool = False,
         sim_date: Optional[str] = None,
     ) -> DayResult:
         """수동매매 1건을 실행한다.
@@ -245,7 +244,6 @@ class MagicSplitEngine:
             ticker: 종목 코드 (활성화된 stock_rules에 등록되어 있어야 함;
                     SELL은 비활성 종목도 청산 목적으로 허용)
             action: OrderAction.BUY 또는 OrderAction.SELL
-            dry_run: True면 신호 생성까지만 수행하고 주문/저장은 생략
             sim_date: 시뮬레이션 날짜 ("YYYY-MM-DD")
         """
         today = sim_date or datetime.now().strftime("%Y-%m-%d")
@@ -337,16 +335,6 @@ class MagicSplitEngine:
                 f"@{format_money(current_price, self.market_type)}"
             )
 
-            if dry_run:
-                self.logger.info("[DRY RUN] 주문 실행 및 저장을 생략합니다.")
-                return DayResult(
-                    date=today,
-                    signals=all_signals,
-                    executions=[],
-                    final_portfolio=portfolio,
-                    has_orders=False,
-                )
-
             # 주문 실행 (자동 사이클과 공유 절차)
             executions = self._execute_signals([signal])
             all_executions.extend(executions)
@@ -369,8 +357,7 @@ class MagicSplitEngine:
                     )
         finally:
             if (
-                not dry_run
-                and portfolio is not None
+                portfolio is not None
                 and positions is not None
                 and all_executions
             ):

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -229,31 +229,29 @@ class MagicSplitEngine:
         self,
         ticker: str,
         action: OrderAction,
-        qty: Optional[int] = None,
-        amount: Optional[float] = None,
         dry_run: bool = False,
         sim_date: Optional[str] = None,
     ) -> DayResult:
         """수동매매 1건을 실행한다.
 
-        evaluate_stock 단계만 우회하고 사용자 입력으로 SplitSignal을 직접 생성한 뒤,
-        자동매매와 동일한 후반부 파이프라인(주문 실행 -> 포지션 반영 -> 저장)에 흘려보낸다.
-        이로써 positions/history/status/last_sell_prices 갱신이 자동매매와 일관되게 보장된다.
+        evaluate_stock 단계만 우회하고, 자동매매와 동일한 방식으로 모든 수량을 도출한다.
+        - BUY: rule.buy_amount_at(next_level) / 현재가 -> 주문 수량 (사용자 입력 없음)
+        - SELL: 최고 차수 lot.quantity 전량 매도 (사용자 입력 없음)
+
+        후반부 파이프라인(주문 실행 -> 포지션 반영 -> 저장)은 자동매매와 100% 동일.
+        max_lots 같은 안전 한도도 동일하게 적용된다.
 
         Args:
-            ticker: 종목 코드 (활성화된 stock_rules에 등록되어 있어야 함)
+            ticker: 종목 코드 (활성화된 stock_rules에 등록되어 있어야 함;
+                    SELL은 비활성 종목도 청산 목적으로 허용)
             action: OrderAction.BUY 또는 OrderAction.SELL
-            qty: 주문 수량 (amount와 둘 중 하나 필수)
-            amount: 매수 금액 (매수 시에만 유효, 현재가로 qty 계산)
             dry_run: True면 신호 생성까지만 수행하고 주문/저장은 생략
             sim_date: 시뮬레이션 날짜 ("YYYY-MM-DD")
         """
         today = sim_date or datetime.now().strftime("%Y-%m-%d")
         disp = display_ticker(ticker)
         self.logger.set_ticker_context(ticker)
-        self.logger.info(
-            f"=== Manual Trade: {disp} {action} (qty={qty}, amount={amount}) ==="
-        )
+        self.logger.info(f"=== Manual Trade: {disp} {action} ===")
 
         target_rule = next(
             (r for r in self.all_stock_rules if r.ticker == ticker), None
@@ -266,18 +264,6 @@ class MagicSplitEngine:
                 f"비활성화된 종목 매수 불가: {ticker}. "
                 f"config에서 enabled=true 설정 후 매수하세요. (매도는 청산 목적으로 허용됨)"
             )
-        # 매도는 자동매매와 동일하게 최고 차수 lot 전량 매도만 지원 — 사용자 수량 지정 불가.
-        if action == OrderAction.SELL:
-            if qty is not None or amount is not None:
-                raise ValueError(
-                    "매도는 최고 차수 lot 전량 매도만 지원합니다. "
-                    "qty/amount는 지정하지 마세요 (자동매매와 동일 정책)."
-                )
-        else:  # BUY
-            if qty is None and amount is None:
-                raise ValueError(
-                    "매수는 qty 또는 amount 중 하나가 필수입니다."
-                )
 
         all_signals: List[SplitSignal] = []
         all_executions: List[TradeExecution] = []
@@ -298,20 +284,27 @@ class MagicSplitEngine:
             target_buy_price: float = 0.0
 
             if action == OrderAction.BUY:
-                # 매수: 사용자가 qty 직접 지정 또는 amount/현재가로 환산.
-                order_qty = qty
-                if order_qty is None and amount is not None:
-                    order_qty = int(amount / current_price)
-                    self.logger.info(
-                        f"금액 기반 수량 계산: "
-                        f"{format_money(amount, self.market_type)} / "
-                        f"{format_money(current_price, self.market_type)} = {order_qty}주"
-                    )
-                if not order_qty or order_qty <= 0:
-                    raise ValueError(
-                        f"{disp} 유효한 매수 수량이 결정되지 않았습니다 (qty={order_qty})."
-                    )
+                # 매수: 자동 evaluator와 동일하게 rule.buy_amount_at(next_level)에서 금액
+                # 도출 후 현재가로 수량 환산. 사용자 수량/금액 지정 없음.
                 level = highest_level + 1
+                if level > target_rule.max_lots:
+                    raise RuntimeError(
+                        f"{disp} max_lots({target_rule.max_lots}) 도달 — "
+                        f"현재 최고 차수 Lv{highest_level}, 다음 차수 Lv{level}는 매수 불가."
+                    )
+                buy_amount = target_rule.buy_amount_at(level)
+                order_qty = int(buy_amount / current_price)
+                if order_qty <= 0:
+                    raise RuntimeError(
+                        f"{disp} 매수 수량 0주 — Lv{level} buy_amount"
+                        f"({format_money(buy_amount, self.market_type)})가 "
+                        f"현재가({format_money(current_price, self.market_type)})보다 작음."
+                    )
+                self.logger.info(
+                    f"매수 수량 자동 도출: Lv{level} buy_amount="
+                    f"{format_money(buy_amount, self.market_type)} / 현재가="
+                    f"{format_money(current_price, self.market_type)} = {order_qty}주"
+                )
             else:
                 # 매도: 자동매매와 동일하게 최고 차수 lot 전량 매도. 수량은 자동 도출.
                 if not ticker_lots:

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -276,9 +276,11 @@ class MagicSplitEngine:
         )
         if target_rule is None:
             raise ValueError(f"설정에 등록되지 않은 종목입니다: {ticker}")
-        if not target_rule.enabled:
+        # 비활성 종목은 매수만 차단. 매도는 잔여 포지션 청산을 위해 허용.
+        if not target_rule.enabled and action == OrderAction.BUY:
             raise ValueError(
-                f"비활성화된 종목입니다: {ticker}. 매매하려면 config에서 enabled=true 설정 필요."
+                f"비활성화된 종목 매수 불가: {ticker}. "
+                f"config에서 enabled=true 설정 후 매수하세요. (매도는 청산 목적으로 허용됨)"
             )
         if qty is None and amount is None:
             raise ValueError("qty 또는 amount 중 하나는 반드시 지정해야 합니다.")
@@ -323,6 +325,7 @@ class MagicSplitEngine:
             highest_level = max((lot.level for lot in ticker_lots), default=0)
             target_lot_id: Optional[str] = None
             target_buy_price: float = 0.0
+            spans_lots: int = 1
             if action == OrderAction.BUY:
                 level = highest_level + 1
             else:
@@ -336,10 +339,19 @@ class MagicSplitEngine:
                         f"{disp} 매도 수량({order_qty}주)이 보유 수량"
                         f"({available_qty}주)보다 많습니다. 팻핑거 방지를 위해 주문 취소."
                     )
-                target_lot = max(ticker_lots, key=lambda l: l.level)
-                level = target_lot.level
-                target_lot_id = target_lot.lot_id
-                target_buy_price = target_lot.buy_price
+                # 매도 계획: 최고 차수부터 lot을 차감하며 가중 평균 매수가 산출.
+                # 단일 lot에 한정하지 않고 필요한 만큼 차수를 소비한다.
+                plan = self._plan_manual_sell_consumption(ticker_lots, order_qty)
+                spans_lots = len(plan)
+                top_lot = plan[0][0]
+                level = top_lot.level
+                target_lot_id = top_lot.lot_id
+                consumed_cost = sum(lot.buy_price * q for lot, q in plan)
+                target_buy_price = consumed_cost / order_qty
+
+            reason = "수동 매매(Manual Trade)"
+            if action == OrderAction.SELL and spans_lots > 1:
+                reason = f"수동 매매(Manual Trade) - {spans_lots}개 차수 소비"
 
             signal = SplitSignal(
                 ticker=ticker,
@@ -347,7 +359,7 @@ class MagicSplitEngine:
                 action=action,
                 quantity=order_qty,
                 price=current_price,
-                reason="수동 매매(Manual Trade)",
+                reason=reason,
                 pct_change=0.0,
                 level=level,
                 buy_price=target_buy_price,
@@ -375,10 +387,16 @@ class MagicSplitEngine:
 
             if executions:
                 try:
-                    positions = self._update_positions(
-                        positions, [signal], executions, today,
-                        last_sell_prices=last_sell_prices,
-                    )
+                    if action == OrderAction.SELL:
+                        positions = self._apply_manual_sell(
+                            positions, ticker, executions[0],
+                            last_sell_prices=last_sell_prices,
+                        )
+                    else:
+                        positions = self._update_positions(
+                            positions, [signal], executions, today,
+                            last_sell_prices=last_sell_prices,
+                        )
                     portfolio = self._refresh_portfolio(portfolio)
                 except Exception as e:
                     self.logger.error(
@@ -424,6 +442,132 @@ class MagicSplitEngine:
             ),
             has_orders=len(all_executions) > 0,
         )
+
+    @staticmethod
+    def _plan_manual_sell_consumption(
+        ticker_lots: List[PositionLot],
+        target_qty: int,
+    ) -> List[tuple]:
+        """target_qty를 소비하기 위해 어떤 lot을 얼마씩 차감할지 계획한다.
+
+        가장 높은 차수부터 순차 소비하며, lot 수량이 부족하면 다음 차수로 넘어간다.
+        호출 측에서 target_qty <= sum(lot.quantity) 검증을 마쳤다고 가정한다.
+
+        Returns:
+            [(lot, qty_to_consume), ...] 리스트. 첫 항목이 가장 높은 차수.
+        """
+        plan: List[tuple] = []
+        remaining = target_qty
+        for lot in sorted(ticker_lots, key=lambda l: l.level, reverse=True):
+            if remaining <= 0:
+                break
+            take = min(remaining, lot.quantity)
+            plan.append((lot, take))
+            remaining -= take
+        return plan
+
+    def _apply_manual_sell(
+        self,
+        positions: List[PositionLot],
+        ticker: str,
+        execution: TradeExecution,
+        last_sell_prices: Optional[dict] = None,
+    ) -> List[PositionLot]:
+        """수동 매도 체결을 다중 차수에 걸쳐 소비한다.
+
+        가장 높은 차수부터 소진하며, 체결 수량이 단일 lot을 초과하면 다음 차수의 lot도
+        부분 또는 전량 소비한다. 실제 체결 수량(execution.quantity) 기준으로 동작하므로
+        PARTIAL 체결 시에도 정확히 반영된다. 소비된 lot들의 매수가 가중평균으로
+        execution.realized_pnl/buy_price를 갱신한다.
+        """
+        disp = display_ticker(ticker)
+        if execution.status == ExecutionStatus.REJECTED:
+            self.logger.warning(
+                f"[Position] Skip: {disp} SELL rejected"
+            )
+            self._notify_alert(
+                f"[{disp}] 수동매도 거절(REJECTED): {execution.reason}"
+            )
+            return positions
+        if execution.status == ExecutionStatus.ORDERED:
+            self.logger.error(
+                f"[Position] ORDERED — 수동 확인 필요: {disp} SELL "
+                f"reason={execution.reason}"
+            )
+            self._notify_alert(
+                f"[{disp}] 수동매도 미체결 잔존 — KIS에서 직접 확인 후 "
+                f"scripts/reconcile_positions.py 실행 권장. {execution.reason}"
+            )
+            return positions
+        if execution.quantity <= 0:
+            self.logger.warning(
+                f"[Position] Skip zero-qty execution: {disp} SELL "
+                f"status={execution.status}"
+            )
+            return positions
+
+        updated = list(positions)
+        target_lots = sorted(
+            [l for l in updated if l.ticker == ticker],
+            key=lambda l: l.level,
+            reverse=True,
+        )
+
+        remaining = execution.quantity
+        consumed_cost = 0.0
+        consumed_qty = 0
+        top_consumed_lot: Optional[PositionLot] = None
+
+        for lot in target_lots:
+            if remaining <= 0:
+                break
+            if lot.quantity <= remaining:
+                consumed_cost += lot.buy_price * lot.quantity
+                consumed_qty += lot.quantity
+                remaining -= lot.quantity
+                if top_consumed_lot is None:
+                    top_consumed_lot = lot
+                updated.remove(lot)
+                self.logger.info(
+                    f"[Position] Remove lot: {lot.lot_id} Lv{lot.level} "
+                    f"({lot.quantity}주 전량 매도)"
+                )
+            else:
+                consumed_cost += lot.buy_price * remaining
+                consumed_qty += remaining
+                if top_consumed_lot is None:
+                    top_consumed_lot = lot
+                new_qty = lot.quantity - remaining
+                idx = updated.index(lot)
+                updated[idx] = replace(lot, quantity=new_qty)
+                self.logger.info(
+                    f"[Position] Partial sell: {lot.lot_id} Lv{lot.level} "
+                    f"({remaining}/{lot.quantity}주, 잔량 {new_qty})"
+                )
+                remaining = 0
+
+        if remaining > 0:
+            self.logger.warning(
+                f"[Position] Over-fill detected: {disp} 매도 체결 "
+                f"{execution.quantity}주 중 {remaining}주가 장부에 반영되지 못했습니다. "
+                f"scripts/reconcile_positions.py 로 정합성 확인 권장."
+            )
+
+        # 가중 평균 매수가로 PnL 재계산 (다중 차수 일관 처리)
+        if consumed_qty > 0:
+            weighted_buy = consumed_cost / consumed_qty
+            execution.buy_price = round(weighted_buy, 4)
+            execution.realized_pnl = round(
+                (execution.price - weighted_buy) * consumed_qty - execution.fee, 2
+            )
+            if top_consumed_lot is not None:
+                execution.lot_id = top_consumed_lot.lot_id
+                execution.level = top_consumed_lot.level
+
+        if last_sell_prices is not None:
+            last_sell_prices[ticker] = execution.price
+
+        return updated
 
     # ── Overridable step methods ─────────────────────────────────
 

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -2,7 +2,7 @@
 import time
 from dataclasses import replace
 from datetime import datetime
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, Tuple
 
 from src.core.interfaces import IBrokerAdapter, IRepository, ILogger, INotifier
 from src.core.models import (
@@ -77,22 +77,8 @@ class MagicSplitEngine:
         positions: Optional[List[PositionLot]] = None
 
         try:
-            # Step 1: 포트폴리오 조회 + 실시간 가격 (전 종목 일괄)
-            self.logger.info(">>> Step 1: Portfolio & Price Fetch")
-            portfolio = self.get_portfolio()
-            self.logger.info(
-                f"Portfolio: Cash={format_money(portfolio.total_cash, self.market_type)}, "
-                f"Value={format_money(portfolio.total_value, self.market_type)}"
-            )
-
-            # Step 2: 기존 분할 포지션 로드
-            self.logger.info(">>> Step 2: Load Positions")
-            positions = self.repo.load_positions()
-            self.logger.info(f"Loaded {len(positions)} position lot(s)")
-
-            # 재진입 가드 및 동적 재매수용 직전 매도가 조회.
-            # 매도 체결 시 갱신, 매수 체결 시 초기화.
-            last_sell_prices: dict = self.repo.load_last_sell_prices()
+            # Step 1+2: 포트폴리오 + 포지션 + 직전 매도가 (수동매매와 공유)
+            portfolio, positions, last_sell_prices = self._load_initial_state()
 
             # Step 2.1: 상태 전환 감지 및 자동 초기화 (OFF -> ON)
             self._handle_state_transitions(positions, last_sell_prices)
@@ -147,10 +133,8 @@ class MagicSplitEngine:
                             )
                         continue
 
-                    # 3b. 주문 실행
-                    orders = self._signals_to_orders(active_signals)
-                    executions = self._execute_stock_orders(orders)
-                    self._enrich_executions(executions, active_signals)
+                    # 3b. 주문 실행 (수동매매와 공유 절차)
+                    executions = self._execute_signals(active_signals)
                     all_executions.extend(executions)
 
                     # 3c. 포지션 즉시 반영 (다음 종목 판단에 영향)
@@ -294,19 +278,11 @@ class MagicSplitEngine:
         last_sell_prices: dict = {}
 
         try:
-            self.logger.info(">>> Step 1: Portfolio & Price Fetch")
-            portfolio = self.get_portfolio()
-            if portfolio.current_prices.get(ticker, 0) <= 0:
-                extra = self.broker.fetch_current_prices([ticker])
-                if extra.get(ticker, 0) > 0:
-                    portfolio.current_prices[ticker] = extra[ticker]
-            current_price = portfolio.current_prices.get(ticker, 0)
+            # Step 1+2: 자동 사이클과 동일한 상태 로드 (공유 헬퍼)
+            portfolio, positions, last_sell_prices = self._load_initial_state()
+            current_price = self._ensure_current_price(portfolio, ticker)
             if current_price <= 0:
                 raise RuntimeError(f"{disp} 현재가 조회 실패")
-
-            self.logger.info(">>> Step 2: Load Positions")
-            positions = self.repo.load_positions()
-            last_sell_prices = self.repo.load_last_sell_prices()
 
             order_qty = qty
             if action == OrderAction.BUY and qty is None and amount is not None:
@@ -380,9 +356,8 @@ class MagicSplitEngine:
                     has_orders=False,
                 )
 
-            orders = self._signals_to_orders([signal])
-            executions = self._execute_stock_orders(orders)
-            self._enrich_executions(executions, [signal])
+            # 주문 실행 (자동 사이클과 공유 절차)
+            executions = self._execute_signals([signal])
             all_executions.extend(executions)
 
             if executions:
@@ -580,6 +555,57 @@ class MagicSplitEngine:
             if price > 0:
                 portfolio.current_prices[ticker] = price
         return portfolio
+
+    # ── Shared procedural helpers (run_one_cycle / run_manual_trade 공용) ─
+
+    def _load_initial_state(
+        self,
+    ) -> Tuple[Portfolio, List[PositionLot], Dict[str, float]]:
+        """Step 1+2: 포트폴리오 + 포지션 + 직전 매도가 일괄 로드.
+
+        run_one_cycle, run_manual_trade가 공통으로 사용한다. 한쪽 절차에 추가/변경이
+        생기면 이 함수만 손대면 양쪽이 동일하게 따라온다.
+        """
+        self.logger.info(">>> Step 1: Portfolio & Price Fetch")
+        portfolio = self.get_portfolio()
+        self.logger.info(
+            f"Portfolio: Cash={format_money(portfolio.total_cash, self.market_type)}, "
+            f"Value={format_money(portfolio.total_value, self.market_type)}"
+        )
+        self.logger.info(">>> Step 2: Load Positions")
+        positions = self.repo.load_positions()
+        self.logger.info(f"Loaded {len(positions)} position lot(s)")
+        # 재진입 가드 및 동적 재매수용 직전 매도가 조회.
+        # 매도 체결 시 갱신, 매수 체결 시 초기화.
+        last_sell_prices: Dict[str, float] = self.repo.load_last_sell_prices()
+        return portfolio, positions, last_sell_prices
+
+    def _ensure_current_price(self, portfolio: Portfolio, ticker: str) -> float:
+        """portfolio.current_prices에 ticker가 빠져 있으면 broker로 보강 조회한다.
+
+        get_portfolio()는 self.all_tickers(활성 종목)에 대해서만 가격을 채우므로,
+        수동매매에서 비활성 종목을 청산할 때 등 전용 경로에서 사용한다.
+        """
+        if portfolio.current_prices.get(ticker, 0) <= 0:
+            extra = self.broker.fetch_current_prices([ticker])
+            if extra.get(ticker, 0) > 0:
+                portfolio.current_prices[ticker] = extra[ticker]
+        return portfolio.current_prices.get(ticker, 0)
+
+    def _execute_signals(
+        self, signals: List[SplitSignal],
+    ) -> List[TradeExecution]:
+        """SplitSignal -> Order -> 브로커 실행 -> 체결 컨텍스트 보강.
+
+        run_one_cycle과 run_manual_trade의 주문 실행 부분이 동일한 절차를 따르도록
+        한 곳으로 모은다. 신호가 비어 있으면 빈 리스트를 반환한다.
+        """
+        if not signals:
+            return []
+        orders = self._signals_to_orders(signals)
+        executions = self._execute_stock_orders(orders)
+        self._enrich_executions(executions, signals)
+        return executions
 
     def _signals_to_orders(self, signals: List[SplitSignal]) -> List[Order]:
         """SplitSignal 리스트를 Order 리스트로 변환한다."""

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -51,6 +51,8 @@ class MagicSplitEngine:
         self.all_tickers = [r.ticker for r in self.stock_rules]
         self.notifier = notifier
         self.is_live_trading = is_live_trading
+        # 비활성 포함 전체 룰. 수동매매 등에서 룰 조회용으로 사용.
+        self.all_stock_rules = list(stock_rules)
         # 한 사이클의 모든 종목은 동일 market_type. 로그 통화 분기에 사용.
         self.market_type = self.stock_rules[0].market_type if self.stock_rules else "overseas"
 
@@ -236,6 +238,190 @@ class MagicSplitEngine:
             signals=all_signals,
             executions=all_executions,
             final_portfolio=final_pf,
+            has_orders=len(all_executions) > 0,
+        )
+
+    def run_manual_trade(
+        self,
+        ticker: str,
+        action: OrderAction,
+        qty: Optional[int] = None,
+        amount: Optional[float] = None,
+        dry_run: bool = False,
+        sim_date: Optional[str] = None,
+    ) -> DayResult:
+        """수동매매 1건을 실행한다.
+
+        evaluate_stock 단계만 우회하고 사용자 입력으로 SplitSignal을 직접 생성한 뒤,
+        자동매매와 동일한 후반부 파이프라인(주문 실행 -> 포지션 반영 -> 저장)에 흘려보낸다.
+        이로써 positions/history/status/last_sell_prices 갱신이 자동매매와 일관되게 보장된다.
+
+        Args:
+            ticker: 종목 코드 (활성화된 stock_rules에 등록되어 있어야 함)
+            action: OrderAction.BUY 또는 OrderAction.SELL
+            qty: 주문 수량 (amount와 둘 중 하나 필수)
+            amount: 매수 금액 (매수 시에만 유효, 현재가로 qty 계산)
+            dry_run: True면 신호 생성까지만 수행하고 주문/저장은 생략
+            sim_date: 시뮬레이션 날짜 ("YYYY-MM-DD")
+        """
+        today = sim_date or datetime.now().strftime("%Y-%m-%d")
+        disp = display_ticker(ticker)
+        self.logger.set_ticker_context(ticker)
+        self.logger.info(
+            f"=== Manual Trade: {disp} {action} (qty={qty}, amount={amount}) ==="
+        )
+
+        target_rule = next(
+            (r for r in self.all_stock_rules if r.ticker == ticker), None
+        )
+        if target_rule is None:
+            raise ValueError(f"설정에 등록되지 않은 종목입니다: {ticker}")
+        if not target_rule.enabled:
+            raise ValueError(
+                f"비활성화된 종목입니다: {ticker}. 매매하려면 config에서 enabled=true 설정 필요."
+            )
+        if qty is None and amount is None:
+            raise ValueError("qty 또는 amount 중 하나는 반드시 지정해야 합니다.")
+        if action == OrderAction.SELL and qty is None:
+            raise ValueError("매도는 qty로 지정해야 합니다 (amount 미지원).")
+
+        all_signals: List[SplitSignal] = []
+        all_executions: List[TradeExecution] = []
+        portfolio: Optional[Portfolio] = None
+        positions: Optional[List[PositionLot]] = None
+        last_sell_prices: dict = {}
+
+        try:
+            self.logger.info(">>> Step 1: Portfolio & Price Fetch")
+            portfolio = self.get_portfolio()
+            if portfolio.current_prices.get(ticker, 0) <= 0:
+                extra = self.broker.fetch_current_prices([ticker])
+                if extra.get(ticker, 0) > 0:
+                    portfolio.current_prices[ticker] = extra[ticker]
+            current_price = portfolio.current_prices.get(ticker, 0)
+            if current_price <= 0:
+                raise RuntimeError(f"{disp} 현재가 조회 실패")
+
+            self.logger.info(">>> Step 2: Load Positions")
+            positions = self.repo.load_positions()
+            last_sell_prices = self.repo.load_last_sell_prices()
+
+            order_qty = qty
+            if action == OrderAction.BUY and qty is None and amount is not None:
+                order_qty = int(amount / current_price)
+                self.logger.info(
+                    f"금액 기반 수량 계산: "
+                    f"{format_money(amount, self.market_type)} / "
+                    f"{format_money(current_price, self.market_type)} = {order_qty}주"
+                )
+            if not order_qty or order_qty <= 0:
+                raise ValueError(
+                    f"{disp} 유효한 주문 수량이 결정되지 않았습니다 (qty={order_qty})."
+                )
+
+            ticker_lots = [lot for lot in positions if lot.ticker == ticker]
+            highest_level = max((lot.level for lot in ticker_lots), default=0)
+            target_lot_id: Optional[str] = None
+            target_buy_price: float = 0.0
+            if action == OrderAction.BUY:
+                level = highest_level + 1
+            else:
+                if not ticker_lots:
+                    raise RuntimeError(
+                        f"{disp} 매도할 포지션이 존재하지 않습니다."
+                    )
+                available_qty = sum(lot.quantity for lot in ticker_lots)
+                if order_qty > available_qty:
+                    raise RuntimeError(
+                        f"{disp} 매도 수량({order_qty}주)이 보유 수량"
+                        f"({available_qty}주)보다 많습니다. 팻핑거 방지를 위해 주문 취소."
+                    )
+                target_lot = max(ticker_lots, key=lambda l: l.level)
+                level = target_lot.level
+                target_lot_id = target_lot.lot_id
+                target_buy_price = target_lot.buy_price
+
+            signal = SplitSignal(
+                ticker=ticker,
+                lot_id=target_lot_id,
+                action=action,
+                quantity=order_qty,
+                price=current_price,
+                reason="수동 매매(Manual Trade)",
+                pct_change=0.0,
+                level=level,
+                buy_price=target_buy_price,
+            )
+            all_signals.append(signal)
+            self.logger.info(
+                f"[{disp}] 수동 신호 생성: {action} Lv{level} {order_qty}주 "
+                f"@{format_money(current_price, self.market_type)}"
+            )
+
+            if dry_run:
+                self.logger.info("[DRY RUN] 주문 실행 및 저장을 생략합니다.")
+                return DayResult(
+                    date=today,
+                    signals=all_signals,
+                    executions=[],
+                    final_portfolio=portfolio,
+                    has_orders=False,
+                )
+
+            orders = self._signals_to_orders([signal])
+            executions = self._execute_stock_orders(orders)
+            self._enrich_executions(executions, [signal])
+            all_executions.extend(executions)
+
+            if executions:
+                try:
+                    positions = self._update_positions(
+                        positions, [signal], executions, today,
+                        last_sell_prices=last_sell_prices,
+                    )
+                    portfolio = self._refresh_portfolio(portfolio)
+                except Exception as e:
+                    self.logger.error(
+                        f"[{disp}] 포지션 반영 실패 (체결은 완료됨): {e}"
+                    )
+                    self._notify_alert(
+                        f"[{disp}] 수동매매 포지션 반영 실패 "
+                        f"(체결 {len(executions)}건 완료됨): {e}"
+                    )
+        finally:
+            if (
+                not dry_run
+                and portfolio is not None
+                and positions is not None
+                and all_executions
+            ):
+                self.logger.info(">>> Step 6: Persist")
+                self._persist(
+                    portfolio, all_signals, all_executions, positions,
+                    sim_date=sim_date, last_sell_prices=last_sell_prices,
+                )
+
+        self.logger.set_ticker_context(None)
+        detail = "\n".join(self.logger.get_captured_logs(ticker))
+        filled = [e for e in all_executions if e.status != ExecutionStatus.REJECTED]
+        if filled:
+            self._notify_message(
+                f"[수동매매] {disp} {action} 체결 {len(filled)}건",
+                detail=detail,
+            )
+        elif all_executions:
+            self._notify_alert(
+                f"[수동매매] {disp} {action} 체결 실패 또는 거절",
+                detail=detail,
+            )
+
+        return DayResult(
+            date=today,
+            signals=all_signals,
+            executions=all_executions,
+            final_portfolio=portfolio or Portfolio(
+                total_cash=0.0, holdings={}, current_prices={},
+            ),
             has_orders=len(all_executions) > 0,
         )
 

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -301,33 +301,25 @@ class MagicSplitEngine:
             highest_level = max((lot.level for lot in ticker_lots), default=0)
             target_lot_id: Optional[str] = None
             target_buy_price: float = 0.0
-            spans_lots: int = 1
             if action == OrderAction.BUY:
                 level = highest_level + 1
             else:
+                # 다중 차수 매도는 지원하지 않음 — 자동매매와 동일하게 한 번에 한 차수(최고 차수)만
+                # 처리한다. 여러 차수를 매도하려면 차수마다 본 스크립트를 다시 실행한다.
                 if not ticker_lots:
                     raise RuntimeError(
                         f"{disp} 매도할 포지션이 존재하지 않습니다."
                     )
-                available_qty = sum(lot.quantity for lot in ticker_lots)
-                if order_qty > available_qty:
+                target_lot = max(ticker_lots, key=lambda l: l.level)
+                if order_qty > target_lot.quantity:
                     raise RuntimeError(
-                        f"{disp} 매도 수량({order_qty}주)이 보유 수량"
-                        f"({available_qty}주)보다 많습니다. 팻핑거 방지를 위해 주문 취소."
+                        f"{disp} 매도 수량({order_qty}주)이 최고 차수(Lv{target_lot.level}) "
+                        f"lot 수량({target_lot.quantity}주)보다 많습니다. "
+                        f"한 번에 한 차수만 매도 가능 — 차수별로 나눠 실행하세요."
                     )
-                # 매도 계획: 최고 차수부터 lot을 차감하며 가중 평균 매수가 산출.
-                # 단일 lot에 한정하지 않고 필요한 만큼 차수를 소비한다.
-                plan = self._plan_manual_sell_consumption(ticker_lots, order_qty)
-                spans_lots = len(plan)
-                top_lot = plan[0][0]
-                level = top_lot.level
-                target_lot_id = top_lot.lot_id
-                consumed_cost = sum(lot.buy_price * q for lot, q in plan)
-                target_buy_price = consumed_cost / order_qty
-
-            reason = "수동 매매(Manual Trade)"
-            if action == OrderAction.SELL and spans_lots > 1:
-                reason = f"수동 매매(Manual Trade) - {spans_lots}개 차수 소비"
+                level = target_lot.level
+                target_lot_id = target_lot.lot_id
+                target_buy_price = target_lot.buy_price
 
             signal = SplitSignal(
                 ticker=ticker,
@@ -335,7 +327,7 @@ class MagicSplitEngine:
                 action=action,
                 quantity=order_qty,
                 price=current_price,
-                reason=reason,
+                reason="수동 매매(Manual Trade)",
                 pct_change=0.0,
                 level=level,
                 buy_price=target_buy_price,
@@ -362,16 +354,11 @@ class MagicSplitEngine:
 
             if executions:
                 try:
-                    if action == OrderAction.SELL:
-                        positions = self._apply_manual_sell(
-                            positions, ticker, executions[0],
-                            last_sell_prices=last_sell_prices,
-                        )
-                    else:
-                        positions = self._update_positions(
-                            positions, [signal], executions, today,
-                            last_sell_prices=last_sell_prices,
-                        )
+                    # 자동매매와 동일: 단일 lot 대상 신호 -> _update_positions
+                    positions = self._update_positions(
+                        positions, [signal], executions, today,
+                        last_sell_prices=last_sell_prices,
+                    )
                     portfolio = self._refresh_portfolio(portfolio)
                 except Exception as e:
                     self.logger.error(
@@ -417,132 +404,6 @@ class MagicSplitEngine:
             ),
             has_orders=len(all_executions) > 0,
         )
-
-    @staticmethod
-    def _plan_manual_sell_consumption(
-        ticker_lots: List[PositionLot],
-        target_qty: int,
-    ) -> List[tuple]:
-        """target_qty를 소비하기 위해 어떤 lot을 얼마씩 차감할지 계획한다.
-
-        가장 높은 차수부터 순차 소비하며, lot 수량이 부족하면 다음 차수로 넘어간다.
-        호출 측에서 target_qty <= sum(lot.quantity) 검증을 마쳤다고 가정한다.
-
-        Returns:
-            [(lot, qty_to_consume), ...] 리스트. 첫 항목이 가장 높은 차수.
-        """
-        plan: List[tuple] = []
-        remaining = target_qty
-        for lot in sorted(ticker_lots, key=lambda l: l.level, reverse=True):
-            if remaining <= 0:
-                break
-            take = min(remaining, lot.quantity)
-            plan.append((lot, take))
-            remaining -= take
-        return plan
-
-    def _apply_manual_sell(
-        self,
-        positions: List[PositionLot],
-        ticker: str,
-        execution: TradeExecution,
-        last_sell_prices: Optional[dict] = None,
-    ) -> List[PositionLot]:
-        """수동 매도 체결을 다중 차수에 걸쳐 소비한다.
-
-        가장 높은 차수부터 소진하며, 체결 수량이 단일 lot을 초과하면 다음 차수의 lot도
-        부분 또는 전량 소비한다. 실제 체결 수량(execution.quantity) 기준으로 동작하므로
-        PARTIAL 체결 시에도 정확히 반영된다. 소비된 lot들의 매수가 가중평균으로
-        execution.realized_pnl/buy_price를 갱신한다.
-        """
-        disp = display_ticker(ticker)
-        if execution.status == ExecutionStatus.REJECTED:
-            self.logger.warning(
-                f"[Position] Skip: {disp} SELL rejected"
-            )
-            self._notify_alert(
-                f"[{disp}] 수동매도 거절(REJECTED): {execution.reason}"
-            )
-            return positions
-        if execution.status == ExecutionStatus.ORDERED:
-            self.logger.error(
-                f"[Position] ORDERED — 수동 확인 필요: {disp} SELL "
-                f"reason={execution.reason}"
-            )
-            self._notify_alert(
-                f"[{disp}] 수동매도 미체결 잔존 — KIS에서 직접 확인 후 "
-                f"scripts/reconcile_positions.py 실행 권장. {execution.reason}"
-            )
-            return positions
-        if execution.quantity <= 0:
-            self.logger.warning(
-                f"[Position] Skip zero-qty execution: {disp} SELL "
-                f"status={execution.status}"
-            )
-            return positions
-
-        updated = list(positions)
-        target_lots = sorted(
-            [l for l in updated if l.ticker == ticker],
-            key=lambda l: l.level,
-            reverse=True,
-        )
-
-        remaining = execution.quantity
-        consumed_cost = 0.0
-        consumed_qty = 0
-        top_consumed_lot: Optional[PositionLot] = None
-
-        for lot in target_lots:
-            if remaining <= 0:
-                break
-            if lot.quantity <= remaining:
-                consumed_cost += lot.buy_price * lot.quantity
-                consumed_qty += lot.quantity
-                remaining -= lot.quantity
-                if top_consumed_lot is None:
-                    top_consumed_lot = lot
-                updated.remove(lot)
-                self.logger.info(
-                    f"[Position] Remove lot: {lot.lot_id} Lv{lot.level} "
-                    f"({lot.quantity}주 전량 매도)"
-                )
-            else:
-                consumed_cost += lot.buy_price * remaining
-                consumed_qty += remaining
-                if top_consumed_lot is None:
-                    top_consumed_lot = lot
-                new_qty = lot.quantity - remaining
-                idx = updated.index(lot)
-                updated[idx] = replace(lot, quantity=new_qty)
-                self.logger.info(
-                    f"[Position] Partial sell: {lot.lot_id} Lv{lot.level} "
-                    f"({remaining}/{lot.quantity}주, 잔량 {new_qty})"
-                )
-                remaining = 0
-
-        if remaining > 0:
-            self.logger.warning(
-                f"[Position] Over-fill detected: {disp} 매도 체결 "
-                f"{execution.quantity}주 중 {remaining}주가 장부에 반영되지 못했습니다. "
-                f"scripts/reconcile_positions.py 로 정합성 확인 권장."
-            )
-
-        # 가중 평균 매수가로 PnL 재계산 (다중 차수 일관 처리)
-        if consumed_qty > 0:
-            weighted_buy = consumed_cost / consumed_qty
-            execution.buy_price = round(weighted_buy, 4)
-            execution.realized_pnl = round(
-                (execution.price - weighted_buy) * consumed_qty - execution.fee, 2
-            )
-            if top_consumed_lot is not None:
-                execution.lot_id = top_consumed_lot.lot_id
-                execution.level = top_consumed_lot.level
-
-        if last_sell_prices is not None:
-            last_sell_prices[ticker] = execution.price
-
-        return updated
 
     # ── Overridable step methods ─────────────────────────────────
 
@@ -821,8 +682,12 @@ class MagicSplitEngine:
                 if target_lot is None:
                     continue
 
-                if (exe.status == ExecutionStatus.PARTIAL
-                        and exe.quantity < target_lot.quantity):
+                # 체결 수량이 lot 수량보다 적으면 차감(부분 매도). 상태(PARTIAL/FILLED)와
+                # 무관 — 자동은 신호 qty == lot.qty라서 FILLED+qty<lot.qty 조합이 안 나오지만,
+                # 수동 단일 차수 부분 매도(예: 5주 lot 중 3주 매도)에서는 FILLED인 채로
+                # exe.quantity < lot.quantity가 발생할 수 있다.
+                # last_sell_prices는 lot이 완전히 청산될 때만 갱신(재진입 가드 정책 유지).
+                if exe.quantity < target_lot.quantity:
                     new_qty = target_lot.quantity - exe.quantity
                     idx = updated.index(target_lot)
                     updated[idx] = replace(target_lot, quantity=new_qty)

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -907,20 +907,55 @@ class TestRunManualTrade:
                 sim_date="2026-04-10",
             )
 
-    def test_disabled_ticker_raises(
+    def test_disabled_ticker_buy_raises(
         self, mock_broker, mock_repo, mock_logger,
     ):
-        """비활성 ticker -> ValueError, 매매 차단."""
+        """비활성 ticker BUY -> ValueError, 매수 차단."""
         rules = [
             StockRule("AAPL", -5.0, 10.0, 500, 10, enabled=True),
             StockRule("MSFT", -5.0, 10.0, 500, 10, enabled=False),
         ]
         eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
-        with pytest.raises(ValueError, match="비활성화"):
+        with pytest.raises(ValueError, match="비활성화된 종목 매수 불가"):
             eng.run_manual_trade(
                 ticker="MSFT", action=OrderAction.BUY, qty=1,
                 sim_date="2026-04-10",
             )
+
+    def test_disabled_ticker_sell_allowed_for_liquidation(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """비활성 ticker SELL -> 청산 목적으로 허용."""
+        rules = [
+            StockRule("AAPL", -5.0, 10.0, 500, 10, enabled=True),
+            StockRule("MSFT", -5.0, 10.0, 500, 10, enabled=False),
+        ]
+        # MSFT는 비활성이므로 self.all_tickers/get_portfolio prices에 안 잡힘
+        # → fetch_current_prices 폴백으로 가격 채움
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={"MSFT": 5},
+            current_prices={"AAPL": 100.0},
+        )
+        mock_broker.fetch_current_prices.side_effect = (
+            lambda tickers: {t: (200.0 if t == "MSFT" else 100.0) for t in tickers}
+        )
+        mock_repo.load_positions.return_value = [
+            PositionLot("lot_msft", "MSFT", 180.0, 5, "2026-04-01", level=1),
+        ]
+        mock_repo.load_last_sell_prices.return_value = {}
+        mock_broker.execute_orders.return_value = [
+            TradeExecution("MSFT", OrderAction.SELL, 5, 200.0, 0.5,
+                           "2026-04-10", ExecutionStatus.FILLED),
+        ]
+
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        result = eng.run_manual_trade(
+            ticker="MSFT", action=OrderAction.SELL, qty=5,
+            sim_date="2026-04-10",
+        )
+        assert result.has_orders is True
+        saved = mock_repo.save_positions.call_args[0][0]
+        assert all(l.ticker != "MSFT" for l in saved)
 
     def test_neither_qty_nor_amount_raises(
         self, mock_broker, mock_repo, mock_logger,
@@ -976,6 +1011,115 @@ class TestRunManualTrade:
         history_args = mock_repo.save_trade_history.call_args
         reason = history_args[0][2]
         assert "수동 매매(Manual Trade)" in reason
+
+    def test_sell_consumes_multiple_lots_in_descending_level_order(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """매도 수량이 최고 차수 lot 수량을 초과하면 다음 차수 lot도 순차 소비."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={"AAPL": 15},
+            current_prices={"AAPL": 110.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 110.0}
+        # Lv1: 5주 @ 100, Lv2: 5주 @ 95, Lv3: 5주 @ 90
+        mock_repo.load_positions.return_value = [
+            PositionLot("lot_lv1", "AAPL", 100.0, 5, "2026-04-01", level=1),
+            PositionLot("lot_lv2", "AAPL", 95.0, 5, "2026-04-05", level=2),
+            PositionLot("lot_lv3", "AAPL", 90.0, 5, "2026-04-08", level=3),
+        ]
+        mock_repo.load_last_sell_prices.return_value = {}
+        # 12주 매도: Lv3 전량(5) + Lv2 전량(5) + Lv1 부분(2) 소비
+        mock_broker.execute_orders.return_value = [
+            TradeExecution("AAPL", OrderAction.SELL, 12, 110.0, 1.0,
+                           "2026-04-10", ExecutionStatus.FILLED),
+        ]
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+
+        eng.run_manual_trade(
+            ticker="AAPL", action=OrderAction.SELL, qty=12,
+            sim_date="2026-04-10",
+        )
+
+        saved = mock_repo.save_positions.call_args[0][0]
+        # Lv3, Lv2 lot 제거됨. Lv1만 남아있고 잔량 3주.
+        remaining = [l for l in saved if l.ticker == "AAPL"]
+        assert len(remaining) == 1
+        assert remaining[0].lot_id == "lot_lv1"
+        assert remaining[0].quantity == 3
+
+    def test_sell_multi_lot_pnl_uses_weighted_average_buy_price(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """다중 lot 매도 시 realized_pnl이 가중평균 매수가로 계산된다."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={"AAPL": 10},
+            current_prices={"AAPL": 110.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 110.0}
+        # Lv1: 5주 @ 100, Lv2: 5주 @ 90 → 10주 모두 매도
+        mock_repo.load_positions.return_value = [
+            PositionLot("lot_lv1", "AAPL", 100.0, 5, "2026-04-01", level=1),
+            PositionLot("lot_lv2", "AAPL", 90.0, 5, "2026-04-05", level=2),
+        ]
+        mock_repo.load_last_sell_prices.return_value = {}
+        execution = TradeExecution(
+            "AAPL", OrderAction.SELL, 10, 110.0, 2.0,
+            "2026-04-10", ExecutionStatus.FILLED,
+        )
+        mock_broker.execute_orders.return_value = [execution]
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+
+        result = eng.run_manual_trade(
+            ticker="AAPL", action=OrderAction.SELL, qty=10,
+            sim_date="2026-04-10",
+        )
+
+        # 가중 평균 매수가 = (100*5 + 90*5) / 10 = 95.0
+        # realized_pnl = (110 - 95) * 10 - 2.0 = 148.0
+        exe = result.executions[0]
+        assert exe.buy_price == 95.0
+        assert exe.realized_pnl == 148.0
+        # 모두 소진
+        saved = mock_repo.save_positions.call_args[0][0]
+        assert [l for l in saved if l.ticker == "AAPL"] == []
+
+    def test_sell_partial_fill_recomputes_consumption_from_actual_qty(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """PARTIAL 체결 시 신호 qty가 아닌 실제 체결 qty 기준으로 lot 소비."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={"AAPL": 10},
+            current_prices={"AAPL": 110.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 110.0}
+        mock_repo.load_positions.return_value = [
+            PositionLot("lot_lv1", "AAPL", 100.0, 5, "2026-04-01", level=1),
+            PositionLot("lot_lv2", "AAPL", 90.0, 5, "2026-04-05", level=2),
+        ]
+        mock_repo.load_last_sell_prices.return_value = {}
+        # 사용자 의도 10주, 실제 체결 6주 (PARTIAL)
+        mock_broker.execute_orders.return_value = [
+            TradeExecution("AAPL", OrderAction.SELL, 6, 110.0, 1.0,
+                           "2026-04-10", ExecutionStatus.PARTIAL),
+        ]
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+
+        eng.run_manual_trade(
+            ticker="AAPL", action=OrderAction.SELL, qty=10,
+            sim_date="2026-04-10",
+        )
+
+        saved = mock_repo.save_positions.call_args[0][0]
+        # Lv2 5주 + Lv1 1주 소비 → Lv1만 4주 잔존
+        remaining = sorted(
+            [l for l in saved if l.ticker == "AAPL"], key=lambda l: l.level,
+        )
+        assert len(remaining) == 1
+        assert remaining[0].lot_id == "lot_lv1"
+        assert remaining[0].quantity == 4
 
     def test_rejected_execution_does_not_persist(
         self, mock_broker, mock_repo, mock_logger,

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -716,3 +716,295 @@ class TestNoSignalLog:
             and "USD 99.00" in m and "USD 100.00" in m
             for m in msgs
         )
+
+
+class TestRunManualTrade:
+    """수동매매(run_manual_trade) — evaluate_stock 우회 후 동일 파이프라인 사용."""
+
+    def _make_engine(self, mock_broker, mock_repo, mock_logger, rules, notifier=None):
+        return MagicSplitEngine(
+            broker=mock_broker, repo=mock_repo, logger=mock_logger,
+            stock_rules=rules, notifier=notifier,
+        )
+
+    def test_buy_creates_new_lot_at_next_level(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """매수: 기존 최고 차수 + 1로 새 lot 생성, save_positions 호출."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={"AAPL": 5},
+            current_prices={"AAPL": 100.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 100.0}
+        mock_repo.load_positions.return_value = [
+            PositionLot("lot_001", "AAPL", 110.0, 5, "2026-04-01", level=1),
+        ]
+        mock_repo.load_last_sell_prices.return_value = {}
+        mock_broker.execute_orders.return_value = [
+            TradeExecution("AAPL", OrderAction.BUY, 3, 100.0, 0.5,
+                           "2026-04-10", ExecutionStatus.FILLED),
+        ]
+
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        result = eng.run_manual_trade(
+            ticker="AAPL", action=OrderAction.BUY, qty=3, sim_date="2026-04-10",
+        )
+
+        assert result.has_orders is True
+        assert len(result.signals) == 1
+        assert result.signals[0].reason == "수동 매매(Manual Trade)"
+        assert result.signals[0].level == 2
+
+        mock_repo.save_positions.assert_called_once()
+        saved = mock_repo.save_positions.call_args[0][0]
+        assert len(saved) == 2
+        new_lot = max(saved, key=lambda l: l.level)
+        assert new_lot.level == 2
+        assert new_lot.quantity == 3
+        assert new_lot.buy_price == 100.0
+
+    def test_sell_targets_highest_level_lot_and_updates_last_sell_prices(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """매도: 최고 차수 lot을 대상으로 신호 생성, last_sell_prices 갱신됨."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={"AAPL": 10},
+            current_prices={"AAPL": 110.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 110.0}
+        mock_repo.load_positions.return_value = [
+            PositionLot("lot_lv1", "AAPL", 100.0, 5, "2026-04-01", level=1),
+            PositionLot("lot_lv2", "AAPL", 95.0, 5, "2026-04-05", level=2),
+        ]
+        last_sell = {}
+        mock_repo.load_last_sell_prices.return_value = last_sell
+        mock_broker.execute_orders.return_value = [
+            TradeExecution("AAPL", OrderAction.SELL, 5, 110.0, 0.5,
+                           "2026-04-10", ExecutionStatus.FILLED),
+        ]
+
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        result = eng.run_manual_trade(
+            ticker="AAPL", action=OrderAction.SELL, qty=5, sim_date="2026-04-10",
+        )
+
+        assert result.signals[0].lot_id == "lot_lv2"
+        assert result.signals[0].level == 2
+        assert result.signals[0].buy_price == 95.0
+
+        saved = mock_repo.save_positions.call_args[0][0]
+        assert len(saved) == 1
+        assert saved[0].lot_id == "lot_lv1"  # Lv2 lot이 제거됨
+
+        # last_sell_prices가 갱신되어 _persist에 전달되었는지
+        mock_repo.save_last_sell_prices.assert_called_once()
+        saved_lsp = mock_repo.save_last_sell_prices.call_args[0][0]
+        assert saved_lsp["AAPL"] == 110.0
+
+    def test_sell_qty_exceeding_holdings_raises(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """매도 수량 > 보유 수량 합 -> RuntimeError, 주문 미실행."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={"AAPL": 5},
+            current_prices={"AAPL": 100.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 100.0}
+        mock_repo.load_positions.return_value = [
+            PositionLot("lot_001", "AAPL", 100.0, 5, "2026-04-01", level=1),
+        ]
+        mock_repo.load_last_sell_prices.return_value = {}
+
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        with pytest.raises(RuntimeError, match="팻핑거"):
+            eng.run_manual_trade(
+                ticker="AAPL", action=OrderAction.SELL, qty=999,
+                sim_date="2026-04-10",
+            )
+        mock_broker.execute_orders.assert_not_called()
+        mock_repo.save_positions.assert_not_called()
+
+    def test_sell_with_no_position_raises(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """보유 수량 0인 종목 매도 시도 -> RuntimeError."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={}, current_prices={"AAPL": 100.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 100.0}
+        mock_repo.load_positions.return_value = []
+        mock_repo.load_last_sell_prices.return_value = {}
+
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        with pytest.raises(RuntimeError, match="매도할 포지션"):
+            eng.run_manual_trade(
+                ticker="AAPL", action=OrderAction.SELL, qty=1,
+                sim_date="2026-04-10",
+            )
+
+    def test_buy_with_amount_calculates_qty_from_current_price(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """amount만 지정한 매수: int(amount/현재가)로 qty 계산."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={}, current_prices={"AAPL": 95.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 95.0}
+        mock_repo.load_positions.return_value = []
+        mock_repo.load_last_sell_prices.return_value = {}
+        mock_broker.execute_orders.return_value = [
+            TradeExecution("AAPL", OrderAction.BUY, 10, 95.0, 0.5,
+                           "2026-04-10", ExecutionStatus.FILLED),
+        ]
+
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        result = eng.run_manual_trade(
+            ticker="AAPL", action=OrderAction.BUY, amount=1000.0,
+            sim_date="2026-04-10",
+        )
+
+        # 1000 / 95 = 10.52 -> int = 10
+        assert result.signals[0].quantity == 10
+
+    def test_dry_run_skips_execute_and_persist(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """dry_run=True: 신호만 생성하고 주문/저장 미실행."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={}, current_prices={"AAPL": 100.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 100.0}
+        mock_repo.load_positions.return_value = []
+        mock_repo.load_last_sell_prices.return_value = {}
+
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        result = eng.run_manual_trade(
+            ticker="AAPL", action=OrderAction.BUY, qty=5, dry_run=True,
+            sim_date="2026-04-10",
+        )
+
+        assert result.has_orders is False
+        assert len(result.signals) == 1
+        mock_broker.execute_orders.assert_not_called()
+        mock_repo.save_positions.assert_not_called()
+        mock_repo.save_status.assert_not_called()
+
+    def test_unknown_ticker_raises(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """설정에 없는 ticker -> ValueError."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        with pytest.raises(ValueError, match="등록되지 않은 종목"):
+            eng.run_manual_trade(
+                ticker="UNKNOWN", action=OrderAction.BUY, qty=1,
+                sim_date="2026-04-10",
+            )
+
+    def test_disabled_ticker_raises(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """비활성 ticker -> ValueError, 매매 차단."""
+        rules = [
+            StockRule("AAPL", -5.0, 10.0, 500, 10, enabled=True),
+            StockRule("MSFT", -5.0, 10.0, 500, 10, enabled=False),
+        ]
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        with pytest.raises(ValueError, match="비활성화"):
+            eng.run_manual_trade(
+                ticker="MSFT", action=OrderAction.BUY, qty=1,
+                sim_date="2026-04-10",
+            )
+
+    def test_neither_qty_nor_amount_raises(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """qty/amount 둘 다 미지정 -> ValueError."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        with pytest.raises(ValueError, match="qty 또는 amount"):
+            eng.run_manual_trade(
+                ticker="AAPL", action=OrderAction.BUY, sim_date="2026-04-10",
+            )
+
+    def test_sell_with_amount_only_raises(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """매도는 amount만으로는 지정 불가 -> ValueError."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        with pytest.raises(ValueError, match="매도는 qty"):
+            eng.run_manual_trade(
+                ticker="AAPL", action=OrderAction.SELL, amount=500.0,
+                sim_date="2026-04-10",
+            )
+
+    def test_persist_called_with_manual_signal(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """체결 성공 시 _persist를 통해 save_positions/save_trade_history/save_status 모두 호출."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={}, current_prices={"AAPL": 100.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 100.0}
+        mock_repo.load_positions.return_value = []
+        mock_repo.load_last_sell_prices.return_value = {}
+        mock_repo.get_realized_pnl_by_ticker.return_value = {}
+        mock_repo.get_last_trade_dates.return_value = {}
+        mock_broker.execute_orders.return_value = [
+            TradeExecution("AAPL", OrderAction.BUY, 5, 100.0, 0.5,
+                           "2026-04-10", ExecutionStatus.FILLED),
+        ]
+
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        eng.run_manual_trade(
+            ticker="AAPL", action=OrderAction.BUY, qty=5,
+            sim_date="2026-04-10",
+        )
+
+        mock_repo.save_positions.assert_called_once()
+        mock_repo.save_trade_history.assert_called_once()
+        mock_repo.save_status.assert_called_once()
+        # 사유 문자열에 "수동 매매(Manual Trade)"가 포함되어야 한다
+        history_args = mock_repo.save_trade_history.call_args
+        reason = history_args[0][2]
+        assert "수동 매매(Manual Trade)" in reason
+
+    def test_rejected_execution_does_not_persist(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """REJECTED 체결만 있으면 포지션 변경이 없으므로 _persist는 호출되지만
+        positions에 새 lot은 추가되지 않고 alert가 발송된다."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={}, current_prices={"AAPL": 100.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 100.0}
+        mock_repo.load_positions.return_value = []
+        mock_repo.load_last_sell_prices.return_value = {}
+        mock_repo.get_realized_pnl_by_ticker.return_value = {}
+        mock_repo.get_last_trade_dates.return_value = {}
+        mock_broker.execute_orders.return_value = [
+            TradeExecution("AAPL", OrderAction.BUY, 0, 0.0, 0.0,
+                           "2026-04-10", ExecutionStatus.REJECTED, reason="잔고 부족"),
+        ]
+        notifier = MagicMock()
+        eng = self._make_engine(
+            mock_broker, mock_repo, mock_logger, rules, notifier=notifier,
+        )
+        eng.run_manual_trade(
+            ticker="AAPL", action=OrderAction.BUY, qty=5,
+            sim_date="2026-04-10",
+        )
+
+        saved = mock_repo.save_positions.call_args[0][0]
+        assert saved == []  # 새 lot 미추가
+        alert_msgs = [c.args[0] for c in notifier.send_alert.call_args_list]
+        assert any("수동매매" in m and "체결 실패 또는 거절" in m for m in alert_msgs)

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -764,10 +764,10 @@ class TestRunManualTrade:
         assert new_lot.quantity == 3
         assert new_lot.buy_price == 100.0
 
-    def test_sell_targets_highest_level_lot_and_updates_last_sell_prices(
+    def test_sell_auto_derives_qty_from_highest_lot_and_updates_last_sell_prices(
         self, mock_broker, mock_repo, mock_logger,
     ):
-        """매도: 최고 차수 lot을 대상으로 신호 생성, last_sell_prices 갱신됨."""
+        """매도: qty 미지정. 엔진이 최고 차수 lot 전량을 자동 도출."""
         rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
         mock_broker.get_portfolio.return_value = Portfolio(
             total_cash=10000.0, holdings={"AAPL": 10},
@@ -778,8 +778,7 @@ class TestRunManualTrade:
             PositionLot("lot_lv1", "AAPL", 100.0, 5, "2026-04-01", level=1),
             PositionLot("lot_lv2", "AAPL", 95.0, 5, "2026-04-05", level=2),
         ]
-        last_sell = {}
-        mock_repo.load_last_sell_prices.return_value = last_sell
+        mock_repo.load_last_sell_prices.return_value = {}
         mock_broker.execute_orders.return_value = [
             TradeExecution("AAPL", OrderAction.SELL, 5, 110.0, 0.5,
                            "2026-04-10", ExecutionStatus.FILLED),
@@ -787,48 +786,51 @@ class TestRunManualTrade:
 
         eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
         result = eng.run_manual_trade(
-            ticker="AAPL", action=OrderAction.SELL, qty=5, sim_date="2026-04-10",
+            ticker="AAPL", action=OrderAction.SELL, sim_date="2026-04-10",
         )
 
+        # 신호: 최고 차수(Lv2) lot 5주 매도
         assert result.signals[0].lot_id == "lot_lv2"
         assert result.signals[0].level == 2
         assert result.signals[0].buy_price == 95.0
+        assert result.signals[0].quantity == 5
+
+        # 브로커에 전달된 주문 수량도 자동 도출된 값
+        sent_orders = mock_broker.execute_orders.call_args[0][0]
+        assert sent_orders[0].quantity == 5
 
         saved = mock_repo.save_positions.call_args[0][0]
         assert len(saved) == 1
         assert saved[0].lot_id == "lot_lv1"  # Lv2 lot이 제거됨
 
-        # last_sell_prices가 갱신되어 _persist에 전달되었는지
+        # 완전 청산이므로 last_sell_prices 갱신
         mock_repo.save_last_sell_prices.assert_called_once()
         saved_lsp = mock_repo.save_last_sell_prices.call_args[0][0]
         assert saved_lsp["AAPL"] == 110.0
 
-    def test_sell_qty_exceeding_highest_lot_raises(
+    def test_sell_rejects_qty_argument(
         self, mock_broker, mock_repo, mock_logger,
     ):
-        """매도 수량 > 최고 차수 lot 수량 -> RuntimeError. 다중 차수 매도는 비지원."""
+        """매도 시 qty를 지정하면 ValueError. 자동매매와 정책 일치."""
         rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
-        mock_broker.get_portfolio.return_value = Portfolio(
-            total_cash=10000.0, holdings={"AAPL": 10},
-            current_prices={"AAPL": 100.0},
-        )
-        mock_broker.fetch_current_prices.return_value = {"AAPL": 100.0}
-        # Lv1: 5주, Lv2: 5주 -> Lv2(최고 차수)는 5주뿐
-        mock_repo.load_positions.return_value = [
-            PositionLot("lot_lv1", "AAPL", 100.0, 5, "2026-04-01", level=1),
-            PositionLot("lot_lv2", "AAPL", 95.0, 5, "2026-04-05", level=2),
-        ]
-        mock_repo.load_last_sell_prices.return_value = {}
-
         eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
-        # 보유 합 10주 < 요청 7주이지만, Lv2가 5주뿐이어서 차단되어야 함
-        with pytest.raises(RuntimeError, match="한 번에 한 차수"):
+        with pytest.raises(ValueError, match="최고 차수 lot 전량 매도만 지원"):
             eng.run_manual_trade(
-                ticker="AAPL", action=OrderAction.SELL, qty=7,
+                ticker="AAPL", action=OrderAction.SELL, qty=3,
                 sim_date="2026-04-10",
             )
-        mock_broker.execute_orders.assert_not_called()
-        mock_repo.save_positions.assert_not_called()
+
+    def test_sell_rejects_amount_argument(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """매도 시 amount를 지정하면 ValueError."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        with pytest.raises(ValueError, match="최고 차수 lot 전량 매도만 지원"):
+            eng.run_manual_trade(
+                ticker="AAPL", action=OrderAction.SELL, amount=500.0,
+                sim_date="2026-04-10",
+            )
 
     def test_sell_with_no_position_raises(
         self, mock_broker, mock_repo, mock_logger,
@@ -845,7 +847,7 @@ class TestRunManualTrade:
         eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
         with pytest.raises(RuntimeError, match="매도할 포지션"):
             eng.run_manual_trade(
-                ticker="AAPL", action=OrderAction.SELL, qty=1,
+                ticker="AAPL", action=OrderAction.SELL,
                 sim_date="2026-04-10",
             )
 
@@ -928,7 +930,7 @@ class TestRunManualTrade:
     def test_disabled_ticker_sell_allowed_for_liquidation(
         self, mock_broker, mock_repo, mock_logger,
     ):
-        """비활성 ticker SELL -> 청산 목적으로 허용."""
+        """비활성 ticker SELL -> 청산 목적으로 허용. 수량은 자동 도출."""
         rules = [
             StockRule("AAPL", -5.0, 10.0, 500, 10, enabled=True),
             StockRule("MSFT", -5.0, 10.0, 500, 10, enabled=False),
@@ -953,34 +955,21 @@ class TestRunManualTrade:
 
         eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
         result = eng.run_manual_trade(
-            ticker="MSFT", action=OrderAction.SELL, qty=5,
-            sim_date="2026-04-10",
+            ticker="MSFT", action=OrderAction.SELL, sim_date="2026-04-10",
         )
         assert result.has_orders is True
         saved = mock_repo.save_positions.call_args[0][0]
         assert all(l.ticker != "MSFT" for l in saved)
 
-    def test_neither_qty_nor_amount_raises(
+    def test_buy_without_qty_or_amount_raises(
         self, mock_broker, mock_repo, mock_logger,
     ):
-        """qty/amount 둘 다 미지정 -> ValueError."""
+        """매수에서 qty/amount 둘 다 미지정 -> ValueError."""
         rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
         eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
-        with pytest.raises(ValueError, match="qty 또는 amount"):
+        with pytest.raises(ValueError, match="매수는 qty 또는 amount"):
             eng.run_manual_trade(
                 ticker="AAPL", action=OrderAction.BUY, sim_date="2026-04-10",
-            )
-
-    def test_sell_with_amount_only_raises(
-        self, mock_broker, mock_repo, mock_logger,
-    ):
-        """매도는 amount만으로는 지정 불가 -> ValueError."""
-        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
-        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
-        with pytest.raises(ValueError, match="매도는 qty"):
-            eng.run_manual_trade(
-                ticker="AAPL", action=OrderAction.SELL, amount=500.0,
-                sim_date="2026-04-10",
             )
 
     def test_persist_called_with_manual_signal(
@@ -1014,41 +1003,6 @@ class TestRunManualTrade:
         history_args = mock_repo.save_trade_history.call_args
         reason = history_args[0][2]
         assert "수동 매매(Manual Trade)" in reason
-
-    def test_sell_partial_within_single_lot_decrements_quantity(
-        self, mock_broker, mock_repo, mock_logger,
-    ):
-        """단일 차수 부분 매도(qty < lot.qty)에서 FILLED 상태여도 lot 수량 차감."""
-        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
-        mock_broker.get_portfolio.return_value = Portfolio(
-            total_cash=10000.0, holdings={"AAPL": 5},
-            current_prices={"AAPL": 110.0},
-        )
-        mock_broker.fetch_current_prices.return_value = {"AAPL": 110.0}
-        # Lv1 단일 lot 5주 → 사용자가 3주만 매도
-        mock_repo.load_positions.return_value = [
-            PositionLot("lot_lv1", "AAPL", 100.0, 5, "2026-04-01", level=1),
-        ]
-        last_sell = {}
-        mock_repo.load_last_sell_prices.return_value = last_sell
-        mock_broker.execute_orders.return_value = [
-            TradeExecution("AAPL", OrderAction.SELL, 3, 110.0, 0.5,
-                           "2026-04-10", ExecutionStatus.FILLED),
-        ]
-        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
-
-        eng.run_manual_trade(
-            ticker="AAPL", action=OrderAction.SELL, qty=3,
-            sim_date="2026-04-10",
-        )
-
-        saved = mock_repo.save_positions.call_args[0][0]
-        remaining = [l for l in saved if l.ticker == "AAPL"]
-        assert len(remaining) == 1
-        assert remaining[0].lot_id == "lot_lv1"
-        assert remaining[0].quantity == 2  # 5 - 3
-        # lot 잔존 시 last_sell_prices 미갱신 (재진입 가드 정책 유지)
-        assert "AAPL" not in mock_repo.save_last_sell_prices.call_args[0][0]
 
     def test_rejected_execution_does_not_persist(
         self, mock_broker, mock_repo, mock_logger,

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -803,25 +803,28 @@ class TestRunManualTrade:
         saved_lsp = mock_repo.save_last_sell_prices.call_args[0][0]
         assert saved_lsp["AAPL"] == 110.0
 
-    def test_sell_qty_exceeding_holdings_raises(
+    def test_sell_qty_exceeding_highest_lot_raises(
         self, mock_broker, mock_repo, mock_logger,
     ):
-        """매도 수량 > 보유 수량 합 -> RuntimeError, 주문 미실행."""
+        """매도 수량 > 최고 차수 lot 수량 -> RuntimeError. 다중 차수 매도는 비지원."""
         rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
         mock_broker.get_portfolio.return_value = Portfolio(
-            total_cash=10000.0, holdings={"AAPL": 5},
+            total_cash=10000.0, holdings={"AAPL": 10},
             current_prices={"AAPL": 100.0},
         )
         mock_broker.fetch_current_prices.return_value = {"AAPL": 100.0}
+        # Lv1: 5주, Lv2: 5주 -> Lv2(최고 차수)는 5주뿐
         mock_repo.load_positions.return_value = [
-            PositionLot("lot_001", "AAPL", 100.0, 5, "2026-04-01", level=1),
+            PositionLot("lot_lv1", "AAPL", 100.0, 5, "2026-04-01", level=1),
+            PositionLot("lot_lv2", "AAPL", 95.0, 5, "2026-04-05", level=2),
         ]
         mock_repo.load_last_sell_prices.return_value = {}
 
         eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
-        with pytest.raises(RuntimeError, match="팻핑거"):
+        # 보유 합 10주 < 요청 7주이지만, Lv2가 5주뿐이어서 차단되어야 함
+        with pytest.raises(RuntimeError, match="한 번에 한 차수"):
             eng.run_manual_trade(
-                ticker="AAPL", action=OrderAction.SELL, qty=999,
+                ticker="AAPL", action=OrderAction.SELL, qty=7,
                 sim_date="2026-04-10",
             )
         mock_broker.execute_orders.assert_not_called()
@@ -1012,114 +1015,40 @@ class TestRunManualTrade:
         reason = history_args[0][2]
         assert "수동 매매(Manual Trade)" in reason
 
-    def test_sell_consumes_multiple_lots_in_descending_level_order(
+    def test_sell_partial_within_single_lot_decrements_quantity(
         self, mock_broker, mock_repo, mock_logger,
     ):
-        """매도 수량이 최고 차수 lot 수량을 초과하면 다음 차수 lot도 순차 소비."""
+        """단일 차수 부분 매도(qty < lot.qty)에서 FILLED 상태여도 lot 수량 차감."""
         rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
         mock_broker.get_portfolio.return_value = Portfolio(
-            total_cash=10000.0, holdings={"AAPL": 15},
+            total_cash=10000.0, holdings={"AAPL": 5},
             current_prices={"AAPL": 110.0},
         )
         mock_broker.fetch_current_prices.return_value = {"AAPL": 110.0}
-        # Lv1: 5주 @ 100, Lv2: 5주 @ 95, Lv3: 5주 @ 90
+        # Lv1 단일 lot 5주 → 사용자가 3주만 매도
         mock_repo.load_positions.return_value = [
             PositionLot("lot_lv1", "AAPL", 100.0, 5, "2026-04-01", level=1),
-            PositionLot("lot_lv2", "AAPL", 95.0, 5, "2026-04-05", level=2),
-            PositionLot("lot_lv3", "AAPL", 90.0, 5, "2026-04-08", level=3),
         ]
-        mock_repo.load_last_sell_prices.return_value = {}
-        # 12주 매도: Lv3 전량(5) + Lv2 전량(5) + Lv1 부분(2) 소비
+        last_sell = {}
+        mock_repo.load_last_sell_prices.return_value = last_sell
         mock_broker.execute_orders.return_value = [
-            TradeExecution("AAPL", OrderAction.SELL, 12, 110.0, 1.0,
+            TradeExecution("AAPL", OrderAction.SELL, 3, 110.0, 0.5,
                            "2026-04-10", ExecutionStatus.FILLED),
         ]
         eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
 
         eng.run_manual_trade(
-            ticker="AAPL", action=OrderAction.SELL, qty=12,
+            ticker="AAPL", action=OrderAction.SELL, qty=3,
             sim_date="2026-04-10",
         )
 
         saved = mock_repo.save_positions.call_args[0][0]
-        # Lv3, Lv2 lot 제거됨. Lv1만 남아있고 잔량 3주.
         remaining = [l for l in saved if l.ticker == "AAPL"]
         assert len(remaining) == 1
         assert remaining[0].lot_id == "lot_lv1"
-        assert remaining[0].quantity == 3
-
-    def test_sell_multi_lot_pnl_uses_weighted_average_buy_price(
-        self, mock_broker, mock_repo, mock_logger,
-    ):
-        """다중 lot 매도 시 realized_pnl이 가중평균 매수가로 계산된다."""
-        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
-        mock_broker.get_portfolio.return_value = Portfolio(
-            total_cash=10000.0, holdings={"AAPL": 10},
-            current_prices={"AAPL": 110.0},
-        )
-        mock_broker.fetch_current_prices.return_value = {"AAPL": 110.0}
-        # Lv1: 5주 @ 100, Lv2: 5주 @ 90 → 10주 모두 매도
-        mock_repo.load_positions.return_value = [
-            PositionLot("lot_lv1", "AAPL", 100.0, 5, "2026-04-01", level=1),
-            PositionLot("lot_lv2", "AAPL", 90.0, 5, "2026-04-05", level=2),
-        ]
-        mock_repo.load_last_sell_prices.return_value = {}
-        execution = TradeExecution(
-            "AAPL", OrderAction.SELL, 10, 110.0, 2.0,
-            "2026-04-10", ExecutionStatus.FILLED,
-        )
-        mock_broker.execute_orders.return_value = [execution]
-        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
-
-        result = eng.run_manual_trade(
-            ticker="AAPL", action=OrderAction.SELL, qty=10,
-            sim_date="2026-04-10",
-        )
-
-        # 가중 평균 매수가 = (100*5 + 90*5) / 10 = 95.0
-        # realized_pnl = (110 - 95) * 10 - 2.0 = 148.0
-        exe = result.executions[0]
-        assert exe.buy_price == 95.0
-        assert exe.realized_pnl == 148.0
-        # 모두 소진
-        saved = mock_repo.save_positions.call_args[0][0]
-        assert [l for l in saved if l.ticker == "AAPL"] == []
-
-    def test_sell_partial_fill_recomputes_consumption_from_actual_qty(
-        self, mock_broker, mock_repo, mock_logger,
-    ):
-        """PARTIAL 체결 시 신호 qty가 아닌 실제 체결 qty 기준으로 lot 소비."""
-        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
-        mock_broker.get_portfolio.return_value = Portfolio(
-            total_cash=10000.0, holdings={"AAPL": 10},
-            current_prices={"AAPL": 110.0},
-        )
-        mock_broker.fetch_current_prices.return_value = {"AAPL": 110.0}
-        mock_repo.load_positions.return_value = [
-            PositionLot("lot_lv1", "AAPL", 100.0, 5, "2026-04-01", level=1),
-            PositionLot("lot_lv2", "AAPL", 90.0, 5, "2026-04-05", level=2),
-        ]
-        mock_repo.load_last_sell_prices.return_value = {}
-        # 사용자 의도 10주, 실제 체결 6주 (PARTIAL)
-        mock_broker.execute_orders.return_value = [
-            TradeExecution("AAPL", OrderAction.SELL, 6, 110.0, 1.0,
-                           "2026-04-10", ExecutionStatus.PARTIAL),
-        ]
-        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
-
-        eng.run_manual_trade(
-            ticker="AAPL", action=OrderAction.SELL, qty=10,
-            sim_date="2026-04-10",
-        )
-
-        saved = mock_repo.save_positions.call_args[0][0]
-        # Lv2 5주 + Lv1 1주 소비 → Lv1만 4주 잔존
-        remaining = sorted(
-            [l for l in saved if l.ticker == "AAPL"], key=lambda l: l.level,
-        )
-        assert len(remaining) == 1
-        assert remaining[0].lot_id == "lot_lv1"
-        assert remaining[0].quantity == 4
+        assert remaining[0].quantity == 2  # 5 - 3
+        # lot 잔존 시 last_sell_prices 미갱신 (재진입 가드 정책 유지)
+        assert "AAPL" not in mock_repo.save_last_sell_prices.call_args[0][0]
 
     def test_rejected_execution_does_not_persist(
         self, mock_broker, mock_repo, mock_logger,

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -730,7 +730,7 @@ class TestRunManualTrade:
     def test_buy_creates_new_lot_at_next_level(
         self, mock_broker, mock_repo, mock_logger,
     ):
-        """매수: 기존 최고 차수 + 1로 새 lot 생성, save_positions 호출."""
+        """매수: rule.buy_amount(500)/현재가(100)=5주를 자동 도출, Lv2로 신규 lot 생성."""
         rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
         mock_broker.get_portfolio.return_value = Portfolio(
             total_cash=10000.0, holdings={"AAPL": 5},
@@ -742,26 +742,27 @@ class TestRunManualTrade:
         ]
         mock_repo.load_last_sell_prices.return_value = {}
         mock_broker.execute_orders.return_value = [
-            TradeExecution("AAPL", OrderAction.BUY, 3, 100.0, 0.5,
+            TradeExecution("AAPL", OrderAction.BUY, 5, 100.0, 0.5,
                            "2026-04-10", ExecutionStatus.FILLED),
         ]
 
         eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
         result = eng.run_manual_trade(
-            ticker="AAPL", action=OrderAction.BUY, qty=3, sim_date="2026-04-10",
+            ticker="AAPL", action=OrderAction.BUY, sim_date="2026-04-10",
         )
 
         assert result.has_orders is True
         assert len(result.signals) == 1
         assert result.signals[0].reason == "수동 매매(Manual Trade)"
         assert result.signals[0].level == 2
+        assert result.signals[0].quantity == 5  # 500 / 100 = 5
 
         mock_repo.save_positions.assert_called_once()
         saved = mock_repo.save_positions.call_args[0][0]
         assert len(saved) == 2
         new_lot = max(saved, key=lambda l: l.level)
         assert new_lot.level == 2
-        assert new_lot.quantity == 3
+        assert new_lot.quantity == 5
         assert new_lot.buy_price == 100.0
 
     def test_sell_auto_derives_qty_from_highest_lot_and_updates_last_sell_prices(
@@ -808,30 +809,6 @@ class TestRunManualTrade:
         saved_lsp = mock_repo.save_last_sell_prices.call_args[0][0]
         assert saved_lsp["AAPL"] == 110.0
 
-    def test_sell_rejects_qty_argument(
-        self, mock_broker, mock_repo, mock_logger,
-    ):
-        """매도 시 qty를 지정하면 ValueError. 자동매매와 정책 일치."""
-        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
-        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
-        with pytest.raises(ValueError, match="최고 차수 lot 전량 매도만 지원"):
-            eng.run_manual_trade(
-                ticker="AAPL", action=OrderAction.SELL, qty=3,
-                sim_date="2026-04-10",
-            )
-
-    def test_sell_rejects_amount_argument(
-        self, mock_broker, mock_repo, mock_logger,
-    ):
-        """매도 시 amount를 지정하면 ValueError."""
-        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
-        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
-        with pytest.raises(ValueError, match="최고 차수 lot 전량 매도만 지원"):
-            eng.run_manual_trade(
-                ticker="AAPL", action=OrderAction.SELL, amount=500.0,
-                sim_date="2026-04-10",
-            )
-
     def test_sell_with_no_position_raises(
         self, mock_broker, mock_repo, mock_logger,
     ):
@@ -851,30 +828,76 @@ class TestRunManualTrade:
                 sim_date="2026-04-10",
             )
 
-    def test_buy_with_amount_calculates_qty_from_current_price(
+    def test_buy_uses_buy_amounts_array_for_target_level(
         self, mock_broker, mock_repo, mock_logger,
     ):
-        """amount만 지정한 매수: int(amount/현재가)로 qty 계산."""
-        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        """buy_amounts 배열이 있으면 다음 차수 인덱스 값을 사용 (단일값 buy_amount보다 우선)."""
+        rules = [StockRule(
+            "AAPL", -5.0, 10.0, 500, 10,
+            buy_amounts=[300.0, 600.0, 900.0],
+        )]
         mock_broker.get_portfolio.return_value = Portfolio(
-            total_cash=10000.0, holdings={}, current_prices={"AAPL": 95.0},
+            total_cash=10000.0, holdings={"AAPL": 3},
+            current_prices={"AAPL": 100.0},
         )
-        mock_broker.fetch_current_prices.return_value = {"AAPL": 95.0}
-        mock_repo.load_positions.return_value = []
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 100.0}
+        mock_repo.load_positions.return_value = [
+            PositionLot("lot_001", "AAPL", 110.0, 3, "2026-04-01", level=1),
+        ]
         mock_repo.load_last_sell_prices.return_value = {}
         mock_broker.execute_orders.return_value = [
-            TradeExecution("AAPL", OrderAction.BUY, 10, 95.0, 0.5,
+            TradeExecution("AAPL", OrderAction.BUY, 6, 100.0, 0.5,
                            "2026-04-10", ExecutionStatus.FILLED),
         ]
 
         eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
         result = eng.run_manual_trade(
-            ticker="AAPL", action=OrderAction.BUY, amount=1000.0,
-            sim_date="2026-04-10",
+            ticker="AAPL", action=OrderAction.BUY, sim_date="2026-04-10",
         )
 
-        # 1000 / 95 = 10.52 -> int = 10
-        assert result.signals[0].quantity == 10
+        # 다음 레벨 = Lv2 -> buy_amounts[1] = 600 / 100 = 6주
+        assert result.signals[0].level == 2
+        assert result.signals[0].quantity == 6
+
+    def test_buy_amount_too_small_raises(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """rule.buy_amount < 현재가 -> 도출 수량이 0이면 RuntimeError."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 50, 10)]  # buy_amount=50
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={}, current_prices={"AAPL": 100.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 100.0}
+        mock_repo.load_positions.return_value = []
+        mock_repo.load_last_sell_prices.return_value = {}
+
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        with pytest.raises(RuntimeError, match="매수 수량 0주"):
+            eng.run_manual_trade(
+                ticker="AAPL", action=OrderAction.BUY, sim_date="2026-04-10",
+            )
+
+    def test_buy_at_max_lots_raises(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """이미 max_lots 도달 상태에서 추가 BUY 요청 -> RuntimeError."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 2)]  # max_lots=2
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={"AAPL": 10},
+            current_prices={"AAPL": 100.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 100.0}
+        mock_repo.load_positions.return_value = [
+            PositionLot("lot_lv1", "AAPL", 110.0, 5, "2026-04-01", level=1),
+            PositionLot("lot_lv2", "AAPL", 100.0, 5, "2026-04-05", level=2),
+        ]
+        mock_repo.load_last_sell_prices.return_value = {}
+
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        with pytest.raises(RuntimeError, match="max_lots"):
+            eng.run_manual_trade(
+                ticker="AAPL", action=OrderAction.BUY, sim_date="2026-04-10",
+            )
 
     def test_dry_run_skips_execute_and_persist(
         self, mock_broker, mock_repo, mock_logger,
@@ -890,7 +913,7 @@ class TestRunManualTrade:
 
         eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
         result = eng.run_manual_trade(
-            ticker="AAPL", action=OrderAction.BUY, qty=5, dry_run=True,
+            ticker="AAPL", action=OrderAction.BUY, dry_run=True,
             sim_date="2026-04-10",
         )
 
@@ -908,7 +931,7 @@ class TestRunManualTrade:
         eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
         with pytest.raises(ValueError, match="등록되지 않은 종목"):
             eng.run_manual_trade(
-                ticker="UNKNOWN", action=OrderAction.BUY, qty=1,
+                ticker="UNKNOWN", action=OrderAction.BUY,
                 sim_date="2026-04-10",
             )
 
@@ -923,7 +946,7 @@ class TestRunManualTrade:
         eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
         with pytest.raises(ValueError, match="비활성화된 종목 매수 불가"):
             eng.run_manual_trade(
-                ticker="MSFT", action=OrderAction.BUY, qty=1,
+                ticker="MSFT", action=OrderAction.BUY,
                 sim_date="2026-04-10",
             )
 
@@ -961,17 +984,6 @@ class TestRunManualTrade:
         saved = mock_repo.save_positions.call_args[0][0]
         assert all(l.ticker != "MSFT" for l in saved)
 
-    def test_buy_without_qty_or_amount_raises(
-        self, mock_broker, mock_repo, mock_logger,
-    ):
-        """매수에서 qty/amount 둘 다 미지정 -> ValueError."""
-        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
-        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
-        with pytest.raises(ValueError, match="매수는 qty 또는 amount"):
-            eng.run_manual_trade(
-                ticker="AAPL", action=OrderAction.BUY, sim_date="2026-04-10",
-            )
-
     def test_persist_called_with_manual_signal(
         self, mock_broker, mock_repo, mock_logger,
     ):
@@ -992,7 +1004,7 @@ class TestRunManualTrade:
 
         eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
         eng.run_manual_trade(
-            ticker="AAPL", action=OrderAction.BUY, qty=5,
+            ticker="AAPL", action=OrderAction.BUY,
             sim_date="2026-04-10",
         )
 
@@ -1027,7 +1039,7 @@ class TestRunManualTrade:
             mock_broker, mock_repo, mock_logger, rules, notifier=notifier,
         )
         eng.run_manual_trade(
-            ticker="AAPL", action=OrderAction.BUY, qty=5,
+            ticker="AAPL", action=OrderAction.BUY,
             sim_date="2026-04-10",
         )
 

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -899,30 +899,6 @@ class TestRunManualTrade:
                 ticker="AAPL", action=OrderAction.BUY, sim_date="2026-04-10",
             )
 
-    def test_dry_run_skips_execute_and_persist(
-        self, mock_broker, mock_repo, mock_logger,
-    ):
-        """dry_run=True: 신호만 생성하고 주문/저장 미실행."""
-        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
-        mock_broker.get_portfolio.return_value = Portfolio(
-            total_cash=10000.0, holdings={}, current_prices={"AAPL": 100.0},
-        )
-        mock_broker.fetch_current_prices.return_value = {"AAPL": 100.0}
-        mock_repo.load_positions.return_value = []
-        mock_repo.load_last_sell_prices.return_value = {}
-
-        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
-        result = eng.run_manual_trade(
-            ticker="AAPL", action=OrderAction.BUY, dry_run=True,
-            sim_date="2026-04-10",
-        )
-
-        assert result.has_orders is False
-        assert len(result.signals) == 1
-        mock_broker.execute_orders.assert_not_called()
-        mock_repo.save_positions.assert_not_called()
-        mock_repo.save_status.assert_not_called()
-
     def test_unknown_ticker_raises(
         self, mock_broker, mock_repo, mock_logger,
     ):


### PR DESCRIPTION
## Summary
- 수동매매(`scripts/manual_trade.py`)가 자동매매와 동일한 후반부 파이프라인을 사용하도록 `MagicSplitEngine.run_manual_trade()` 신규 추가. 신호 평가(`evaluate_stock`)만 우회하고, 사용자 입력으로부터 `SplitSignal`을 직접 생성한 뒤 `_signals_to_orders → _execute_stock_orders → _enrich_executions → _update_positions → _persist`를 그대로 흘려보냄.
- `scripts/manual_trade.py`는 인자 파싱 + 엔진 인스턴스 생성 + `run_manual_trade` 호출만 담당하는 얇은 래퍼로 축소(225줄 → ~120줄). 기존에 중복으로 구현돼 있던 `PositionLot` 추가/삭제, `last_sell_prices` 갱신 누락, `update_status`(자동매매와 다른 경로) 호출 등을 모두 엔진의 검증된 경로로 일원화.
- 차수(level) 결정은 기존 동작 유지(매수 = 최고 차수 + 1, 매도 = 최고 차수 lot의 `lot_id`/`buy_price`로 신호 생성). 매도 수량 > 보유 수량 검증과 비활성/미등록 종목 차단은 엔진 안에서 수행되어 CLI/UI 양쪽이 동일한 보호를 받음.

## 주요 변경
- `src/core/engine/base.py` `MagicSplitEngine`
  - `__init__`에 `self.all_stock_rules`(비활성 포함 전체 룰 보존) 추가.
  - `run_manual_trade(ticker, action, qty=None, amount=None, dry_run=False, sim_date=None)` 메서드 신설. 검증 → 시세/포지션/직전 매도가 로드 → SplitSignal 생성 → 주문 실행 → 포지션 반영 → `_persist` → Slack 알림.
- `scripts/manual_trade.py`: 인자 파싱 + 브로커/리포지토리/노티파이어 와이어링 + `engine.run_manual_trade(...)` 호출. REJECTED 시 비-0 종료, dry-run 지원 등 CLI 동작은 유지.
- `tests/test_core_engine.py`: `TestRunManualTrade` 클래스 신규 (총 13건). 매수 차수 부여, 매도 lot 매칭 + `last_sell_prices` 갱신, 팻핑거 방지(매도수량 > 보유수량), 매도할 포지션 없음, amount→qty 변환, dry-run, 미등록/비활성 종목, qty/amount 미지정, 매도-amount 거부, `_persist` 호출 검증, REJECTED 시 lot 미추가 + alert 발송 등을 커버.

## Test plan
- [x] `pytest --cov=src tests/` → 280 passed, 16 skipped(KIS live 자격증명 의존), **coverage 88%** (engine/base.py 90%).
- [x] `python scripts/manual_trade.py --help` 정상 출력.
- [x] `python -c "import scripts.manual_trade"` import 검증.
- [ ] (수동) Actions UI에서 `manual-trade.yml` 트리거 → mock 또는 paper 모드로 매수/매도 실행 후 `docs/data/<market>/positions.json`, `history.json`, `status.json`, `last_sell_prices.json`이 자동매매와 동일한 스키마로 갱신되는지 확인.
- [ ] (수동) 수동매매 직후 자동매매 사이클을 한 번 더 실행해 직전 매도가/재진입 가드 흐름이 매끄럽게 이어지는지 확인.

https://claude.ai/code/session_0159KXPMQmfRWE4FgM3R6Dz7

---
_Generated by [Claude Code](https://claude.ai/code/session_0159KXPMQmfRWE4FgM3R6Dz7)_