### PR TITLE
fix: 호가 조회 실패 시 수동 매매 주문이 건너뛰어지는 버그 수정

### DIFF
--- a/src/infra/broker/kis_base.py
+++ b/src/infra/broker/kis_base.py
@@ -173,10 +173,19 @@ class KisBrokerCommon(IBrokerAdapter):
                 # 호가 기반 매수가 추정 (ask 가격 사용, 실패 시 2% 버퍼)
                 bid, ask = self._fetch_asking_price(order.ticker)
                 disp = display_ticker(order.ticker)
-                if not self._check_spread(bid, ask):
-                    self.logger.warning(f"[KisBroker] 스프레드 비정상 — {disp} 매수 건너뜀")
+                if bid <= 0 or ask <= 0 or ask < bid:
+                    self.logger.warning(f"[KisBroker] 호가 조회 실패 — {disp} 현재가 기반 주문 진행")
+                    estimated_price = order.price * 1.02 if order.price > 0 else 0.0
+                elif not self._check_spread(bid, ask):
+                    mid = (bid + ask) / 2
+                    spread_pct = (ask - bid) / mid * 100
+                    self.logger.warning(
+                        f"[KisBroker] 스프레드 비정상 — {disp} 매수 건너뜀 "
+                        f"bid={bid} ask={ask} spread={spread_pct:.2f}%"
+                    )
                     continue
-                estimated_price = ask if ask > 0 else order.price * 1.02
+                else:
+                    estimated_price = ask
                 if estimated_price <= 0: continue
 
                 # 수량 재계산

--- a/src/infra/broker/kis_domestic.py
+++ b/src/infra/broker/kis_domestic.py
@@ -129,7 +129,10 @@ class KisDomesticBrokerBase(KisBrokerCommon):
 
         bid, ask = self._fetch_asking_price(order.ticker)
 
-        if not self._check_spread(bid, ask):
+        if bid <= 0 or ask <= 0 or ask < bid:
+            self.logger.warning(f"[KisDomestic] 호가 조회 실패 — {display_ticker(order.ticker)} 현재가 기반 주문 진행")
+            bid, ask = 0.0, 0.0
+        elif not self._check_spread(bid, ask):
             mid = (bid + ask) / 2
             spread_pct = (ask - bid) / mid * 100
             self.logger.warning(

--- a/src/infra/broker/kis_overseas.py
+++ b/src/infra/broker/kis_overseas.py
@@ -127,7 +127,10 @@ class KisOverseasBrokerBase(KisBrokerCommon):
 
         bid, ask = self._fetch_asking_price(order.ticker)
 
-        if not self._check_spread(bid, ask):
+        if bid <= 0 or ask <= 0 or ask < bid:
+            self.logger.warning(f"[KisBroker] 호가 조회 실패 — {display_ticker(order.ticker)} 현재가 기반 주문 진행")
+            bid, ask = 0.0, 0.0
+        elif not self._check_spread(bid, ask):
             mid = (bid + ask) / 2
             spread_pct = (ask - bid) / mid * 100
             self.logger.warning(


### PR DESCRIPTION
## Summary

- `_fetch_asking_price`가 시장 마감·API 오류로 `(0.0, 0.0)` 반환 시, `_check_spread`가 `bid <= 0`으로 `False`를 반환해 실제 비정상 스프레드와 구분 없이 주문을 건너뛰는 버그 수정
- `kis_base.py`, `kis_overseas.py`, `kis_domestic.py` 세 곳 모두 수정
- 호가 조회 실패(bid/ask = 0) → 경고 로그 후 현재가(`order.price`) 기반 fallback으로 주문 진행
- 실제 비정상 스프레드(bid/ask 유효하나 spread > 0.5%) → 기존과 동일하게 주문 보류

## Root Cause

```
[KisBroker] 호가 조회 실패 → (0.0, 0.0) 반환
_check_spread(0.0, 0.0) → bid <= 0 이므로 False
execute_orders: continue → 주문 건너뜀
주문이 실행되지 않았습니다. (exit code 1)
```

## Test plan

- [x] `pytest` 279 passed, 16 skipped

https://claude.ai/code/session_01Ru8sSnWLZW2MrWaE2CVQYw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ru8sSnWLZW2MrWaE2CVQYw)_