### PR TITLE
fix: add contents: write permission to manual-trade workflow

### DIFF
--- a/.github/workflows/manual-trade.yml
+++ b/.github/workflows/manual-trade.yml
@@ -22,6 +22,9 @@ on:
           - buy
           - sell
 
+permissions:
+  contents: write
+
 jobs:
   trade:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- `manual-trade.yml`에 `permissions: contents: write` 추가
- `github-actions[bot]`이 `stefanzweifel/git-auto-commit-action`으로 push할 때 403 오류 발생하던 문제 수정
- 다른 워크플로우(`trading-bot-domestic.yml`, `trading-bot-overseas.yml`, `run-backtest.yml` 등)에는 이미 해당 권한이 있었으나 `manual-trade.yml`만 누락되어 있었음

## Test plan

- [ ] `manual-trade.yml` 워크플로우를 수동 실행 후 "Push updated data and logs" 단계에서 403 오류 없이 성공하는지 확인

https://claude.ai/code/session_01HkydAXrF7HwJd7RJL5HTW3

---
_Generated by [Claude Code](https://claude.ai/code/session_01HkydAXrF7HwJd7RJL5HTW3)_