### PR TITLE
레짐 필터 + 상승장 누적 매매 (백테스트 우선)

### DIFF
--- a/.github/workflows/run-backtest.yml
+++ b/.github/workflows/run-backtest.yml
@@ -48,10 +48,10 @@ jobs:
     - name: Set Environment Variables
       run: |
         if [ "${{ inputs.market_type }}" == "국내" ]; then
-          echo "CONFIG_PATH=config_domestic.json" >> $GITHUB_ENV
+          echo "CONFIG_PATH=config_test_domestic.json" >> $GITHUB_ENV
           echo "MARKET_VAL=domestic" >> $GITHUB_ENV
         else
-          echo "CONFIG_PATH=config_overseas.json" >> $GITHUB_ENV
+          echo "CONFIG_PATH=config_test_overseas.json" >> $GITHUB_ENV
           echo "MARKET_VAL=overseas" >> $GITHUB_ENV
         fi
       shell: bash

--- a/config_test_domestic.json
+++ b/config_test_domestic.json
@@ -1,0 +1,101 @@
+{
+    "stocks": [
+        {
+            "ticker": "005930",
+            "market_type": "domestic",
+            "enabled": true,
+            "preset": "large_cap_ks"
+        },
+        {
+            "ticker": "483320",
+            "market_type": "domestic",
+            "enabled": true,
+            "preset": "large_cap_ks"
+        },
+        {
+            "ticker": "005380",
+            "enabled": true,
+            "market_type": "domestic",
+            "preset": "large_cap_ks",
+            "buy_amounts": [2000000, 1000000]
+        },
+        {
+            "ticker": "006800",
+            "enabled": true,
+            "market_type": "domestic",
+            "preset": "large_cap_ks"
+        },
+        {
+            "ticker": "102970",
+            "enabled": true,
+            "market_type": "domestic",
+            "preset": "large_cap_ks"
+        },
+        {
+            "ticker": "000660",
+            "enabled": false,
+            "market_type": "domestic",
+            "preset": "large_cap_ks"
+        },
+        {
+            "ticker": "307520",
+            "enabled": true,
+            "market_type": "domestic",
+            "preset": "large_cap_ks"
+        },
+        {
+            "ticker": "138040",
+            "enabled": true,
+            "market_type": "domestic",
+            "preset": "large_cap_ks"
+        },
+        {
+            "ticker": "218420",
+            "enabled": true,
+            "market_type": "domestic",
+            "preset": "large_cap_ks"
+        },
+        {
+            "ticker": "453650",
+            "enabled": true,
+            "market_type": "domestic",
+            "preset": "large_cap_ks"
+        },
+        {
+            "ticker": "453630",
+            "enabled": true,
+            "market_type": "domestic",
+            "preset": "large_cap_ks"
+        },
+        {
+            "ticker": "457480",
+            "enabled": true,
+            "market_type": "domestic",
+            "preset": "large_cap_ks"
+        },
+        {
+            "ticker": "475300",
+            "enabled": true,
+            "market_type": "domestic",
+            "preset": "large_cap_ks"
+        },
+        {
+            "ticker": "095610",
+            "enabled": true,
+            "market_type": "domestic",
+            "preset": "large_cap_ks",
+            "max_lots": 20
+        },
+        {
+            "ticker": "0174B0",
+            "enabled": true,
+            "market_type": "domestic",
+            "preset": "large_cap_ks"
+        }
+    ],
+    "global": {
+        "max_exposure_pct": 99,
+        "notification_enabled": true,
+        "regime_enabled": true
+    }
+}

--- a/config_test_overseas.json
+++ b/config_test_overseas.json
@@ -1,0 +1,93 @@
+{
+    "stocks": [
+        {
+            "ticker": "AAPL",
+            "market_type": "overseas",
+            "enabled": true,
+            "preset": "large_cap_us"
+        },
+        {
+            "ticker": "PFE",
+            "market_type": "overseas",
+            "enabled": false,
+            "preset": "large_cap_us"
+        },
+        {
+            "ticker": "O",
+            "market_type": "overseas",
+            "enabled": true,
+            "preset": "large_cap_us"
+        },
+        {
+            "ticker": "WM",
+            "market_type": "overseas",
+            "enabled": false,
+            "preset": "large_cap_us"
+        },
+        {
+            "ticker": "PG",
+            "market_type": "overseas",
+            "enabled": true,
+            "preset": "large_cap_us"
+        },
+        {
+            "ticker": "PEP",
+            "market_type": "overseas",
+            "enabled": true,
+            "preset": "large_cap_us"
+        },
+        {
+            "ticker": "DUK",
+            "market_type": "overseas",
+            "enabled": true,
+            "preset": "large_cap_us"
+        },
+        {
+            "ticker": "ARKK",
+            "market_type": "overseas",
+            "enabled": true,
+            "preset": "large_cap_us"
+        },
+        {
+            "ticker": "SCHD",
+            "market_type": "overseas",
+            "enabled": true,
+            "preset": "large_cap_us"
+        },
+        {
+            "ticker": "ICLN",
+            "market_type": "overseas",
+            "enabled": true,
+            "preset": "large_cap_us"
+        },
+        {
+            "ticker": "GOOGL",
+            "market_type": "overseas",
+            "enabled": true,
+            "preset": "large_cap_us"
+        },
+        {
+            "ticker": "AVGO",
+            "market_type": "overseas",
+            "enabled": true,
+            "preset": "large_cap_us"
+        },
+        {
+            "ticker": "TSLA",
+            "market_type": "overseas",
+            "enabled": true,
+            "preset": "large_cap_us"
+        },
+        {
+            "ticker": "GLW",
+            "enabled": true,
+            "market_type": "overseas",
+            "preset": "large_cap_us"
+        }
+    ],
+    "global": {
+        "max_exposure_pct": 30,
+        "notification_enabled": true,
+        "regime_enabled": true
+    }
+}

--- a/src/backtest/cache.py
+++ b/src/backtest/cache.py
@@ -29,6 +29,7 @@ class BacktestDataCache:
     def __init__(self, cache_dir: Path = CACHE_DIR, logger: Optional[ILogger] = None):
         self.cache_dir = Path(cache_dir)
         self.close_path = self.cache_dir / "close.parquet"
+        self.ohlc_path = self.cache_dir / "ohlc.parquet"
         self._logger: ILogger = logger if logger is not None else _NullLogger()
 
     def get_data(
@@ -76,6 +77,118 @@ class BacktestDataCache:
         self._save_parquet(close_df, self.close_path)
 
         return close_df
+
+    def get_ohlc(
+        self, tickers: List[str], start_date: str, end_date: str
+    ) -> pd.DataFrame:
+        """OHLC(High/Low/Close) 데이터를 반환한다. 레짐 지표(MA/ADX/ATR) 계산용.
+
+        반환 형태는 컬럼이 MultiIndex (field, ticker)인 DataFrame이며
+        field 는 'High'/'Low'/'Close'. 저장 위치는 src/backtest/cache/ohlc.parquet.
+        close.parquet(get_data)과는 독립적으로 캐시한다.
+        """
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+        cached = self._try_load_ohlc_cache(tickers, start_date, end_date)
+        if cached is not None:
+            return cached
+
+        if self.ohlc_path.exists():
+            self.ohlc_path.unlink()
+        self._logger.info(f"OHLC 다운로드 시작: {tickers} ({start_date} ~ {end_date})")
+        ohlc_df = self._download_ohlc(tickers, start_date, end_date)
+
+        if ohlc_df is None or ohlc_df.empty:
+            raise ValueError(f"OHLC 다운로드 실패: {tickers} ({start_date} ~ {end_date})")
+
+        # 상장일 기준 시작일 조정 (Close 서브프레임 기준으로 판정)
+        close_sub = ohlc_df["Close"]
+        trimmed_close = self._trim_to_latest_ipo(close_sub, tickers)
+        ohlc_df = ohlc_df.loc[trimmed_close.index.min():]
+
+        # 남은 NaN -> ffill
+        nan_before = int(ohlc_df.isna().sum().sum())
+        if nan_before > 0:
+            ohlc_df = ohlc_df.ffill()
+            nan_after = int(ohlc_df.isna().sum().sum())
+            self._logger.info(
+                f"OHLC NaN ffill: {nan_before - nan_after}개 채움, 잔여 {nan_after}개"
+            )
+
+        self._save_parquet(ohlc_df, self.ohlc_path)
+        return ohlc_df
+
+    def _try_load_ohlc_cache(
+        self, tickers: List[str], start_date: str, end_date: str
+    ) -> Optional[pd.DataFrame]:
+        """ohlc.parquet이 요청 기간·티커를 모두 포함하면 반환, 아니면 None."""
+        if not self.ohlc_path.exists():
+            return None
+        try:
+            cached_df = pd.read_parquet(self.ohlc_path)
+        except Exception as e:
+            self._logger.warning(f"OHLC 캐시 읽기 실패, 재다운로드합니다: {e}")
+            return None
+
+        if not isinstance(cached_df.columns, pd.MultiIndex):
+            return None
+        cached_tickers = set(cached_df.columns.get_level_values(1))
+        missing = [t for t in tickers if t not in cached_tickers]
+        if missing:
+            self._logger.info(f"OHLC 캐시에 누락된 티커 {missing} -> 재다운로드")
+            return None
+
+        cache_start_ts = cached_df.index.min()
+        cache_end_ts = cached_df.index.max()
+        slack = pd.Timedelta(days=5)
+        if (cache_start_ts > pd.Timestamp(start_date) + slack
+                or cache_end_ts < pd.Timestamp(end_date) - slack):
+            self._logger.info(
+                f"OHLC 캐시 범위 부족 ({cache_start_ts.date()}~{cache_end_ts.date()}) "
+                f"-> 재다운로드"
+            )
+            return None
+
+        self._logger.info(
+            f"✅ OHLC 캐시 히트: {self.ohlc_path.name} "
+            f"({cache_start_ts.date()}~{cache_end_ts.date()})"
+        )
+        mask = cached_df.columns.get_level_values(1).isin(tickers)
+        return cached_df.loc[start_date:end_date, mask]
+
+    def _download_ohlc(
+        self, tickers: List[str], start_date: str, end_date: str
+    ) -> Optional[pd.DataFrame]:
+        """yfinance로 High/Low/Close를 다운로드한다. 컬럼은 (field, MagicSplit표준티커)."""
+        fields = ["High", "Low", "Close"]
+        yf_to_std = {to_yfinance_ticker(t): t for t in tickers}
+        yf_tickers = list(yf_to_std.keys())
+        try:
+            df = yf.download(
+                yf_tickers, start=start_date, end=end_date,
+                auto_adjust=False, progress=False,
+            )
+            if df is None or df.empty:
+                return None
+
+            if not isinstance(df.columns, pd.MultiIndex):
+                # 단일 티커: 컬럼이 필드명(SingleIndex)
+                if any(f not in df.columns for f in fields):
+                    return None
+                sub = df[fields].copy()
+                std = yf_to_std[yf_tickers[0]]
+                sub.columns = pd.MultiIndex.from_product([fields, [std]])
+                return sub
+
+            level0 = df.columns.get_level_values(0)
+            if any(f not in level0 for f in fields):
+                return None
+            sub = df[fields]
+            sub = sub.rename(columns=yf_to_std, level=1)
+            return sub
+        except Exception as e:
+            self._logger.warning(f"OHLC 다운로드 실패: {e}")
+            return None
 
     # ── 캐시 히트 검사 ─────────────────────────────────────
 
@@ -210,3 +323,5 @@ class BacktestDataCache:
         if self.close_path.exists():
             self.close_path.unlink()
             self._logger.info("기존 캐시 삭제 완료")
+        if self.ohlc_path.exists():
+            self.ohlc_path.unlink()

--- a/src/backtest/components.py
+++ b/src/backtest/components.py
@@ -17,6 +17,7 @@ class BacktestBroker(MockBroker):
         super().__init__(initial_cash=initial_cash, logger=logger)
         self.simulation_prices: Dict[str, float] = {}
         self.current_date = None  # 시뮬레이션 상의 '오늘'
+        self.ohlc_windows: Dict[str, "pd.DataFrame"] = {}
 
     def set_date(self, date):
         """시뮬레이션 날짜를 설정한다. runner가 매 거래일마다 호출해야 한다."""
@@ -25,6 +26,14 @@ class BacktestBroker(MockBroker):
     def set_prices(self, prices: Dict[str, float]):
         """시뮬레이션 종가를 설정한다."""
         self.simulation_prices = prices
+
+    def set_ohlc_windows(self, windows: Dict[str, "pd.DataFrame"]):
+        """현재 거래일까지의 종목별 추세 OHLC 윈도우를 설정한다 (레짐 판정용)."""
+        self.ohlc_windows = windows
+
+    def get_ohlc_windows(self) -> Dict[str, "pd.DataFrame"]:
+        """현재 거래일 기준 종목별 OHLC 윈도우를 반환한다 (엔진이 조회)."""
+        return self.ohlc_windows
 
     def fetch_current_prices(self, tickers: List[str]) -> Dict[str, float]:
         """백테스터가 설정해준 시뮬레이션 가격을 반환한다."""

--- a/src/backtest/components.py
+++ b/src/backtest/components.py
@@ -1,10 +1,35 @@
 # src/backtest/components.py
 from dataclasses import replace
-from typing import List, Dict, Optional
+from typing import Any, List, Dict, Optional
 
-from src.core.interfaces import ILogger
+import pandas as pd
+
+from src.core.interfaces import ILogger, IMarketDataProvider
 from src.core.models import Portfolio, Order, TradeExecution
 from src.infra.broker.mock import MockBroker
+
+
+class BacktestMarketDataProvider(IMarketDataProvider):
+    """백테스트용 시세 제공자. 다운로드된 OHLC 프레임에서 '오늘 직전까지' 윈도우를 잘라준다.
+
+    실행 브로커와 완전히 분리된 시장 데이터 출처다. 입력 프레임은 컬럼이
+    MultiIndex (field, ticker)이고 field는 High/Low/Close.
+    """
+
+    def __init__(self, ohlc_df: pd.DataFrame, window_size: int = 260):
+        self.ohlc_df = ohlc_df
+        self.window_size = window_size
+
+    def get_ohlc_window(self, ticker: str, asof: Any) -> Optional[pd.DataFrame]:
+        asof_ts = pd.Timestamp(asof)
+        # 오늘(asof) 봉 제외: index < asof 인 완성봉만. 룩어헤드/장중 repaint 방지.
+        block = self.ohlc_df[self.ohlc_df.index < asof_ts].tail(self.window_size)
+        if block.empty:
+            return None
+        try:
+            return block.xs(ticker, axis=1, level=1)
+        except KeyError:
+            return None
 
 
 class BacktestBroker(MockBroker):
@@ -17,7 +42,6 @@ class BacktestBroker(MockBroker):
         super().__init__(initial_cash=initial_cash, logger=logger)
         self.simulation_prices: Dict[str, float] = {}
         self.current_date = None  # 시뮬레이션 상의 '오늘'
-        self.ohlc_windows: Dict[str, "pd.DataFrame"] = {}
 
     def set_date(self, date):
         """시뮬레이션 날짜를 설정한다. runner가 매 거래일마다 호출해야 한다."""
@@ -26,14 +50,6 @@ class BacktestBroker(MockBroker):
     def set_prices(self, prices: Dict[str, float]):
         """시뮬레이션 종가를 설정한다."""
         self.simulation_prices = prices
-
-    def set_ohlc_windows(self, windows: Dict[str, "pd.DataFrame"]):
-        """현재 거래일까지의 종목별 추세 OHLC 윈도우를 설정한다 (레짐 판정용)."""
-        self.ohlc_windows = windows
-
-    def get_ohlc_windows(self) -> Dict[str, "pd.DataFrame"]:
-        """현재 거래일 기준 종목별 OHLC 윈도우를 반환한다 (엔진이 조회)."""
-        return self.ohlc_windows
 
     def fetch_current_prices(self, tickers: List[str]) -> Dict[str, float]:
         """백테스터가 설정해준 시뮬레이션 가격을 반환한다."""

--- a/src/backtest/fetcher.py
+++ b/src/backtest/fetcher.py
@@ -25,3 +25,20 @@ def download_historical_data(
         cache = BacktestDataCache()
 
     return cache.get_data(tickers, start_date, end_date)
+
+
+def download_ohlc_data(
+    tickers: list,
+    start_date: str,
+    end_date: str,
+    cache: BacktestDataCache = None,
+) -> pd.DataFrame:
+    """백테스트용 OHLC(High/Low/Close) 데이터 다운로드 (캐시 활용).
+
+    Returns:
+        컬럼이 MultiIndex (field, ticker)인 DataFrame. field는 High/Low/Close.
+    """
+    if cache is None:
+        cache = BacktestDataCache()
+
+    return cache.get_ohlc(tickers, start_date, end_date)

--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -11,7 +11,7 @@ from src.infra.repo import JsonRepository
 from src.utils.logger import TradeLogger
 from src.utils.currency import format_money
 from src.strategy_config import StrategyConfig
-from src.backtest.fetcher import download_historical_data
+from src.backtest.fetcher import download_ohlc_data
 from src.backtest.components import BacktestBroker
 
 
@@ -66,9 +66,10 @@ def run_backtest(
         logger.warning("활성화된 종목이 없습니다.")
         return None
 
-    # 2. 데이터 다운로드
+    # 2. 데이터 다운로드 (OHLC; 레짐 지표 + 종가 모두 여기서 파생)
     logger.info(f"--- 데이터 다운로드: {tickers} ({start_date} ~ {end_date}) ---")
-    close_df = download_historical_data(tickers, start_date, end_date)
+    ohlc_df = download_ohlc_data(tickers, start_date, end_date)
+    close_df = ohlc_df["Close"]
 
     if _validate_tickers(close_df, tickers, logger):
         return None
@@ -104,6 +105,10 @@ def run_backtest(
     prev_prices: Dict[str, float] = {}
     last_result: Optional[DayResult] = None
 
+    # 레짐 필터가 켜진 종목이 하나라도 있으면 추세 윈도우를 매일 공급한다.
+    regime_active = any(getattr(r, "regime_enabled", False) for r in rules)
+    window_size = max((r.regime_min_bars for r in rules), default=200) + 60
+
     for today in sim_days:
         # 종가 추출
         try:
@@ -124,6 +129,17 @@ def run_backtest(
 
         broker.set_date(today)
         broker.set_prices(current_prices)
+
+        if regime_active:
+            # 오늘까지 포함한 추세 윈도우 (룩어헤드 금지: .loc[:today])
+            window_block = ohlc_df.loc[:today].tail(window_size)
+            windows: Dict[str, pd.DataFrame] = {}
+            for t in tickers:
+                try:
+                    windows[t] = window_block.xs(t, axis=1, level=1)
+                except KeyError:
+                    continue
+            broker.set_ohlc_windows(windows)
 
         try:
             last_result = engine.run_one_cycle(sim_date=sim_date)

--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -131,8 +131,10 @@ def run_backtest(
         broker.set_prices(current_prices)
 
         if regime_active:
-            # 오늘까지 포함한 추세 윈도우 (룩어헤드 금지: .loc[:today])
-            window_block = ohlc_df.loc[:today].tail(window_size)
+            # 지표는 "어제까지 완성봉"으로만 계산한다 (오늘 봉 제외).
+            # 오늘의 미완성 봉을 끼우면 ADX/ATR의 H/L 결손·장중 repaint·룩어헤드가
+            # 생기므로, 현재가(오늘 종가)는 트리거 비교에만 쓰고 지표 입력에선 뺀다.
+            window_block = ohlc_df.loc[:today].iloc[:-1].tail(window_size)
             windows: Dict[str, pd.DataFrame] = {}
             for t in tickers:
                 try:

--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -67,8 +67,22 @@ def run_backtest(
         return None
 
     # 2. 데이터 다운로드 (OHLC; 레짐 지표 + 종가 모두 여기서 파생)
-    logger.info(f"--- 데이터 다운로드: {tickers} ({start_date} ~ {end_date}) ---")
-    ohlc_df = download_ohlc_data(tickers, start_date, end_date)
+    # 만약 레짐 지표(이동평균/ADX/ATR 등)를 사용한다면, 첫 백테스트 거래일에 충분한 과거 데이터(window_size 봉)가 
+    # 확보되도록 데이터 다운로드 시작 시점을 과거로 이동합니다.
+    regime_active = any(getattr(r, "regime_enabled", False) for r in rules)
+    window_size = max((r.regime_min_bars for r in rules), default=200) + 60
+    
+    if regime_active:
+        start_dt = pd.to_datetime(start_date)
+        # 1 거래일 = 약 1.45 영업일. 안전하게 1.6배 곱해 calendar days 산출
+        days_to_subtract = int(window_size * 1.6)
+        download_start = (start_dt - pd.Timedelta(days=days_to_subtract)).strftime("%Y-%m-%d")
+        logger.info(f"레짐 감지 활성화: 과거 데이터 {window_size}봉 확보를 위해 다운로드 시작일을 {start_date}에서 {download_start}로 조정합니다.")
+    else:
+        download_start = start_date
+
+    logger.info(f"--- 데이터 다운로드: {tickers} ({download_start} ~ {end_date}) ---")
+    ohlc_df = download_ohlc_data(tickers, download_start, end_date)
     close_df = ohlc_df["Close"]
 
     if _validate_tickers(close_df, tickers, logger):

--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -12,7 +12,7 @@ from src.utils.logger import TradeLogger
 from src.utils.currency import format_money
 from src.strategy_config import StrategyConfig
 from src.backtest.fetcher import download_ohlc_data
-from src.backtest.components import BacktestBroker
+from src.backtest.components import BacktestBroker, BacktestMarketDataProvider
 
 
 def _validate_tickers(
@@ -90,6 +90,13 @@ def run_backtest(
 
     broker = BacktestBroker(initial_cash=initial_cash, logger=logger)
     repo = JsonRepository(root_path=output_dir)
+    # 레짐 지표용 시세 제공자 (브로커와 분리). 레짐 종목이 있을 때만 주입.
+    regime_active = any(getattr(r, "regime_enabled", False) for r in rules)
+    window_size = max((r.regime_min_bars for r in rules), default=200) + 60
+    market_data = (
+        BacktestMarketDataProvider(ohlc_df, window_size=window_size)
+        if regime_active else None
+    )
     engine = MagicSplitEngine(
         broker=broker,
         repo=repo,
@@ -97,6 +104,7 @@ def run_backtest(
         stock_rules=rules,
         notifier=None,
         is_live_trading=False,
+        market_data=market_data,
     )
 
     # 5. 시뮬레이션 루프
@@ -104,10 +112,6 @@ def run_backtest(
 
     prev_prices: Dict[str, float] = {}
     last_result: Optional[DayResult] = None
-
-    # 레짐 필터가 켜진 종목이 하나라도 있으면 추세 윈도우를 매일 공급한다.
-    regime_active = any(getattr(r, "regime_enabled", False) for r in rules)
-    window_size = max((r.regime_min_bars for r in rules), default=200) + 60
 
     for today in sim_days:
         # 종가 추출
@@ -130,20 +134,8 @@ def run_backtest(
         broker.set_date(today)
         broker.set_prices(current_prices)
 
-        if regime_active:
-            # 지표는 "어제까지 완성봉"으로만 계산한다 (오늘 봉 제외).
-            # 오늘의 미완성 봉을 끼우면 ADX/ATR의 H/L 결손·장중 repaint·룩어헤드가
-            # 생기므로, 현재가(오늘 종가)는 트리거 비교에만 쓰고 지표 입력에선 뺀다.
-            window_block = ohlc_df.loc[:today].iloc[:-1].tail(window_size)
-            windows: Dict[str, pd.DataFrame] = {}
-            for t in tickers:
-                try:
-                    windows[t] = window_block.xs(t, axis=1, level=1)
-                except KeyError:
-                    continue
-            broker.set_ohlc_windows(windows)
-
         try:
+            # 엔진이 market_data 제공자에서 "오늘 직전까지" 윈도우를 직접 조회한다.
             last_result = engine.run_one_cycle(sim_date=sim_date)
         except Exception as e:
             logger.error(f"[{sim_date}] 사이클 실행 실패: {e}")

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -614,6 +614,13 @@ class MagicSplitEngine:
 
         for exe in executions:
             disp = display_ticker(exe.ticker)
+            # 매도 신호 큐는 스킵(REJECTED/ORDERED/zero-qty) 여부와 무관하게 루프 시작에서
+            # 먼저 소비한다. 체결 순서와 신호 순서의 정렬을 유지해 전량청산 다중 매도 시
+            # 거절된 건이 뒤 체결과 잘못 매칭되는 것을 막는다.
+            sell_sig = None
+            if exe.action == OrderAction.SELL:
+                q = sell_queues.get(exe.ticker)
+                sell_sig = q.popleft() if q else None
             if exe.status == ExecutionStatus.REJECTED:
                 self.logger.warning(
                     f"[Position] Skip: {disp} {exe.action} rejected"
@@ -671,8 +678,7 @@ class MagicSplitEngine:
                 )
 
             elif exe.action == OrderAction.SELL:
-                q = sell_queues.get(exe.ticker)
-                sig = q.popleft() if q else None
+                sig = sell_sig
                 target_lot = None
                 if sig and sig.lot_id:
                     candidates = [l for l in updated if l.lot_id == sig.lot_id]
@@ -725,10 +731,11 @@ class MagicSplitEngine:
         for sig in signals:
             queues.setdefault((sig.ticker, sig.action), deque()).append(sig)
         for exe in executions:
-            if exe.status == ExecutionStatus.REJECTED:
-                continue
+            # 큐는 REJECTED 여부와 무관하게 먼저 소비해 체결-신호 순서 정렬을 유지한다.
             q = queues.get((exe.ticker, OrderAction(exe.action)))
             sig = q.popleft() if q else None
+            if exe.status == ExecutionStatus.REJECTED:
+                continue
             if sig:
                 exe.lot_id = sig.lot_id
                 exe.level = sig.level

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -147,6 +147,8 @@ class MagicSplitEngine:
                         if not blocked_signals and not info_signals:
                             self._log_no_signal_status(
                                 rule, positions, portfolio, last_sell_prices,
+                                regime_state=regime_state,
+                                ohlc_window=ohlc_window,
                             )
                         continue
 
@@ -536,6 +538,8 @@ class MagicSplitEngine:
         positions: List[PositionLot],
         portfolio: Portfolio,
         last_sell_prices: Optional[dict] = None,
+        regime_state: Optional[dict] = None,
+        ohlc_window = None,
     ) -> None:
         """신호 없음일 때 마지막 차수 현황을 한 줄로 요약 로깅한다.
 
@@ -567,6 +571,39 @@ class MagicSplitEngine:
             return
 
         last_lot = max(ticker_lots, key=lambda l: l.level)
+
+        # ── 상승 레짐 전용 요약 로그 분기 ──
+        ticker_state = regime_state.get(ticker, {}) if regime_state else {}
+        if ticker_state.get("regime") == "uptrend" and ohlc_window is not None:
+            from src.core.logic.regime import classify
+            reading = classify(
+                ohlc_window,
+                adx_trend_threshold=rule.regime_adx_trend,
+                adx_range_threshold=rule.regime_adx_range,
+                chandelier_k=rule.trendbreak_chandelier_k,
+                chandelier_lookback=rule.trendbreak_chandelier_lookback,
+                swing_lookback=rule.uptrend_swing_lookback,
+                min_bars=rule.regime_min_bars,
+            )
+            ema20 = reading.ema20
+            sma50 = reading.sma50
+            adds = ticker_state.get("adds", 0)
+            
+            profit_pct = (current_price - last_lot.buy_price) / last_lot.buy_price * 100
+            ema_dist = (current_price - ema20) / ema20 * 100 if ema20 > 0 else float("nan")
+            
+            msg = (
+                f"  [{disp}] 📈 상승 레짐 유지 | Lv{last_lot.level} "
+                f"매수 {format_money(last_lot.buy_price, rule.market_type)} -> "
+                f"현재 {format_money(current_price, rule.market_type)} ({profit_pct:+.2f}%) | "
+                f"50MA(이탈선) {format_money(sma50, rule.market_type)} | "
+                f"20EMA(눌림) {format_money(ema20, rule.market_type)} (이격 {ema_dist:+.2f}%) | "
+                f"adds {adds}/{rule.uptrend_max_adds}"
+            )
+            self.logger.info(msg)
+            return
+
+        # ── 횡보/하락장 (Sideways) 기본 요약 로그 ──
         profit_pct = (current_price - last_lot.buy_price) / last_lot.buy_price * 100
         sell_threshold = rule.sell_threshold_at(last_lot.level)
         buy_threshold = rule.buy_threshold_at(last_lot.level)
@@ -738,8 +775,11 @@ class MagicSplitEngine:
 
                 # 추세이탈 전량청산 매도 체결 확정 시에만 레짐 상태 리셋(flat 재시작).
                 # (신호 생성이 아닌 실제 체결 기준 -> 청산 거절 시 모드 유지하고 재시도)
+                # 단, 부분 매도 거절 등으로 인해 여전히 잔여 포지션이 남아있다면 상태 리셋을 보류하고 
+                # 다음 사이클에서 마저 청산하도록 보장합니다.
+                remaining_lots = [l for l in updated if l.ticker == exe.ticker]
                 if (regime_state is not None and sig is not None
-                        and sig.regime_liquidation):
+                        and sig.regime_liquidation and not remaining_lots):
                     regime_state.pop(exe.ticker, None)
 
         return updated

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -1,6 +1,5 @@
 # src/core/engine/base.py
 import time
-from collections import deque
 from dataclasses import replace
 from datetime import datetime
 from typing import Dict, List, Optional, Set, Tuple
@@ -647,26 +646,14 @@ class MagicSplitEngine:
         """
         updated = list(positions)
 
-        # 신호 매핑: 매수는 종목당 1건이므로 (ticker, action) 맵으로 충분.
-        # 매도는 추세이탈 전량청산 시 종목당 N건이 가능하므로 종목별 순서 큐로 매칭한다.
-        # (백테스트 결정적 체결 전제; 라이브는 윈도우 부재로 레짐/전량청산이 비활성)
+        # 신호 매핑: 종목당 한 사이클에 매수/매도 각 1건이므로 (ticker, action) 맵으로 충분.
+        # (추세이탈 전량청산도 통합 매도 1건이라 종목별 다중 매도가 발생하지 않는다.)
         signal_map = {}
-        sell_queues: Dict[str, deque] = {}
         for sig in signals:
-            if sig.action == OrderAction.SELL:
-                sell_queues.setdefault(sig.ticker, deque()).append(sig)
-            else:
-                signal_map[(sig.ticker, sig.action)] = sig
+            signal_map[(sig.ticker, sig.action)] = sig
 
         for exe in executions:
             disp = display_ticker(exe.ticker)
-            # 매도 신호 큐는 스킵(REJECTED/ORDERED/zero-qty) 여부와 무관하게 루프 시작에서
-            # 먼저 소비한다. 체결 순서와 신호 순서의 정렬을 유지해 전량청산 다중 매도 시
-            # 거절된 건이 뒤 체결과 잘못 매칭되는 것을 막는다.
-            sell_sig = None
-            if exe.action == OrderAction.SELL:
-                q = sell_queues.get(exe.ticker)
-                sell_sig = q.popleft() if q else None
             if exe.status == ExecutionStatus.REJECTED:
                 self.logger.warning(
                     f"[Position] Skip: {disp} {exe.action} rejected"
@@ -731,7 +718,18 @@ class MagicSplitEngine:
                 )
 
             elif exe.action == OrderAction.SELL:
-                sig = sell_sig
+                sig = signal_map.get((exe.ticker, OrderAction.SELL))
+
+                # 통합 전량청산(Bulk Sell): lot_id 없는 청산 매도는 체결 수량을
+                # 고차수(High Level)부터 순차 차감하며 lot을 지운다. 손익은 차감한
+                # 각 lot의 매수가 대비로 합산해 단일 체결 내역에 기록한다.
+                if sig is not None and sig.regime_liquidation and sig.lot_id is None:
+                    updated = self._apply_bulk_liquidation(
+                        updated, exe, disp, last_sell_prices, regime_state
+                    )
+                    continue
+
+                # 일반 단건 매도: 신호의 lot_id로 해당 차수 lot 제거
                 target_lot = None
                 if sig and sig.lot_id:
                     candidates = [l for l in updated if l.lot_id == sig.lot_id]
@@ -773,31 +771,78 @@ class MagicSplitEngine:
                         f"Lv{target_lot.level} ({target_lot.quantity}주 전량 매도)"
                     )
 
-                # 추세이탈 전량청산 매도 체결 확정 시에만 레짐 상태 리셋(flat 재시작).
-                # (신호 생성이 아닌 실제 체결 기준 -> 청산 거절 시 모드 유지하고 재시도)
-                # 단, 부분 매도 거절 등으로 인해 여전히 잔여 포지션이 남아있다면 상태 리셋을 보류하고 
-                # 다음 사이클에서 마저 청산하도록 보장합니다.
-                remaining_lots = [l for l in updated if l.ticker == exe.ticker]
-                if (regime_state is not None and sig is not None
-                        and sig.regime_liquidation and not remaining_lots):
-                    regime_state.pop(exe.ticker, None)
+        return updated
 
+    def _apply_bulk_liquidation(
+        self,
+        updated: List[PositionLot],
+        exe: TradeExecution,
+        disp: str,
+        last_sell_prices: Optional[dict],
+        regime_state: Optional[dict],
+    ) -> List[PositionLot]:
+        """통합 전량청산 체결을 고차수부터 순차 차감하여 반영한다.
+
+        - 체결 수량만큼 고레벨 lot부터 소진(전량 소진 lot은 제거, 마지막은 부분 잔량).
+        - 실현 손익은 소진한 각 lot의 매수가 기준으로 합산해 exe에 기록.
+        - 잔여 포지션이 0이 될 때만 레짐 상태를 리셋(부분체결/거절 시 모드 유지).
+        """
+        qty_left = exe.quantity
+        lots_desc = sorted(
+            [l for l in updated if l.ticker == exe.ticker],
+            key=lambda l: l.level, reverse=True,
+        )
+        total_pnl = 0.0
+        total_cost = 0.0
+        consumed = 0
+        for lot in lots_desc:
+            if qty_left <= 0:
+                break
+            take = min(qty_left, lot.quantity)
+            total_pnl += (exe.price - lot.buy_price) * take
+            total_cost += lot.buy_price * take
+            consumed += take
+            if take >= lot.quantity:
+                updated.remove(lot)
+            else:
+                updated[updated.index(lot)] = replace(lot, quantity=lot.quantity - take)
+            qty_left -= take
+
+        if consumed > 0:
+            exe.buy_price = round(total_cost / consumed, 4)
+            exe.realized_pnl = round(total_pnl - exe.fee, 2)
+            if last_sell_prices is not None:
+                last_sell_prices[exe.ticker] = exe.price
+
+        remaining = [l for l in updated if l.ticker == exe.ticker]
+        self.logger.info(
+            f"[Position] Bulk 청산: {disp} {consumed}주 소진 "
+            f"(잔여 {sum(l.quantity for l in remaining)}주), "
+            f"실현손익 {format_money(exe.realized_pnl, self.market_type)}"
+        )
+        if qty_left > 0:
+            self.logger.warning(
+                f"[Position] Bulk 청산 초과 체결: {disp} 미차감 {qty_left}주 — "
+                f"scripts/reconcile_positions.py 로 정합성 확인 권장."
+            )
+
+        # 잔여 0일 때만 레짐 리셋(flat 재시작). 부분체결/거절이면 모드 유지 -> 다음 사이클 재청산.
+        if regime_state is not None and not remaining:
+            regime_state.pop(exe.ticker, None)
         return updated
 
     def _enrich_executions(self, executions: List[TradeExecution], signals: List[SplitSignal]) -> None:
         """체결 내역에 신호의 비즈니스 컨텍스트(차수, 손익 등)를 주입한다.
 
-        전량청산 시 한 종목에 매도 신호가 여럿이므로 (ticker, action)별 순서 큐로 매칭한다.
+        종목당 매수/매도 각 1건이므로 (ticker, action) 맵으로 매칭한다.
+        통합 청산 매도는 buy_price를 신호에 싣지 않으므로(=0) 여기서 손익을 계산하지 않고,
+        _apply_bulk_liquidation에서 소진 lot별로 합산해 기록한다.
         """
-        queues: Dict[Tuple[str, OrderAction], deque] = {}
-        for sig in signals:
-            queues.setdefault((sig.ticker, sig.action), deque()).append(sig)
+        signal_map = {(sig.ticker, sig.action): sig for sig in signals}
         for exe in executions:
-            # 큐는 REJECTED 여부와 무관하게 먼저 소비해 체결-신호 순서 정렬을 유지한다.
-            q = queues.get((exe.ticker, OrderAction(exe.action)))
-            sig = q.popleft() if q else None
             if exe.status == ExecutionStatus.REJECTED:
                 continue
+            sig = signal_map.get((exe.ticker, OrderAction(exe.action)))
             if sig:
                 exe.lot_id = sig.lot_id
                 exe.level = sig.level

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -76,13 +76,17 @@ class MagicSplitEngine:
         failed_tickers: List[str] = []
         portfolio: Optional[Portfolio] = None
         positions: Optional[List[PositionLot]] = None
+        regime_state: dict = {}
 
         try:
             # Step 1+2: 포트폴리오 + 포지션 + 직전 매도가 (수동매매와 공유)
             portfolio, positions, last_sell_prices = self._load_initial_state()
 
+            # 레짐 상태 로드 (status.json에 영속). 종목별 현재 레짐/스윙고점/누적횟수.
+            regime_state = self._load_regime_state()
+
             # Step 2.1: 상태 전환 감지 및 자동 초기화 (OFF -> ON)
-            self._handle_state_transitions(positions, last_sell_prices)
+            self._handle_state_transitions(positions, last_sell_prices, regime_state)
 
             # Step 2.5: 브로커 수량 ↔ positions 수량 합 불일치 검사
             # 불일치 종목은 이번 사이클에서 매매 중단 (자동 보정 미지원)
@@ -109,6 +113,7 @@ class MagicSplitEngine:
                     signals = self.evaluator.evaluate_stock(
                         rule, positions, portfolio, last_sell_prices,
                         ohlc_window=ohlc_windows.get(rule.ticker),
+                        regime_state=regime_state,
                     )
 
                     # 신호 3-way 분류: blocked(경고) / info(상태보고) / active(주문)
@@ -177,7 +182,8 @@ class MagicSplitEngine:
                 self.logger.info(">>> Step 6: Persist")
                 self._persist(portfolio, all_signals, all_executions, positions,
                               sim_date=sim_date,
-                              last_sell_prices=last_sell_prices)
+                              last_sell_prices=last_sell_prices,
+                              regime_state=regime_state)
             else:
                 missing = []
                 if portfolio is None:
@@ -740,6 +746,7 @@ class MagicSplitEngine:
         positions: List[PositionLot],
         sim_date: Optional[str] = None,
         last_sell_prices: Optional[dict] = None,
+        regime_state: Optional[dict] = None,
     ) -> None:
         """Step 6: 저장 4종 호출."""
         reason = self._build_reason(signals)
@@ -761,8 +768,21 @@ class MagicSplitEngine:
             portfolio, positions, reason, old_realized_pnl, executions,
             self.all_tickers, sim_date, self.stock_rules, last_trade_dates,
             market_type=self.market_type,
+            regime_state_by_ticker=regime_state,
         )
         self.repo.save_status(status_data)
+
+    def _load_regime_state(self) -> dict:
+        """status.json에서 종목별 레짐 상태를 로드한다 (없으면 빈 dict)."""
+        try:
+            prev = self.repo.load_status()
+        except Exception:
+            return {}
+        if isinstance(prev, dict):
+            state = prev.get("regime_state_by_ticker")
+            if isinstance(state, dict):
+                return state
+        return {}
 
     # ── Private helpers ──────────────────────────────────────────
 
@@ -770,6 +790,7 @@ class MagicSplitEngine:
         self,
         positions: List[PositionLot],
         last_sell_prices: Dict[str, float],
+        regime_state: Optional[dict] = None,
     ) -> None:
         """종목의 상태 전이(OFF -> ON)를 감지하여 낡은 상태값을 초기화한다."""
         try:
@@ -789,6 +810,10 @@ class MagicSplitEngine:
             self.logger.info(f">>> Step 2.1: Detected {len(newly_enabled)} newly enabled ticker(s)")
             
             for ticker in newly_enabled:
+                # 레짐 상태도 새 시즌으로 초기화 (낡은 레짐/스윙고점/누적횟수 제거)
+                if regime_state is not None:
+                    regime_state.pop(ticker, None)
+
                 # A. 보유 수량이 0인 경우 -> 직전 매도가 및 실현 손익(새 시즌) 초기화
                 ticker_lots = [l for l in positions if l.ticker == ticker]
                 if not ticker_lots:

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -736,6 +736,12 @@ class MagicSplitEngine:
                         f"Lv{target_lot.level} ({target_lot.quantity}주 전량 매도)"
                     )
 
+                # 추세이탈 전량청산 매도 체결 확정 시에만 레짐 상태 리셋(flat 재시작).
+                # (신호 생성이 아닌 실제 체결 기준 -> 청산 거절 시 모드 유지하고 재시도)
+                if (regime_state is not None and sig is not None
+                        and sig.regime_liquidation):
+                    regime_state.pop(exe.ticker, None)
+
         return updated
 
     def _enrich_executions(self, executions: List[TradeExecution], signals: List[SplitSignal]) -> None:

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -160,6 +160,7 @@ class MagicSplitEngine:
                             positions = self._update_positions(
                                 positions, signals, executions, today,
                                 last_sell_prices=last_sell_prices,
+                                regime_state=regime_state,
                             )
                             portfolio = self._refresh_portfolio(portfolio)
                         except Exception as e:
@@ -600,6 +601,7 @@ class MagicSplitEngine:
         executions: List[TradeExecution],
         today: str,
         last_sell_prices: Optional[dict] = None,
+        regime_state: Optional[dict] = None,
     ) -> List[PositionLot]:
         """체결 결과를 반영하여 포지션을 업데이트한다.
 
@@ -671,6 +673,13 @@ class MagicSplitEngine:
                     level=level,
                 )
                 updated.append(new_lot)
+                # 상승장 누적매수(add) 체결 확정 시에만 regime_state를 갱신한다.
+                # (신호 생성이 아닌 실제 체결 기준 -> 백테스트/라이브 동일 동작)
+                if (regime_state is not None and sig is not None
+                        and sig.regime_add_swing_high is not None):
+                    st = regime_state.setdefault(exe.ticker, {})
+                    st["adds"] = st.get("adds", 0) + 1
+                    st["last_add_swing_high"] = sig.regime_add_swing_high
                 # 동적 재매수 소비: 매수 체결 시 직전 매도가 초기화
                 if last_sell_prices is not None and exe.ticker in last_sell_prices:
                     self.logger.info(

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -795,13 +795,19 @@ class MagicSplitEngine:
         total_pnl = 0.0
         total_cost = 0.0
         consumed = 0
+        breakdown = []  # 소진 lot별 분해(차수별 손익 기록용)
         for lot in lots_desc:
             if qty_left <= 0:
                 break
             take = min(qty_left, lot.quantity)
-            total_pnl += (exe.price - lot.buy_price) * take
+            gross = (exe.price - lot.buy_price) * take
+            total_pnl += gross
             total_cost += lot.buy_price * take
             consumed += take
+            breakdown.append({
+                "lot_id": lot.lot_id, "level": lot.level,
+                "buy_price": lot.buy_price, "quantity": take, "_gross": gross,
+            })
             if take >= lot.quantity:
                 updated.remove(lot)
             else:
@@ -811,6 +817,11 @@ class MagicSplitEngine:
         if consumed > 0:
             exe.buy_price = round(total_cost / consumed, 4)
             exe.realized_pnl = round(total_pnl - exe.fee, 2)
+            # 수수료를 소진 수량 비례로 배분해 lot별 실현손익을 확정(합 = 순실현손익).
+            for item in breakdown:
+                lot_fee = exe.fee * (item["quantity"] / consumed)
+                item["realized_pnl"] = round(item.pop("_gross") - lot_fee, 2)
+            exe.liquidation_lots = breakdown
             if last_sell_prices is not None:
                 last_sell_prices[exe.ticker] = exe.price
 

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -1,5 +1,6 @@
 # src/core/engine/base.py
 import time
+from collections import deque
 from dataclasses import replace
 from datetime import datetime
 from typing import Dict, List, Optional, Set, Tuple
@@ -594,11 +595,16 @@ class MagicSplitEngine:
         """
         updated = list(positions)
 
-        # 신호 매핑: (ticker, action) -> signal
-        # 한 종목당 한 사이클에 하나의 신호만 발생하므로 unambiguous
+        # 신호 매핑: 매수는 종목당 1건이므로 (ticker, action) 맵으로 충분.
+        # 매도는 추세이탈 전량청산 시 종목당 N건이 가능하므로 종목별 순서 큐로 매칭한다.
+        # (백테스트 결정적 체결 전제; 라이브는 윈도우 부재로 레짐/전량청산이 비활성)
         signal_map = {}
+        sell_queues: Dict[str, deque] = {}
         for sig in signals:
-            signal_map[(sig.ticker, sig.action)] = sig
+            if sig.action == OrderAction.SELL:
+                sell_queues.setdefault(sig.ticker, deque()).append(sig)
+            else:
+                signal_map[(sig.ticker, sig.action)] = sig
 
         for exe in executions:
             disp = display_ticker(exe.ticker)
@@ -659,7 +665,8 @@ class MagicSplitEngine:
                 )
 
             elif exe.action == OrderAction.SELL:
-                sig = signal_map.get((exe.ticker, OrderAction.SELL))
+                q = sell_queues.get(exe.ticker)
+                sig = q.popleft() if q else None
                 target_lot = None
                 if sig and sig.lot_id:
                     candidates = [l for l in updated if l.lot_id == sig.lot_id]
@@ -704,12 +711,18 @@ class MagicSplitEngine:
         return updated
 
     def _enrich_executions(self, executions: List[TradeExecution], signals: List[SplitSignal]) -> None:
-        """체결 내역에 신호의 비즈니스 컨텍스트(차수, 손익 등)를 주입한다."""
-        signal_map = {(sig.ticker, sig.action): sig for sig in signals}
+        """체결 내역에 신호의 비즈니스 컨텍스트(차수, 손익 등)를 주입한다.
+
+        전량청산 시 한 종목에 매도 신호가 여럿이므로 (ticker, action)별 순서 큐로 매칭한다.
+        """
+        queues: Dict[Tuple[str, OrderAction], deque] = {}
+        for sig in signals:
+            queues.setdefault((sig.ticker, sig.action), deque()).append(sig)
         for exe in executions:
             if exe.status == ExecutionStatus.REJECTED:
                 continue
-            sig = signal_map.get((exe.ticker, OrderAction(exe.action)))
+            q = queues.get((exe.ticker, OrderAction(exe.action)))
+            sig = q.popleft() if q else None
             if sig:
                 exe.lot_id = sig.lot_id
                 exe.level = sig.level

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -88,6 +88,9 @@ class MagicSplitEngine:
             self.logger.set_ticker_context(None)  # 공통 영역
             halted_tickers = self._check_reconcile(positions, portfolio)
 
+            # 레짐 판정용 종목별 OHLC 윈도우 (백테스트 브로커만 제공; 라이브는 빈 dict)
+            ohlc_windows = getattr(self.broker, "get_ohlc_windows", lambda: {})()
+
             # Step 3~5: 종목별 순차 실행
             for rule in self.stock_rules:
                 self.logger.set_ticker_context(rule.ticker)  # 종목 영역 시작
@@ -104,6 +107,7 @@ class MagicSplitEngine:
                     # 3a. 해당 종목 신호 평가
                     signals = self.evaluator.evaluate_stock(
                         rule, positions, portfolio, last_sell_prices,
+                        ohlc_window=ohlc_windows.get(rule.ticker),
                     )
 
                     # 신호 3-way 분류: blocked(경고) / info(상태보고) / active(주문)

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -5,7 +5,9 @@ from dataclasses import replace
 from datetime import datetime
 from typing import Dict, List, Optional, Set, Tuple
 
-from src.core.interfaces import IBrokerAdapter, IRepository, ILogger, INotifier
+from src.core.interfaces import (
+    IBrokerAdapter, IRepository, ILogger, INotifier, IMarketDataProvider,
+)
 from src.core.models import (
     StockRule,
     PositionLot,
@@ -43,10 +45,13 @@ class MagicSplitEngine:
         stock_rules: List[StockRule],
         notifier: Optional[INotifier] = None,
         is_live_trading: bool = False,
+        market_data: Optional[IMarketDataProvider] = None,
     ):
         self.broker = broker
         self.repo = repo
         self.logger = logger
+        # 레짐 지표용 시세 제공자 (실행 브로커와 분리). None이면 레짐 비활성(현 라이브).
+        self.market_data = market_data
         self.evaluator = SplitEvaluator(logger=logger)
         self.stock_rules = [r for r in stock_rules if r.enabled]
         self.all_tickers = [r.ticker for r in self.stock_rules]
@@ -93,9 +98,6 @@ class MagicSplitEngine:
             self.logger.set_ticker_context(None)  # 공통 영역
             halted_tickers = self._check_reconcile(positions, portfolio)
 
-            # 레짐 판정용 종목별 OHLC 윈도우 (백테스트 브로커만 제공; 라이브는 빈 dict)
-            ohlc_windows = getattr(self.broker, "get_ohlc_windows", lambda: {})()
-
             # Step 3~5: 종목별 순차 실행
             for rule in self.stock_rules:
                 self.logger.set_ticker_context(rule.ticker)  # 종목 영역 시작
@@ -110,9 +112,14 @@ class MagicSplitEngine:
                     self.logger.info(f">>> Processing {display_ticker(rule.ticker)}")
 
                     # 3a. 해당 종목 신호 평가
+                    # 레짐 지표용 OHLC 윈도우는 시세 제공자에서 (오늘 직전까지). 없으면 None.
+                    ohlc_window = (
+                        self.market_data.get_ohlc_window(rule.ticker, today)
+                        if self.market_data is not None else None
+                    )
                     signals = self.evaluator.evaluate_stock(
                         rule, positions, portfolio, last_sell_prices,
-                        ohlc_window=ohlc_windows.get(rule.ticker),
+                        ohlc_window=ohlc_window,
                         regime_state=regime_state,
                     )
 

--- a/src/core/interfaces.py
+++ b/src/core/interfaces.py
@@ -1,6 +1,6 @@
 # src/core/interfaces.py
 from abc import ABC, abstractmethod
-from typing import List, Dict, Optional
+from typing import Any, List, Dict, Optional
 from src.core.models import Portfolio, Order, TradeExecution, PositionLot, SplitSignal
 
 
@@ -11,6 +11,21 @@ class IBrokerAdapter(ABC):
     def execute_orders(self, orders: List[Order]) -> List[TradeExecution]: ...
     @abstractmethod
     def fetch_current_prices(self, tickers: List[str]) -> Dict[str, float]: ...
+
+
+class IMarketDataProvider(ABC):
+    """레짐 지표 계산용 과거 시세(OHLC)를 제공한다. 실행 브로커와 분리된 시장 데이터 출처.
+
+    백테스트는 yfinance 캐시 기반 프레임을, 라이브는 yfinance/증권사 일봉을 구현으로 끼운다.
+    """
+
+    @abstractmethod
+    def get_ohlc_window(self, ticker: str, asof: Any) -> Optional["Any"]:
+        """asof(오늘) *직전*까지의 완성봉 OHLC 윈도우를 반환한다 (오늘 봉 제외).
+
+        반환: index=날짜, columns=[High, Low, Close]인 DataFrame. 데이터가 없으면 None.
+        """
+        ...
 
 
 class ILogger(ABC):

--- a/src/core/logic/__init__.py
+++ b/src/core/logic/__init__.py
@@ -1,5 +1,14 @@
 from src.core.logic.position_reconciler import QuantityMismatch, detect_mismatches
+from src.core.logic.regime import Regime, RegimeReading, classify
 from src.core.logic.split_evaluator import SplitEvaluator
 from src.core.logic.status_builder import build_dashboard_status
 
-__all__ = ["SplitEvaluator", "QuantityMismatch", "detect_mismatches", "build_dashboard_status"]
+__all__ = [
+    "SplitEvaluator",
+    "QuantityMismatch",
+    "detect_mismatches",
+    "build_dashboard_status",
+    "Regime",
+    "RegimeReading",
+    "classify",
+]

--- a/src/core/logic/regime.py
+++ b/src/core/logic/regime.py
@@ -1,0 +1,167 @@
+# src/core/logic/regime.py
+"""시장 레짐(횡보/상승/하락) 판정용 순수 함수 모듈.
+
+OHLC 시계열(pandas DataFrame)에 대해 이동평균/ADX/ATR 등을 계산하고
+종목의 현재 국면을 분류한다. 외부 의존성(TA-Lib 등) 없이 pandas/numpy로 계산한다.
+
+이 모듈은 상태를 갖지 않는 스냅샷 리더다. 말단 bar 기준의 RegimeReading을 반환하며,
+레짐 전이의 히스테리시스 같은 시간축 상태 관리는 호출부(평가기)가 담당한다.
+"""
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+
+class Regime(str, Enum):
+    SIDEWAYS = "sideways"
+    UPTREND = "uptrend"
+    DOWNTREND = "downtrend"
+    UNKNOWN = "unknown"  # 히스토리 부족 등으로 판정 불가
+
+    def __str__(self):
+        return self.value
+
+
+def ema(series: pd.Series, span: int) -> pd.Series:
+    return series.ewm(span=span, adjust=False).mean()
+
+
+def sma(series: pd.Series, window: int) -> pd.Series:
+    return series.rolling(window=window).mean()
+
+
+def true_range(df: pd.DataFrame) -> pd.Series:
+    """TR = max(H-L, |H-Cprev|, |L-Cprev|)."""
+    prev_close = df["Close"].shift(1)
+    ranges = pd.concat(
+        [
+            df["High"] - df["Low"],
+            (df["High"] - prev_close).abs(),
+            (df["Low"] - prev_close).abs(),
+        ],
+        axis=1,
+    )
+    return ranges.max(axis=1)
+
+
+def atr(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    """Wilder smoothing(ewm alpha=1/period)을 적용한 ATR."""
+    tr = true_range(df)
+    return tr.ewm(alpha=1 / period, adjust=False).mean()
+
+
+def adx(df: pd.DataFrame, period: int = 14) -> pd.Series:
+    """Wilder ADX. +DM/-DM -> Wilder 평활 -> +DI/-DI -> DX -> ADX 순으로 계산."""
+    high = df["High"]
+    low = df["Low"]
+    up_move = high - high.shift(1)
+    down_move = low.shift(1) - low
+
+    plus_dm = up_move.where((up_move > down_move) & (up_move > 0), 0.0)
+    minus_dm = down_move.where((down_move > up_move) & (down_move > 0), 0.0)
+
+    tr = true_range(df)
+    atr_ = tr.ewm(alpha=1 / period, adjust=False).mean()
+    plus_di = 100 * plus_dm.ewm(alpha=1 / period, adjust=False).mean() / atr_
+    minus_di = 100 * minus_dm.ewm(alpha=1 / period, adjust=False).mean() / atr_
+
+    di_sum = plus_di + minus_di
+    dx = 100 * (plus_di - minus_di).abs() / di_sum
+    # 방향성 움직임이 전혀 없으면(0/0) DX=0 으로 본다.
+    dx = dx.replace([np.inf, -np.inf], np.nan).fillna(0.0)
+    return dx.ewm(alpha=1 / period, adjust=False).mean()
+
+
+def swing_high(df: pd.DataFrame, lookback: int = 10) -> float:
+    """최근 lookback 봉의 고가 최대값."""
+    return float(df["High"].tail(lookback).max())
+
+
+@dataclass(frozen=True)
+class RegimeReading:
+    regime: Regime
+    close: float
+    prev_close: float
+    ema20: float
+    sma50: float
+    sma200: float
+    adx: float
+    atr: float
+    aligned_up: bool
+    swing_high: float
+    chandelier_stop: float
+    n_bars: int
+
+
+def _is_nan(*values: float) -> bool:
+    return any(v is None or (isinstance(v, float) and np.isnan(v)) for v in values)
+
+
+def classify(
+    df: pd.DataFrame,
+    *,
+    adx_trend_threshold: float = 25.0,
+    adx_range_threshold: float = 20.0,
+    chandelier_k: float = 3.0,
+    chandelier_lookback: int = 22,
+    swing_lookback: int = 10,
+    adx_period: int = 14,
+    atr_period: int = 14,
+    min_bars: int = 200,
+) -> RegimeReading:
+    """말단 bar 기준으로 레짐을 분류한다.
+
+    - 히스토리가 부족(min_bars 미만)하거나 말단 이동평균이 NaN이면 UNKNOWN.
+    - UPTREND  : close>sma200 and ema20>sma50>sma200 (정렬 상승) and adx>=adx_trend.
+    - DOWNTREND: 역정렬 and adx>=adx_trend (감지만, 호출부에서 no-op 가능).
+    - 그 외    : SIDEWAYS (히스테리시스 밴드 range..trend 포함).
+    """
+    n_bars = int(len(df))
+    close = float(df["Close"].iloc[-1]) if n_bars >= 1 else float("nan")
+    prev_close = float(df["Close"].iloc[-2]) if n_bars >= 2 else close
+
+    if n_bars < min_bars:
+        return RegimeReading(
+            regime=Regime.UNKNOWN, close=close, prev_close=prev_close,
+            ema20=float("nan"), sma50=float("nan"), sma200=float("nan"),
+            adx=float("nan"), atr=float("nan"), aligned_up=False,
+            swing_high=float("nan"), chandelier_stop=float("nan"), n_bars=n_bars,
+        )
+
+    ema20 = float(ema(df["Close"], 20).iloc[-1])
+    sma50 = float(sma(df["Close"], 50).iloc[-1])
+    sma200 = float(sma(df["Close"], 200).iloc[-1])
+    adx_val = float(adx(df, adx_period).iloc[-1])
+    atr_val = float(atr(df, atr_period).iloc[-1])
+    sh = swing_high(df, swing_lookback)
+    highest_high = float(df["High"].tail(chandelier_lookback).max())
+    chandelier_stop = highest_high - chandelier_k * atr_val
+
+    if _is_nan(ema20, sma50, sma200, adx_val, atr_val):
+        return RegimeReading(
+            regime=Regime.UNKNOWN, close=close, prev_close=prev_close,
+            ema20=ema20, sma50=sma50, sma200=sma200, adx=adx_val, atr=atr_val,
+            aligned_up=False, swing_high=sh, chandelier_stop=chandelier_stop,
+            n_bars=n_bars,
+        )
+
+    aligned_up = close > sma200 and ema20 > sma50 > sma200
+    aligned_down = close < sma200 and ema20 < sma50 < sma200
+    trending = adx_val >= adx_trend_threshold
+
+    if aligned_up and trending:
+        regime = Regime.UPTREND
+    elif aligned_down and trending:
+        regime = Regime.DOWNTREND
+    else:
+        regime = Regime.SIDEWAYS
+
+    return RegimeReading(
+        regime=regime, close=close, prev_close=prev_close,
+        ema20=ema20, sma50=sma50, sma200=sma200, adx=adx_val, atr=atr_val,
+        aligned_up=aligned_up, swing_high=sh, chandelier_stop=chandelier_stop,
+        n_bars=n_bars,
+    )

--- a/src/core/logic/regime.py
+++ b/src/core/logic/regime.py
@@ -65,8 +65,10 @@ def adx(df: pd.DataFrame, period: int = 14) -> pd.Series:
 
     tr = true_range(df)
     atr_ = tr.ewm(alpha=1 / period, adjust=False).mean()
-    plus_di = 100 * plus_dm.ewm(alpha=1 / period, adjust=False).mean() / atr_
-    minus_di = 100 * minus_dm.ewm(alpha=1 / period, adjust=False).mean() / atr_
+    # 변동이 전혀 없는 횡보/거래정지 구간은 atr_=0 -> 0으로 나누지 않도록 NaN 처리 후 0으로 복구
+    atr_safe = atr_.replace(0, np.nan)
+    plus_di = (100 * plus_dm.ewm(alpha=1 / period, adjust=False).mean() / atr_safe).fillna(0.0)
+    minus_di = (100 * minus_dm.ewm(alpha=1 / period, adjust=False).mean() / atr_safe).fillna(0.0)
 
     di_sum = plus_di + minus_di
     dx = 100 * (plus_di - minus_di).abs() / di_sum

--- a/src/core/logic/split_evaluator.py
+++ b/src/core/logic/split_evaluator.py
@@ -796,10 +796,9 @@ class SplitEvaluator:
                 pct_change=0.0, level=next_level, is_blocked=True,
             )
 
-        # 낙관적 상태 갱신 (백테스트 결정적 체결 가정). 가드 통과 후에만 갱신한다.
-        st["adds"] = adds + 1
-        st["last_add_swing_high"] = reading.swing_high
-
+        # 상태 갱신은 여기서 하지 않는다. 매수 체결이 확정될 때(엔진 _update_positions)
+        # regime_state["adds"]/["last_add_swing_high"]를 갱신해야 백테스트/라이브가 동일해진다.
+        # 신호에 스윙고점을 실어 보내 체결 시 엔진이 커밋하도록 한다.
         if self._logger:
             self._logger.info(
                 f"[{display_ticker(rule.ticker)}] 상승장 누적 매수 Lv{next_level} "
@@ -815,5 +814,6 @@ class SplitEvaluator:
             reason=f"상승장 누적 매수 Lv{next_level} (20EMA 눌림, add {adds + 1})",
             pct_change=0.0,
             level=next_level,
+            regime_add_swing_high=reading.swing_high,
         )
 

--- a/src/core/logic/split_evaluator.py
+++ b/src/core/logic/split_evaluator.py
@@ -118,7 +118,7 @@ class SplitEvaluator:
                 min_bars=rule.regime_min_bars,
             )
             st = regime_state.setdefault(rule.ticker, {}) if regime_state is not None else {}
-            if self._resolve_regime(reading, st) == Regime.UPTREND:
+            if self._resolve_regime(reading, st, rule.ticker) == Regime.UPTREND:
                 return self._evaluate_uptrend(
                     rule, ticker_lots, current_price, reading, st, portfolio
                 )
@@ -665,7 +665,7 @@ class SplitEvaluator:
 
     # ── 레짐(상승장) 분기 ──────────────────────────────────────
 
-    def _resolve_regime(self, reading, st: dict) -> Regime:
+    def _resolve_regime(self, reading, st: dict, ticker: str) -> Regime:
         """레짐 히스테리시스를 적용해 유효 레짐을 반환한다 (st를 in-place 변이).
 
         - 상승 진입은 REGIME_CONFIRM_BARS 연속 UPTREND 판정 후에만.
@@ -685,6 +685,11 @@ class SplitEvaluator:
             st["adds"] = 0
             st["last_add_swing_high"] = reading.swing_high
             st["uptrend_streak"] = 0
+            if self._logger:
+                self._logger.info(
+                    f"[{display_ticker(ticker)}] 🔥 강한 상승 추세 진입 확정! "
+                    f"(ADX {reading.adx:.1f} 돌파, 20EMA/50MA/200MA 정배열 정렬 상승 국면)"
+                )
             return Regime.UPTREND
         return Regime.SIDEWAYS
 
@@ -703,6 +708,18 @@ class SplitEvaluator:
         # 기본(use_sma50)은 50MA 하향 이탈을 쓴다. 50MA는 상승 정렬에서 항상 20EMA보다
         # 아래이므로, 20EMA로의 정상 눌림이 이탈로 오인되지 않는 버퍼가 보장된다.
         # use_sma50=False면 변동성 기반 Chandelier 스톱을 쓴다(버퍼는 사용자 책임).
+        
+        # 지표 결손(NaN) 감지 시 안전 최우선 필터: 오작동 및 청산 누락 방지
+        import math
+        target_indicator = reading.sma50 if rule.trendbreak_use_sma50 else reading.chandelier_stop
+        if math.isnan(target_indicator):
+            if self._logger:
+                self._logger.warning(
+                    f"[{display_ticker(rule.ticker)}] ⚠️ 레짐 기술적 지표 결손(NaN) 감지! "
+                    "추세 이탈 여부를 판단할 수 없으므로 안전을 위해 매매 평가를 보류합니다."
+                )
+            return []
+
         if rule.trendbreak_use_sma50:
             broke = current_price < reading.sma50
         else:
@@ -755,14 +772,30 @@ class SplitEvaluator:
         """상승 추세 눌림 매수(불타기) 평가. 새 고점 게이트 + 눌림/반등 확인."""
         adds = st.get("adds", 0)
         if adds >= rule.uptrend_max_adds:
+            if self._logger:
+                self._logger.debug(
+                    f"  [{display_ticker(rule.ticker)}] 불타기 대기 | "
+                    f"최대 추가 매수 횟수 도달 ({adds}/{rule.uptrend_max_adds})"
+                )
             return None
         next_level = last_lot.level + 1
         if next_level > rule.max_lots:
+            if self._logger:
+                self._logger.debug(
+                    f"  [{display_ticker(rule.ticker)}] 불타기 대기 | "
+                    f"최대 보유 차수 도달 ({next_level - 1}/{rule.max_lots})"
+                )
             return None
 
         # 새 고점 게이트: 직전 add(또는 진입) 이후 새 스윙 고점이 나와야 추가
         last_high = st.get("last_add_swing_high")
         if last_high is not None and not (reading.swing_high > last_high):
+            if self._logger:
+                self._logger.debug(
+                    f"  [{display_ticker(rule.ticker)}] 불타기 대기 | "
+                    f"고점 게이트 미갱신 (현재 swing_high {format_money(reading.swing_high, rule.market_type)} "
+                    f"<= 직전 고점 {format_money(last_high, rule.market_type)})"
+                )
             return None
 
         # 눌림(20EMA 근처) + 반등 확인.
@@ -772,11 +805,25 @@ class SplitEvaluator:
         in_band = abs(current_price - ema20) <= ema20 * rule.uptrend_pullback_band_pct / 100
         bounced = current_price > reading.close or current_price > ema20
         if not (in_band and bounced):
+            if self._logger:
+                self._logger.debug(
+                    f"  [{display_ticker(rule.ticker)}] 불타기 대기 | "
+                    f"눌림목 조건 미충족 (현재 {format_money(current_price, rule.market_type)} vs "
+                    f"20EMA {format_money(ema20, rule.market_type)}, "
+                    f"이격 {abs(current_price - ema20)/ema20*100:.2f}% (임계 {rule.uptrend_pullback_band_pct}%), "
+                    f"bounced={bounced})"
+                )
             return None
 
         amount = rule.uptrend_add_amount_at(adds + 1)
         buy_qty = math.floor(amount / current_price)
         if buy_qty <= 0:
+            if self._logger:
+                self._logger.warning(
+                    f"  [{display_ticker(rule.ticker)}] 불타기 취소 | "
+                    f"주문 수량이 0주입니다 (금액 {format_money(amount, rule.market_type)} "
+                    f"< 현재가 {format_money(current_price, rule.market_type)})"
+                )
             return None
 
         passed, reason = self._passes_cash_guard(rule, current_price, buy_qty, portfolio)

--- a/src/core/logic/split_evaluator.py
+++ b/src/core/logic/split_evaluator.py
@@ -65,6 +65,8 @@ class SplitEvaluator:
         positions: List[PositionLot],
         portfolio: Portfolio,
         last_sell_prices: Optional[Dict[str, float]] = None,
+        ohlc_window=None,
+        regime_state: Optional[dict] = None,
     ) -> List[SplitSignal]:
         """단일 종목에 대해 매수/매도 신호를 평가한다.
 

--- a/src/core/logic/split_evaluator.py
+++ b/src/core/logic/split_evaluator.py
@@ -3,6 +3,7 @@ import math
 from typing import Dict, List, Optional
 
 from src.core.interfaces import ILogger
+from src.core.logic.regime import Regime, classify
 from src.core.models import (
     StockRule,
     PositionLot,
@@ -12,6 +13,9 @@ from src.core.models import (
 )
 from src.utils.ticker_reader import display_ticker
 from src.utils.currency import format_money
+
+# 상승 레짐 진입 확정에 필요한 연속 UPTREND 판정 횟수 (휩쏘 완화)
+REGIME_CONFIRM_BARS = 2
 
 
 class SplitEvaluator:
@@ -100,6 +104,24 @@ class SplitEvaluator:
                 pct_change=0.0,
                 is_blocked=True,
             )]
+
+        # 레짐 분기: 상승 레짐 + 보유 lot이 있을 때만 누적/추세이탈 로직으로 분기.
+        # (OFF / 윈도우 없음 / UNKNOWN / SIDEWAYS / DOWNTREND / flat -> 기존 경로)
+        if rule.regime_enabled and ohlc_window is not None and ticker_lots:
+            reading = classify(
+                ohlc_window,
+                adx_trend_threshold=rule.regime_adx_trend,
+                adx_range_threshold=rule.regime_adx_range,
+                chandelier_k=rule.trendbreak_chandelier_k,
+                chandelier_lookback=rule.trendbreak_chandelier_lookback,
+                swing_lookback=rule.uptrend_swing_lookback,
+                min_bars=rule.regime_min_bars,
+            )
+            st = regime_state.setdefault(rule.ticker, {}) if regime_state is not None else {}
+            if self._resolve_regime(reading, st) == Regime.UPTREND:
+                return self._evaluate_uptrend(
+                    rule, ticker_lots, current_price, reading, st, portfolio
+                )
 
         # 보유 lot이 없으면 -> 1차수 초기 매수
         if not ticker_lots:
@@ -640,4 +662,156 @@ class SplitEvaluator:
             )
 
         return None
+
+    # ── 레짐(상승장) 분기 ──────────────────────────────────────
+
+    def _resolve_regime(self, reading, st: dict) -> Regime:
+        """레짐 히스테리시스를 적용해 유효 레짐을 반환한다 (st를 in-place 변이).
+
+        - 상승 진입은 REGIME_CONFIRM_BARS 연속 UPTREND 판정 후에만.
+        - 일단 상승에 진입하면 탈출은 추세 이탈(전량 청산)로만 이뤄진다.
+          (소프트 ADX 하락으로는 매도 churn을 일으키지 않음)
+        """
+        if st.get("regime") == "uptrend":
+            return Regime.UPTREND
+
+        if reading.regime == Regime.UPTREND:
+            st["uptrend_streak"] = st.get("uptrend_streak", 0) + 1
+        else:
+            st["uptrend_streak"] = 0
+
+        if st.get("uptrend_streak", 0) >= REGIME_CONFIRM_BARS:
+            st["regime"] = "uptrend"
+            st["adds"] = 0
+            st["last_add_swing_high"] = reading.swing_high
+            st["uptrend_streak"] = 0
+            return Regime.UPTREND
+        return Regime.SIDEWAYS
+
+    def _evaluate_uptrend(
+        self,
+        rule: StockRule,
+        ticker_lots: List[PositionLot],
+        current_price: float,
+        reading,
+        st: dict,
+        portfolio: Optional[Portfolio],
+    ) -> List[SplitSignal]:
+        """상승 레짐: 차수별 매도를 잠그고 추세 눌림에 누적 매수하며,
+        추세 이탈 시 전 차수를 전량 청산한다."""
+        # 1. 추세 이탈 우선 판정 -> 전량 청산.
+        # 기본(use_sma50)은 50MA 하향 이탈을 쓴다. 50MA는 상승 정렬에서 항상 20EMA보다
+        # 아래이므로, 20EMA로의 정상 눌림이 이탈로 오인되지 않는 버퍼가 보장된다.
+        # use_sma50=False면 변동성 기반 Chandelier 스톱을 쓴다(버퍼는 사용자 책임).
+        if rule.trendbreak_use_sma50:
+            broke = current_price < reading.sma50
+        else:
+            broke = current_price < reading.chandelier_stop
+        if broke:
+            st["regime"] = "sideways"
+            st["adds"] = 0
+            st["uptrend_streak"] = 0
+            st.pop("last_add_swing_high", None)
+            if self._logger:
+                self._logger.info(
+                    f"[{display_ticker(rule.ticker)}] 추세 이탈 -> 전량 청산 "
+                    f"(현재가 {format_money(current_price, rule.market_type)}, "
+                    f"50MA {format_money(reading.sma50, rule.market_type)}, "
+                    f"Chandelier {format_money(reading.chandelier_stop, rule.market_type)})"
+                )
+            signals: List[SplitSignal] = []
+            for lot in sorted(ticker_lots, key=lambda l: l.level, reverse=True):
+                pct = (current_price - lot.buy_price) / lot.buy_price * 100
+                signals.append(SplitSignal(
+                    ticker=rule.ticker,
+                    lot_id=lot.lot_id,
+                    action=OrderAction.SELL,
+                    quantity=lot.quantity,
+                    price=current_price,
+                    reason=f"추세 이탈 전량 청산 (Lv{lot.level} {pct:+.1f}%)",
+                    pct_change=pct,
+                    level=lot.level,
+                    buy_price=lot.buy_price,
+                ))
+            return signals
+
+        # 2. 매도 잠금 -> 추세 눌림 누적 매수만 평가
+        last_lot = max(ticker_lots, key=lambda l: l.level)
+        add_signal = self._evaluate_uptrend_add(
+            rule, ticker_lots, last_lot, current_price, reading, st, portfolio
+        )
+        return [add_signal] if add_signal else []
+
+    def _evaluate_uptrend_add(
+        self,
+        rule: StockRule,
+        lots: List[PositionLot],
+        last_lot: PositionLot,
+        current_price: float,
+        reading,
+        st: dict,
+        portfolio: Optional[Portfolio],
+    ) -> Optional[SplitSignal]:
+        """상승 추세 눌림 매수(불타기) 평가. 새 고점 게이트 + 눌림/반등 확인."""
+        adds = st.get("adds", 0)
+        if adds >= rule.uptrend_max_adds:
+            return None
+        next_level = last_lot.level + 1
+        if next_level > rule.max_lots:
+            return None
+
+        # 새 고점 게이트: 직전 add(또는 진입) 이후 새 스윙 고점이 나와야 추가
+        last_high = st.get("last_add_swing_high")
+        if last_high is not None and not (reading.swing_high > last_high):
+            return None
+
+        # 눌림(20EMA 근처) + 반등 확인
+        ema20 = reading.ema20
+        in_band = abs(current_price - ema20) <= ema20 * rule.uptrend_pullback_band_pct / 100
+        bounced = current_price > reading.prev_close or current_price > ema20
+        if not (in_band and bounced):
+            return None
+
+        amount = rule.uptrend_add_amount_at(adds + 1)
+        buy_qty = math.floor(amount / current_price)
+        if buy_qty <= 0:
+            return None
+
+        passed, reason = self._passes_cash_guard(rule, current_price, buy_qty, portfolio)
+        if not passed:
+            return SplitSignal(
+                ticker=rule.ticker, lot_id=None, action=OrderAction.BUY,
+                quantity=buy_qty, price=current_price, reason=reason,
+                pct_change=0.0, level=next_level, is_blocked=True,
+            )
+        passed, reason = self._passes_exposure_guard(
+            rule, lots, current_price, buy_qty, portfolio
+        )
+        if not passed:
+            return SplitSignal(
+                ticker=rule.ticker, lot_id=None, action=OrderAction.BUY,
+                quantity=buy_qty, price=current_price, reason=reason,
+                pct_change=0.0, level=next_level, is_blocked=True,
+            )
+
+        # 낙관적 상태 갱신 (백테스트 결정적 체결 가정). 가드 통과 후에만 갱신한다.
+        st["adds"] = adds + 1
+        st["last_add_swing_high"] = reading.swing_high
+
+        if self._logger:
+            self._logger.info(
+                f"[{display_ticker(rule.ticker)}] 상승장 누적 매수 Lv{next_level} "
+                f"{buy_qty}주 @{format_money(current_price, rule.market_type)} "
+                f"(20EMA {format_money(ema20, rule.market_type)} 눌림, add {adds + 1}/{rule.uptrend_max_adds})"
+            )
+        return SplitSignal(
+            ticker=rule.ticker,
+            lot_id=None,
+            action=OrderAction.BUY,
+            quantity=buy_qty,
+            price=current_price,
+            reason=f"상승장 누적 매수 Lv{next_level} (20EMA 눌림, add {adds + 1})",
+            pct_change=0.0,
+            level=next_level,
+        )
 

--- a/src/core/logic/split_evaluator.py
+++ b/src/core/logic/split_evaluator.py
@@ -727,30 +727,33 @@ class SplitEvaluator:
         if broke:
             # regime_state 리셋은 여기서 하지 않는다. 매도 체결이 확정될 때
             # (엔진 _update_positions)에서 리셋해야 백테스트/라이브가 동일하다.
-            # 청산 매도가 모두 거절되면 다음 사이클에 다시 청산을 시도한다.
+            # 청산 매도가 거절되면 다음 사이클에 다시 청산을 시도한다.
+            # 통합 매도(Bulk Sell): 차수별 N건이 아니라 총 보유 수량 1건으로 청산한다.
+            # (라이브 API 호출/수수료 최소화. 손익은 엔진이 고차수부터 차감하며 계산.)
+            total_qty = sum(l.quantity for l in ticker_lots)
+            total_cost = sum(l.buy_price * l.quantity for l in ticker_lots)
+            avg_buy = total_cost / total_qty if total_qty else 0.0
+            pct = (current_price - avg_buy) / avg_buy * 100 if avg_buy else 0.0
+            max_level = max(l.level for l in ticker_lots)
             if self._logger:
                 self._logger.info(
-                    f"[{display_ticker(rule.ticker)}] 추세 이탈 -> 전량 청산 "
-                    f"(현재가 {format_money(current_price, rule.market_type)}, "
+                    f"[{display_ticker(rule.ticker)}] 추세 이탈 -> 통합 전량 청산(Bulk) "
+                    f"{total_qty}주 (평단 {format_money(avg_buy, rule.market_type)}, "
+                    f"현재가 {format_money(current_price, rule.market_type)}, "
                     f"50MA {format_money(reading.sma50, rule.market_type)}, "
                     f"Chandelier {format_money(reading.chandelier_stop, rule.market_type)})"
                 )
-            signals: List[SplitSignal] = []
-            for lot in sorted(ticker_lots, key=lambda l: l.level, reverse=True):
-                pct = (current_price - lot.buy_price) / lot.buy_price * 100
-                signals.append(SplitSignal(
-                    ticker=rule.ticker,
-                    lot_id=lot.lot_id,
-                    action=OrderAction.SELL,
-                    quantity=lot.quantity,
-                    price=current_price,
-                    reason=f"추세 이탈 전량 청산 (Lv{lot.level} {pct:+.1f}%)",
-                    pct_change=pct,
-                    level=lot.level,
-                    buy_price=lot.buy_price,
-                    regime_liquidation=True,
-                ))
-            return signals
+            return [SplitSignal(
+                ticker=rule.ticker,
+                lot_id=None,  # 개별 lot이 아닌 합산 -> 엔진이 고차수부터 차감
+                action=OrderAction.SELL,
+                quantity=total_qty,
+                price=current_price,
+                reason=f"추세 이탈 통합 전량 청산(Bulk Sell, {total_qty}주 {pct:+.1f}%)",
+                pct_change=pct,
+                level=max_level,
+                regime_liquidation=True,
+            )]
 
         # 2. 매도 잠금 -> 추세 눌림 누적 매수만 평가
         last_lot = max(ticker_lots, key=lambda l: l.level)

--- a/src/core/logic/split_evaluator.py
+++ b/src/core/logic/split_evaluator.py
@@ -765,10 +765,12 @@ class SplitEvaluator:
         if last_high is not None and not (reading.swing_high > last_high):
             return None
 
-        # 눌림(20EMA 근처) + 반등 확인
+        # 눌림(20EMA 근처) + 반등 확인.
+        # 윈도우는 "어제까지"이므로 reading.close = 직전 완성봉(어제) 종가.
+        # 반등 = 현재가가 어제 종가 위 또는 20EMA 위.
         ema20 = reading.ema20
         in_band = abs(current_price - ema20) <= ema20 * rule.uptrend_pullback_band_pct / 100
-        bounced = current_price > reading.prev_close or current_price > ema20
+        bounced = current_price > reading.close or current_price > ema20
         if not (in_band and bounced):
             return None
 

--- a/src/core/logic/split_evaluator.py
+++ b/src/core/logic/split_evaluator.py
@@ -708,10 +708,9 @@ class SplitEvaluator:
         else:
             broke = current_price < reading.chandelier_stop
         if broke:
-            st["regime"] = "sideways"
-            st["adds"] = 0
-            st["uptrend_streak"] = 0
-            st.pop("last_add_swing_high", None)
+            # regime_state 리셋은 여기서 하지 않는다. 매도 체결이 확정될 때
+            # (엔진 _update_positions)에서 리셋해야 백테스트/라이브가 동일하다.
+            # 청산 매도가 모두 거절되면 다음 사이클에 다시 청산을 시도한다.
             if self._logger:
                 self._logger.info(
                     f"[{display_ticker(rule.ticker)}] 추세 이탈 -> 전량 청산 "
@@ -732,6 +731,7 @@ class SplitEvaluator:
                     pct_change=pct,
                     level=lot.level,
                     buy_price=lot.buy_price,
+                    regime_liquidation=True,
                 ))
             return signals
 

--- a/src/core/logic/status_builder.py
+++ b/src/core/logic/status_builder.py
@@ -15,6 +15,7 @@ def build_dashboard_status(
     stock_rules: Optional[List[StockRule]] = None,
     last_trade_dates: Optional[Dict[str, str]] = None,
     market_type: str = "overseas",
+    regime_state_by_ticker: Optional[Dict[str, dict]] = None,
 ) -> dict:
     """대시보드 렌더링에 필요한 상태 데이터 구조(JSON)를 조립한다.
 
@@ -209,6 +210,7 @@ def build_dashboard_status(
         },
         "positions": ticker_summary,
         "realized_pnl_by_ticker": realized_by_ticker,
+        "regime_state_by_ticker": regime_state_by_ticker or {},
         "enabled_tickers": enabled_tickers,
         "risk_summary": {
             "next_level_needs": round(next_level_needs, 2),

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -214,6 +214,9 @@ class SplitSignal:
     buy_price: float = 0.0  # 매도 시 원래 매수 단가 (손익 계산용)
     is_blocked: bool = False  # 비중 제한 등으로 인해 실행이 차단된 신호 여부
     is_info: bool = False     # 정보성 알림 전용 신호 (주문 없이 상태 변화만 알림)
+    # 상승장 누적매수(add) 신호 표식 + 체결 확정 시 기록할 스윙고점.
+    # None이 아니면 "상승 add"이며, 매수 체결이 확정될 때 regime_state를 갱신한다.
+    regime_add_swing_high: Optional[float] = None
 
 
 @dataclass

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -198,6 +198,10 @@ class TradeExecution:
     level: int = 0
     buy_price: float = 0.0
     realized_pnl: float = 0.0
+    # 통합 청산(Bulk Sell) 시 소진한 lot별 분해 내역(차수별 손익 기록용).
+    # 각 항목: {lot_id, level, buy_price, quantity, realized_pnl}.
+    # 저장 시 이 내역을 차수별 N개 레코드로 펼친다.
+    liquidation_lots: Optional[List[dict]] = None
 
 
 @dataclass

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -217,6 +217,8 @@ class SplitSignal:
     # 상승장 누적매수(add) 신호 표식 + 체결 확정 시 기록할 스윙고점.
     # None이 아니면 "상승 add"이며, 매수 체결이 확정될 때 regime_state를 갱신한다.
     regime_add_swing_high: Optional[float] = None
+    # 추세이탈 전량청산 매도 표식. 매도 체결이 확정될 때 regime_state를 리셋(flat 재시작)한다.
+    regime_liquidation: bool = False
 
 
 @dataclass

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -51,6 +51,22 @@ class StockRule:
     # None이면 비중 제한 없음. 글로벌 설정을 strategy_config에서 상속받을 수 있음.
     max_exposure_pct: Optional[float] = None
 
+    # --- 레짐 필터 (전부 기본값 => OFF => 오늘과 완전히 동일 동작) ---
+    regime_enabled: bool = False
+    regime_adx_trend: float = 25.0      # ADX 이상이면 추세장으로 간주
+    regime_adx_range: float = 20.0      # ADX 미만이면 횡보장 (히스테리시스 하단)
+    regime_min_bars: int = 200          # 레짐 판정에 필요한 최소 봉 수
+    # 상승 레짐: 차수 매도를 잠그고 추세 눌림에 누적 매수
+    uptrend_pullback_band_pct: float = 1.5   # 상승 20EMA 위 +band% 이내면 눌림 매수
+    uptrend_max_adds: int = 3                # 상승장 1사이클 최대 추가매수 횟수
+    uptrend_add_amount: Optional[float] = None          # 회차 공통 금액 (scalar fallback)
+    uptrend_add_amounts: Optional[List[float]] = None   # 회차별 금액 (점감 권장)
+    uptrend_swing_lookback: int = 10         # 새 고점 게이트용 스윙 룩백
+    # 추세 이탈 (전량 청산). 눌림 밴드보다 깊어야 정상 눌림에 안 털린다.
+    trendbreak_chandelier_k: float = 3.0     # 고점 - k*ATR
+    trendbreak_chandelier_lookback: int = 22
+    trendbreak_use_sma50: bool = True        # 이탈 = close<sma50 OR close<chandelier_stop
+
     def __post_init__(self):
         if self.buy_threshold_pct is None and not self.buy_threshold_pcts:
             raise ValueError(
@@ -69,9 +85,25 @@ class StockRule:
             ("sell_threshold_pcts", self.sell_threshold_pcts),
             ("buy_amounts", self.buy_amounts),
             ("trailing_drop_pcts", self.trailing_drop_pcts),
+            ("uptrend_add_amounts", self.uptrend_add_amounts),
         ):
             if arr is not None and len(arr) == 0:
                 raise ValueError(f"StockRule({self.ticker}): {name}는 비어 있으면 안 됩니다.")
+
+        if self.regime_enabled:
+            if self.regime_adx_range > self.regime_adx_trend:
+                raise ValueError(
+                    f"StockRule({self.ticker}): regime_adx_range({self.regime_adx_range})는 "
+                    f"regime_adx_trend({self.regime_adx_trend}) 이하여야 합니다."
+                )
+            if self.uptrend_pullback_band_pct < 0:
+                raise ValueError(
+                    f"StockRule({self.ticker}): uptrend_pullback_band_pct는 음수일 수 없습니다."
+                )
+            if self.uptrend_max_adds < 0:
+                raise ValueError(
+                    f"StockRule({self.ticker}): uptrend_max_adds는 음수일 수 없습니다."
+                )
 
     @staticmethod
     def _at(arr: Optional[List[float]], scalar: Optional[float], level: int) -> float:
@@ -102,6 +134,19 @@ class StockRule:
         if self.trailing_drop_pct is not None:
             return float(self.trailing_drop_pct)
         return None
+
+    def uptrend_add_amount_at(self, add_index: int) -> float:
+        """주어진 상승장 추가매수 회차(1-based)의 금액을 반환한다.
+
+        uptrend_add_amounts(배열) > uptrend_add_amount(단일) > buy_amount(기본) 순으로 fallback.
+        배열이 회차보다 짧으면 마지막 값으로 clamp.
+        """
+        if self.uptrend_add_amounts:
+            idx = max(0, min(add_index - 1, len(self.uptrend_add_amounts) - 1))
+            return float(self.uptrend_add_amounts[idx])
+        if self.uptrend_add_amount is not None:
+            return float(self.uptrend_add_amount)
+        return self.buy_amount_at(1)
 
 
 @dataclass

--- a/src/infra/repo.py
+++ b/src/infra/repo.py
@@ -131,9 +131,25 @@ class JsonRepository(IRepository):
         alias_by_ticker = {e.ticker: get_alias(e.ticker) or e.ticker for e in executions}
         enriched_execs = []
         for e in executions:
-            rec = asdict(e)
-            rec["alias"] = alias_by_ticker[e.ticker]
+            base = asdict(e)
+            base["alias"] = alias_by_ticker[e.ticker]
+            breakdown = base.pop("liquidation_lots", None)
 
+            # 통합 청산(Bulk): 소진 lot별 N개 레코드로 분리 기록(차수별 손익 보존)
+            if breakdown:
+                for lot in breakdown:
+                    rec = dict(base)
+                    rec.update({
+                        "quantity": lot["quantity"],
+                        "lot_id": lot["lot_id"],
+                        "level": lot["level"],
+                        "buy_price": lot["buy_price"],
+                        "realized_pnl": lot["realized_pnl"],
+                    })
+                    enriched_execs.append(rec)
+                continue
+
+            rec = base
             # JSON 깔끔함을 위해 불필요한 빈 필드 제거
             if rec.get("lot_id") is None:
                 rec.pop("lot_id", None)

--- a/src/strategy_config.py
+++ b/src/strategy_config.py
@@ -106,6 +106,49 @@ class StrategyConfig:
         merged.pop("preset", None)
         return merged
 
+    # 레짐 필터 파라미터: 타입별 키 집합 (개별 > 글로벌 > dataclass 기본값)
+    _REGIME_KEYS_BOOL = ("regime_enabled", "trendbreak_use_sma50")
+    _REGIME_KEYS_INT = (
+        "regime_min_bars", "uptrend_max_adds",
+        "uptrend_swing_lookback", "trendbreak_chandelier_lookback",
+    )
+    _REGIME_KEYS_FLOAT = (
+        "regime_adx_trend", "regime_adx_range",
+        "uptrend_pullback_band_pct", "uptrend_add_amount",
+        "trendbreak_chandelier_k",
+    )
+    _REGIME_KEYS_LIST = ("uptrend_add_amounts",)
+
+    def _build_regime_kwargs(self, merged: dict) -> dict:
+        """레짐 필터 파라미터를 StockRule 생성자 kwargs로 변환한다.
+
+        개별 종목 설정 > 글로벌 설정 순. 둘 다 없으면 키를 생략하여
+        StockRule의 dataclass 기본값(=OFF)이 적용되게 한다.
+        """
+        def resolve(key):
+            if key in merged:
+                return merged[key]
+            return self.global_config.get(key)
+
+        kwargs: dict = {}
+        for key in self._REGIME_KEYS_BOOL:
+            val = resolve(key)
+            if val is not None:
+                kwargs[key] = bool(val)
+        for key in self._REGIME_KEYS_INT:
+            val = resolve(key)
+            if val is not None:
+                kwargs[key] = int(val)
+        for key in self._REGIME_KEYS_FLOAT:
+            val = resolve(key)
+            if val is not None:
+                kwargs[key] = float(val)
+        for key in self._REGIME_KEYS_LIST:
+            val = resolve(key)
+            if val:
+                kwargs[key] = [float(x) for x in val]
+        return kwargs
+
     def _load(self):
         if not os.path.exists(self.config_path):
             raise FileNotFoundError(
@@ -191,6 +234,9 @@ class StrategyConfig:
                 float(trailing_drop_raw) if trailing_drop_raw is not None else None
             )
 
+            # 레짐 필터: 개별 설정 > 글로벌 설정 > StockRule 기본값(부재 시 키 생략).
+            regime_kwargs = self._build_regime_kwargs(merged)
+
             rule = StockRule(
                 ticker=ticker,
                 buy_threshold_pct=float(buy_pct) if buy_pct is not None else None,
@@ -206,6 +252,7 @@ class StrategyConfig:
                 trailing_drop_pct=trailing_drop_pct,
                 trailing_drop_pcts=[float(x) for x in trailing_drops] if trailing_drops else None,
                 max_exposure_pct=max_exposure_pct,
+                **regime_kwargs,
             )
             self.rules.append(rule)
             self.market_types.add(market_type)

--- a/tests/test_backtest_cache.py
+++ b/tests/test_backtest_cache.py
@@ -182,3 +182,50 @@ class TestIpoTrim:
 
         # 트림 없이 yf 응답의 첫 날짜가 그대로 유지
         assert result.index.min() == pd.Timestamp("2024-01-02")
+
+
+class TestBacktestDataCacheOHLC:
+    def test_get_ohlc_single_ticker(self, cache, tmp_cache_dir):
+        mock_df = _make_yf_response(["AAPL"], days=5)
+        with patch("src.backtest.cache.yf.download", return_value=mock_df):
+            result = cache.get_ohlc(["AAPL"], "2024-01-01", "2024-01-10")
+
+        assert isinstance(result.columns, pd.MultiIndex)
+        assert set(result.columns.get_level_values(0)) == {"High", "Low", "Close"}
+        assert "AAPL" in result.columns.get_level_values(1)
+        assert (tmp_cache_dir / "ohlc.parquet").exists()
+
+    def test_get_ohlc_multi_ticker(self, cache):
+        mock_df = _make_yf_response(["AAPL", "MSFT"], days=5)
+        with patch("src.backtest.cache.yf.download", return_value=mock_df):
+            result = cache.get_ohlc(["AAPL", "MSFT"], "2024-01-01", "2024-01-10")
+
+        tickers = set(result.columns.get_level_values(1))
+        assert {"AAPL", "MSFT"} <= tickers
+        # 종목별 서브프레임 추출이 동작해야 한다
+        sub = result.xs("AAPL", axis=1, level=1)
+        assert list(sub.columns) == ["High", "Low", "Close"]
+
+    def test_get_ohlc_parquet_roundtrip(self, cache, tmp_cache_dir):
+        """ohlc.parquet에 MultiIndex 컬럼이 보존되어 캐시 히트가 동작한다."""
+        mock_df = _make_yf_response(["AAPL", "MSFT"], days=8)
+        with patch("src.backtest.cache.yf.download", return_value=mock_df) as dl:
+            first = cache.get_ohlc(["AAPL", "MSFT"], "2024-01-01", "2024-01-12")
+            assert dl.call_count == 1
+            # 두 번째 호출은 캐시 히트 -> 다운로드 미발생
+            second = cache.get_ohlc(["AAPL", "MSFT"], "2024-01-01", "2024-01-12")
+            assert dl.call_count == 1
+
+        assert isinstance(second.columns, pd.MultiIndex)
+        assert set(second.columns.get_level_values(0)) == {"High", "Low", "Close"}
+
+    def test_get_ohlc_raises_on_empty(self, cache):
+        with patch("src.backtest.cache.yf.download", return_value=pd.DataFrame()):
+            with pytest.raises(ValueError, match="OHLC 다운로드 실패"):
+                cache.get_ohlc(["AAPL"], "2024-01-01", "2024-01-10")
+
+    def test_clear_removes_ohlc(self, cache, tmp_cache_dir):
+        tmp_cache_dir.mkdir(parents=True, exist_ok=True)
+        (tmp_cache_dir / "ohlc.parquet").write_text("dummy")
+        cache.clear()
+        assert not (tmp_cache_dir / "ohlc.parquet").exists()

--- a/tests/test_backtest_components.py
+++ b/tests/test_backtest_components.py
@@ -123,16 +123,44 @@ class TestBacktestBrokerOrderExecution:
         assert portfolio.current_prices["AAPL"] == 110.0
 
 
-class TestBacktestBrokerOhlcWindows:
-    def test_windows_default_empty(self, broker):
-        assert broker.get_ohlc_windows() == {}
+class TestBacktestMarketDataProvider:
+    def _ohlc(self, tickers, days=10):
+        idx = pd.bdate_range("2024-01-02", periods=days)
+        data = {}
+        for t in tickers:
+            base = [100 + i for i in range(days)]
+            data[("High", t)] = [x + 0.5 for x in base]
+            data[("Low", t)] = [x - 0.5 for x in base]
+            data[("Close", t)] = base
+        df = pd.DataFrame(data, index=idx)
+        df.columns = pd.MultiIndex.from_tuples(df.columns)
+        return df
 
-    def test_set_get_windows_roundtrip(self, broker):
-        idx = pd.bdate_range("2024-01-02", periods=3)
-        win = pd.DataFrame(
-            {"High": [1, 2, 3], "Low": [0, 1, 2], "Close": [0.5, 1.5, 2.5]}, index=idx
-        )
-        broker.set_ohlc_windows({"AAPL": win})
-        out = broker.get_ohlc_windows()
-        assert "AAPL" in out
-        pd.testing.assert_frame_equal(out["AAPL"], win)
+    def test_window_excludes_today(self):
+        from src.backtest.components import BacktestMarketDataProvider
+        df = self._ohlc(["AAPL"], days=10)
+        provider = BacktestMarketDataProvider(df, window_size=260)
+        asof = df.index[5]                      # 6번째 거래일
+        win = provider.get_ohlc_window("AAPL", asof)
+        assert list(win.columns) == ["High", "Low", "Close"]
+        assert (win.index < asof).all()          # 오늘 봉 제외
+        assert win.index.max() == df.index[4]    # 직전 완성봉(어제)까지
+
+    def test_window_size_clamp(self):
+        from src.backtest.components import BacktestMarketDataProvider
+        df = self._ohlc(["AAPL"], days=10)
+        provider = BacktestMarketDataProvider(df, window_size=3)
+        win = provider.get_ohlc_window("AAPL", df.index[9])
+        assert len(win) == 3
+
+    def test_empty_before_first_day_returns_none(self):
+        from src.backtest.components import BacktestMarketDataProvider
+        df = self._ohlc(["AAPL"], days=10)
+        provider = BacktestMarketDataProvider(df)
+        assert provider.get_ohlc_window("AAPL", df.index[0]) is None  # 직전 봉 없음
+
+    def test_unknown_ticker_returns_none(self):
+        from src.backtest.components import BacktestMarketDataProvider
+        df = self._ohlc(["AAPL"], days=10)
+        provider = BacktestMarketDataProvider(df)
+        assert provider.get_ohlc_window("MSFT", df.index[5]) is None

--- a/tests/test_backtest_components.py
+++ b/tests/test_backtest_components.py
@@ -121,3 +121,18 @@ class TestBacktestBrokerOrderExecution:
         # 보유 가치: 5 * 110 = 550
         assert portfolio.holdings["AAPL"] == 5
         assert portfolio.current_prices["AAPL"] == 110.0
+
+
+class TestBacktestBrokerOhlcWindows:
+    def test_windows_default_empty(self, broker):
+        assert broker.get_ohlc_windows() == {}
+
+    def test_set_get_windows_roundtrip(self, broker):
+        idx = pd.bdate_range("2024-01-02", periods=3)
+        win = pd.DataFrame(
+            {"High": [1, 2, 3], "Low": [0, 1, 2], "Close": [0.5, 1.5, 2.5]}, index=idx
+        )
+        broker.set_ohlc_windows({"AAPL": win})
+        out = broker.get_ohlc_windows()
+        assert "AAPL" in out
+        pd.testing.assert_frame_equal(out["AAPL"], win)

--- a/tests/test_backtest_runner.py
+++ b/tests/test_backtest_runner.py
@@ -67,16 +67,23 @@ def multi_stock_config(tmp_path):
     return str(config_path)
 
 
-def _make_close_df(tickers, days=20, start_price=100.0, price_step=-1.0):
-    """가격이 점진적으로 변하는 종가 DataFrame 생성.
+def _make_ohlc_df(tickers, days=20, start_price=100.0, price_step=-1.0, spread=0.5):
+    """가격이 점진적으로 변하는 OHLC DataFrame 생성 (컬럼 MultiIndex (field, ticker)).
 
     기본값: 100 -> 99 -> 98 -> ... (하락 추세, 추가 매수 유도)
+    runner는 ohlc_df["Close"]로 종가를 파생한다.
     """
     dates = pd.bdate_range("2024-01-02", periods=days)
+    closes = {t: [start_price + i * price_step for i in range(days)] for t in tickers}
     data = {}
     for t in tickers:
-        data[t] = [start_price + i * price_step for i in range(days)]
-    return pd.DataFrame(data, index=dates)
+        c = closes[t]
+        data[("High", t)] = [x + spread for x in c]
+        data[("Low", t)] = [x - spread for x in c]
+        data[("Close", t)] = c
+    df = pd.DataFrame(data, index=dates)
+    df.columns = pd.MultiIndex.from_tuples(df.columns)
+    return df
 
 
 class TestValidateTickers:
@@ -103,10 +110,10 @@ class TestValidateTickers:
 class TestRunBacktest:
     def test_basic_backtest_flow(self, backtest_config, tmp_path):
         """기본 백테스트 흐름: 데이터 다운 -> 시뮬레이션 -> 결과 파일 생성"""
-        close_df = _make_close_df(["AAPL"], days=10, start_price=100.0, price_step=-2.0)
+        close_df = _make_ohlc_df(["AAPL"], days=10, start_price=100.0, price_step=-2.0)
         output_dir = str(tmp_path / "output")
 
-        with patch("src.backtest.runner.download_historical_data", return_value=close_df):
+        with patch("src.backtest.runner.download_ohlc_data", return_value=close_df):
             result = run_backtest(
                 config_path=backtest_config,
                 start_date="2024-01-02",
@@ -124,10 +131,10 @@ class TestRunBacktest:
 
     def test_initial_buy_occurs(self, backtest_config, tmp_path):
         """첫 거래일에 Lv1 초기 매수가 발생"""
-        close_df = _make_close_df(["AAPL"], days=5, start_price=100.0, price_step=0.0)
+        close_df = _make_ohlc_df(["AAPL"], days=5, start_price=100.0, price_step=0.0)
         output_dir = str(tmp_path / "output")
 
-        with patch("src.backtest.runner.download_historical_data", return_value=close_df):
+        with patch("src.backtest.runner.download_ohlc_data", return_value=close_df):
             result = run_backtest(
                 config_path=backtest_config,
                 start_date="2024-01-02",
@@ -176,12 +183,12 @@ class TestRunBacktest:
 
     def test_multi_stock_backtest(self, multi_stock_config, tmp_path):
         """2종목 백테스트가 정상 실행"""
-        close_df = _make_close_df(
+        close_df = _make_ohlc_df(
             ["AAPL", "MSFT"], days=10, start_price=100.0, price_step=-1.0,
         )
         output_dir = str(tmp_path / "output")
 
-        with patch("src.backtest.runner.download_historical_data", return_value=close_df):
+        with patch("src.backtest.runner.download_ohlc_data", return_value=close_df):
             result = run_backtest(
                 config_path=multi_stock_config,
                 start_date="2024-01-02",
@@ -199,10 +206,10 @@ class TestRunBacktest:
     def test_missing_ticker_data_returns_none(self, backtest_config, tmp_path):
         """필요한 티커 데이터가 없으면 None 반환"""
         # AAPL이 필요한데 MSFT만 있는 데이터
-        close_df = _make_close_df(["MSFT"], days=5)
+        close_df = _make_ohlc_df(["MSFT"], days=5)
         output_dir = str(tmp_path / "output")
 
-        with patch("src.backtest.runner.download_historical_data", return_value=close_df):
+        with patch("src.backtest.runner.download_ohlc_data", return_value=close_df):
             result = run_backtest(
                 config_path=backtest_config,
                 start_date="2024-01-02",

--- a/tests/test_backtest_runner.py
+++ b/tests/test_backtest_runner.py
@@ -267,21 +267,20 @@ def _regime_config(tmp_path, enabled):
     return str(path)
 
 
-def _max_sells_per_day(output_dir, ticker="AAPL"):
+def _max_exec_qty(output_dir, action, ticker="AAPL"):
+    """history.json에서 단일 체결의 최대 수량(해당 action·종목)을 반환."""
     with open(os.path.join(output_dir, "history.json"), encoding="utf-8") as f:
         history = json.load(f)
-    worst = 0
+    best = 0
     for rec in history:
-        sells = sum(
-            1 for e in rec.get("executions", [])
-            if e.get("ticker") == ticker and e.get("action") == "SELL"
-        )
-        worst = max(worst, sells)
-    return worst
+        for e in rec.get("executions", []):
+            if e.get("ticker") == ticker and e.get("action") == action:
+                best = max(best, int(e.get("quantity", 0)))
+    return best
 
 
 class TestRegimeIntegration:
-    def test_uptrend_accumulates_then_liquidates(self, tmp_path):
+    def test_uptrend_accumulates_then_bulk_liquidates(self, tmp_path):
         ohlc = _make_regime_switch_ohlc()
         dates = ohlc.index
         start, end = dates[0].strftime("%Y-%m-%d"), dates[-1].strftime("%Y-%m-%d")
@@ -294,10 +293,11 @@ class TestRegimeIntegration:
                 initial_cash=100000.0, output_dir=on_dir,
             )
         assert result is not None
-        # 상승장에서 누적 후 추세 이탈 시 다수 lot을 같은 날 전량 청산
-        assert _max_sells_per_day(on_dir) >= 2
+        # 누적된 여러 lot을 추세 이탈 시 통합 1건으로 청산 -> 단일 매도 수량이
+        # 어떤 단일 매수 수량보다 크다(여러 lot 합산 청산의 증거).
+        assert _max_exec_qty(on_dir, "SELL") > _max_exec_qty(on_dir, "BUY")
 
-    def test_control_regime_off_single_sell_path(self, tmp_path):
+    def test_control_regime_off_no_bulk_sell(self, tmp_path):
         ohlc = _make_regime_switch_ohlc()
         dates = ohlc.index
         start, end = dates[0].strftime("%Y-%m-%d"), dates[-1].strftime("%Y-%m-%d")
@@ -309,5 +309,5 @@ class TestRegimeIntegration:
                 start_date=start, end_date=end,
                 initial_cash=100000.0, output_dir=off_dir,
             )
-        # 평균회귀 경로는 종목당 하루 최대 1건 매도 (동시 다중 청산 없음)
-        assert _max_sells_per_day(off_dir) <= 1
+        # 평균회귀 경로는 lot 단위 매도뿐 -> 통합 매도(매수보다 큰 단일 매도) 없음
+        assert _max_exec_qty(off_dir, "SELL") <= _max_exec_qty(off_dir, "BUY")

--- a/tests/test_backtest_runner.py
+++ b/tests/test_backtest_runner.py
@@ -217,3 +217,97 @@ class TestRunBacktest:
                 output_dir=output_dir,
             )
         assert result is None
+
+
+def _make_regime_switch_ohlc(spread=0.3):
+    """횡보(210) -> 완만한 상승(150) -> 급락(15)으로 레짐 전환을 합성한다."""
+    sideways = [100 + (i % 2) * 0.5 for i in range(210)]
+    climb = []
+    p = sideways[-1]
+    for _ in range(150):
+        p *= 1.001
+        climb.append(p)
+    drop = []
+    p = climb[-1]
+    for _ in range(15):
+        p *= 0.97
+        drop.append(p)
+    closes = sideways + climb + drop
+    dates = pd.bdate_range("2022-01-03", periods=len(closes))
+    data = {
+        ("High", "AAPL"): [c + spread for c in closes],
+        ("Low", "AAPL"): [c - spread for c in closes],
+        ("Close", "AAPL"): closes,
+    }
+    df = pd.DataFrame(data, index=dates)
+    df.columns = pd.MultiIndex.from_tuples(df.columns)
+    return df
+
+
+def _regime_config(tmp_path, enabled):
+    config = {
+        "stocks": [{
+            "ticker": "AAPL",
+            "market_type": "overseas",
+            "buy_threshold_pct": -20.0,
+            "sell_threshold_pct": 50.0,
+            "buy_amount": 300,
+            "max_lots": 20,
+            "enabled": True,
+            "regime_enabled": enabled,
+            "regime_min_bars": 200,
+            "uptrend_max_adds": 5,
+            "uptrend_pullback_band_pct": 4.0,
+        }],
+        "global": {"notification_enabled": False},
+    }
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    path = tmp_path / "config_overseas.json"
+    path.write_text(json.dumps(config))
+    return str(path)
+
+
+def _max_sells_per_day(output_dir, ticker="AAPL"):
+    with open(os.path.join(output_dir, "history.json"), encoding="utf-8") as f:
+        history = json.load(f)
+    worst = 0
+    for rec in history:
+        sells = sum(
+            1 for e in rec.get("executions", [])
+            if e.get("ticker") == ticker and e.get("action") == "SELL"
+        )
+        worst = max(worst, sells)
+    return worst
+
+
+class TestRegimeIntegration:
+    def test_uptrend_accumulates_then_liquidates(self, tmp_path):
+        ohlc = _make_regime_switch_ohlc()
+        dates = ohlc.index
+        start, end = dates[0].strftime("%Y-%m-%d"), dates[-1].strftime("%Y-%m-%d")
+
+        on_dir = str(tmp_path / "on")
+        with patch("src.backtest.runner.download_ohlc_data", return_value=ohlc):
+            result = run_backtest(
+                config_path=_regime_config(tmp_path / "on_cfg", enabled=True),
+                start_date=start, end_date=end,
+                initial_cash=100000.0, output_dir=on_dir,
+            )
+        assert result is not None
+        # 상승장에서 누적 후 추세 이탈 시 다수 lot을 같은 날 전량 청산
+        assert _max_sells_per_day(on_dir) >= 2
+
+    def test_control_regime_off_single_sell_path(self, tmp_path):
+        ohlc = _make_regime_switch_ohlc()
+        dates = ohlc.index
+        start, end = dates[0].strftime("%Y-%m-%d"), dates[-1].strftime("%Y-%m-%d")
+
+        off_dir = str(tmp_path / "off")
+        with patch("src.backtest.runner.download_ohlc_data", return_value=ohlc):
+            run_backtest(
+                config_path=_regime_config(tmp_path / "off_cfg", enabled=False),
+                start_date=start, end_date=end,
+                initial_cash=100000.0, output_dir=off_dir,
+            )
+        # 평균회귀 경로는 종목당 하루 최대 1건 매도 (동시 다중 청산 없음)
+        assert _max_sells_per_day(off_dir) <= 1

--- a/tests/test_backtest_runner.py
+++ b/tests/test_backtest_runner.py
@@ -267,16 +267,18 @@ def _regime_config(tmp_path, enabled):
     return str(path)
 
 
-def _max_exec_qty(output_dir, action, ticker="AAPL"):
-    """history.json에서 단일 체결의 최대 수량(해당 action·종목)을 반환."""
+def _max_sells_in_a_day(output_dir, ticker="AAPL"):
+    """history.json에서 하루치 레코드 내 SELL 체결 건수의 최댓값."""
     with open(os.path.join(output_dir, "history.json"), encoding="utf-8") as f:
         history = json.load(f)
-    best = 0
+    worst = 0
     for rec in history:
-        for e in rec.get("executions", []):
-            if e.get("ticker") == ticker and e.get("action") == action:
-                best = max(best, int(e.get("quantity", 0)))
-    return best
+        sells = sum(
+            1 for e in rec.get("executions", [])
+            if e.get("ticker") == ticker and e.get("action") == "SELL"
+        )
+        worst = max(worst, sells)
+    return worst
 
 
 class TestRegimeIntegration:
@@ -293,9 +295,9 @@ class TestRegimeIntegration:
                 initial_cash=100000.0, output_dir=on_dir,
             )
         assert result is not None
-        # 누적된 여러 lot을 추세 이탈 시 통합 1건으로 청산 -> 단일 매도 수량이
-        # 어떤 단일 매수 수량보다 크다(여러 lot 합산 청산의 증거).
-        assert _max_exec_qty(on_dir, "SELL") > _max_exec_qty(on_dir, "BUY")
+        # 통합 1건 청산이지만 history엔 소진 lot별 N개 레코드로 분리 기록되므로,
+        # 청산 당일 SELL 레코드가 2건 이상이면 다수 lot 누적 후 일괄 청산의 증거.
+        assert _max_sells_in_a_day(on_dir) >= 2
 
     def test_control_regime_off_no_bulk_sell(self, tmp_path):
         ohlc = _make_regime_switch_ohlc()
@@ -309,5 +311,5 @@ class TestRegimeIntegration:
                 start_date=start, end_date=end,
                 initial_cash=100000.0, output_dir=off_dir,
             )
-        # 평균회귀 경로는 lot 단위 매도뿐 -> 통합 매도(매수보다 큰 단일 매도) 없음
-        assert _max_exec_qty(off_dir, "SELL") <= _max_exec_qty(off_dir, "BUY")
+        # 평균회귀 경로는 종목당 하루 최대 1건 매도 (일괄 분리 청산 없음)
+        assert _max_sells_in_a_day(off_dir) <= 1

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -143,11 +143,11 @@ class TestRunOneCycle:
         # Original _update_positions method
         original_update_positions = engine._update_positions
 
-        def mock_update_positions(positions, signals, executions, today, last_sell_prices=None):
+        def mock_update_positions(positions, signals, executions, today, last_sell_prices=None, **kwargs):
             # Check if this is the AAPL update
             if any(e.ticker == "AAPL" for e in executions):
                 raise Exception("Mock position update error")
-            return original_update_positions(positions, signals, executions, today, last_sell_prices=last_sell_prices)
+            return original_update_positions(positions, signals, executions, today, last_sell_prices=last_sell_prices, **kwargs)
 
         engine._update_positions = MagicMock(side_effect=mock_update_positions)
 
@@ -1024,6 +1024,52 @@ class TestRunManualTrade:
         assert saved == []  # 새 lot 미추가
         alert_msgs = [c.args[0] for c in notifier.send_alert.call_args_list]
         assert any("수동매매" in m and "체결 실패 또는 거절" in m for m in alert_msgs)
+
+
+class TestRegimeAddCommitOnFill:
+    """상승 add는 매수 체결이 확정될 때만 regime_state를 갱신한다 (백테스트/라이브 동일)."""
+
+    def _buy_sig(self):
+        sig = SplitSignal("AAPL", None, OrderAction.BUY, 5, 110.0, "상승 add", 0.0, 2)
+        sig.regime_add_swing_high = 120.0
+        return sig
+
+    def test_commit_on_filled_buy(self, engine):
+        regime_state = {"AAPL": {"regime": "uptrend", "adds": 0, "last_add_swing_high": 100.0}}
+        exe = TradeExecution(
+            "AAPL", OrderAction.BUY, 5, 110.0, 1.0, "2024-01-01", ExecutionStatus.FILLED,
+        )
+        engine._update_positions(
+            [], [self._buy_sig()], [exe], "2024-01-02",
+            last_sell_prices={}, regime_state=regime_state,
+        )
+        assert regime_state["AAPL"]["adds"] == 1
+        assert regime_state["AAPL"]["last_add_swing_high"] == 120.0
+
+    def test_no_commit_on_rejected_buy(self, engine):
+        regime_state = {"AAPL": {"regime": "uptrend", "adds": 0, "last_add_swing_high": 100.0}}
+        exe = TradeExecution(
+            "AAPL", OrderAction.BUY, 0, 110.0, 0.0, "2024-01-01", ExecutionStatus.REJECTED,
+        )
+        engine._update_positions(
+            [], [self._buy_sig()], [exe], "2024-01-02",
+            last_sell_prices={}, regime_state=regime_state,
+        )
+        # 거절되면 add 카운트/고점 기준이 그대로 유지된다
+        assert regime_state["AAPL"]["adds"] == 0
+        assert regime_state["AAPL"]["last_add_swing_high"] == 100.0
+
+    def test_normal_buy_does_not_touch_regime_state(self, engine):
+        # regime_add_swing_high 없는 일반 매수는 regime_state를 건드리지 않는다
+        regime_state = {"AAPL": {"regime": "uptrend", "adds": 2, "last_add_swing_high": 100.0}}
+        sig = SplitSignal("AAPL", None, OrderAction.BUY, 5, 110.0, "일반 매수", 0.0, 2)
+        exe = TradeExecution(
+            "AAPL", OrderAction.BUY, 5, 110.0, 1.0, "2024-01-01", ExecutionStatus.FILLED,
+        )
+        engine._update_positions(
+            [], [sig], [exe], "2024-01-02", last_sell_prices={}, regime_state=regime_state,
+        )
+        assert regime_state["AAPL"]["adds"] == 2
 
 
 class TestUpdatePositionsMultiSell:

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -1024,3 +1024,59 @@ class TestRunManualTrade:
         assert saved == []  # 새 lot 미추가
         alert_msgs = [c.args[0] for c in notifier.send_alert.call_args_list]
         assert any("수동매매" in m and "체결 실패 또는 거절" in m for m in alert_msgs)
+
+
+class TestUpdatePositionsMultiSell:
+    """추세 이탈 전량청산: 한 종목에 매도 신호가 여럿일 때 lot별로 모두 제거."""
+
+    def _exe(self, qty, price):
+        return TradeExecution(
+            "AAPL", OrderAction.SELL, qty, price, 0.0,
+            "2024-01-01", ExecutionStatus.FILLED,
+        )
+
+    def test_all_lots_removed_and_last_sell_price_is_final_fill(self, engine):
+        positions = [
+            PositionLot("lotA", "AAPL", 50.0, 5, "2024-01-01", level=1),
+            PositionLot("lotB", "AAPL", 60.0, 5, "2024-01-01", level=2),
+            PositionLot("lotC", "AAPL", 70.0, 5, "2024-01-01", level=3),
+        ]
+        signals = [
+            SplitSignal("AAPL", "lotC", OrderAction.SELL, 5, 90.0, "청산 Lv3", 0.0, 3, 70.0),
+            SplitSignal("AAPL", "lotB", OrderAction.SELL, 5, 90.0, "청산 Lv2", 0.0, 2, 60.0),
+            SplitSignal("AAPL", "lotA", OrderAction.SELL, 5, 90.0, "청산 Lv1", 0.0, 1, 50.0),
+        ]
+        executions = [self._exe(5, 90.0), self._exe(5, 90.0), self._exe(5, 91.0)]
+        last_sell = {}
+        result = engine._update_positions(
+            positions, signals, executions, "2024-01-02", last_sell_prices=last_sell,
+        )
+        assert result == []
+        assert last_sell["AAPL"] == 91.0  # 마지막 체결가
+
+    def test_single_sell_path_unchanged(self, engine):
+        positions = [
+            PositionLot("lotA", "AAPL", 50.0, 5, "2024-01-01", level=1),
+            PositionLot("lotB", "AAPL", 60.0, 5, "2024-01-01", level=2),
+        ]
+        signals = [
+            SplitSignal("AAPL", "lotB", OrderAction.SELL, 5, 90.0, "익절 Lv2", 0.0, 2, 60.0),
+        ]
+        executions = [self._exe(5, 90.0)]
+        result = engine._update_positions(
+            positions, signals, executions, "2024-01-02", last_sell_prices={},
+        )
+        assert [l.lot_id for l in result] == ["lotA"]
+
+    def test_enrich_executions_matches_each_lot(self, engine):
+        signals = [
+            SplitSignal("AAPL", "lotB", OrderAction.SELL, 5, 90.0, "Lv2", 0.0, 2, 60.0),
+            SplitSignal("AAPL", "lotA", OrderAction.SELL, 5, 90.0, "Lv1", 0.0, 1, 50.0),
+        ]
+        executions = [self._exe(5, 90.0), self._exe(5, 90.0)]
+        engine._enrich_executions(executions, signals)
+        assert executions[0].level == 2
+        assert executions[0].buy_price == 60.0
+        assert executions[0].realized_pnl == round((90.0 - 60.0) * 5, 2)
+        assert executions[1].level == 1
+        assert executions[1].buy_price == 50.0

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -81,7 +81,7 @@ class TestRunOneCycle:
             logger=mock_logger, stock_rules=rules,
         )
 
-        def mock_evaluate_stock(rule, positions, portfolio, last_sell_prices=None):
+        def mock_evaluate_stock(rule, positions, portfolio, last_sell_prices=None, **kwargs):
             if rule.ticker == "AAPL":
                 raise Exception("Mock evaluator error")
             elif rule.ticker == "MSFT":
@@ -121,7 +121,7 @@ class TestRunOneCycle:
             logger=mock_logger, stock_rules=rules,
         )
 
-        def mock_evaluate_stock(rule, positions, portfolio, last_sell_prices=None):
+        def mock_evaluate_stock(rule, positions, portfolio, last_sell_prices=None, **kwargs):
             if rule.ticker == "AAPL":
                 return [SplitSignal("AAPL", None, OrderAction.BUY, 5, 100.0, "AAPL Buy", 0.0, 1)]
             elif rule.ticker == "MSFT":

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -1072,6 +1072,48 @@ class TestRegimeAddCommitOnFill:
         assert regime_state["AAPL"]["adds"] == 2
 
 
+class TestRegimeLiquidationResetOnFill:
+    """추세이탈 전량청산: 매도 체결이 확정될 때만 regime_state를 리셋한다."""
+
+    def _positions(self):
+        return [
+            PositionLot("lotA", "AAPL", 50.0, 5, "2024-01-01", level=1),
+            PositionLot("lotB", "AAPL", 60.0, 5, "2024-01-01", level=2),
+        ]
+
+    def _liq_signals(self):
+        return [
+            SplitSignal("AAPL", "lotB", OrderAction.SELL, 5, 90.0, "청산", 0.0, 2, 60.0,
+                        regime_liquidation=True),
+            SplitSignal("AAPL", "lotA", OrderAction.SELL, 5, 90.0, "청산", 0.0, 1, 50.0,
+                        regime_liquidation=True),
+        ]
+
+    def _sell(self, status=ExecutionStatus.FILLED, qty=5):
+        return TradeExecution("AAPL", OrderAction.SELL, qty, 90.0, 0.0, "2024-01-01", status)
+
+    def test_reset_on_filled_liquidation(self, engine):
+        regime_state = {"AAPL": {"regime": "uptrend", "adds": 3, "last_add_swing_high": 200.0}}
+        engine._update_positions(
+            self._positions(), self._liq_signals(), [self._sell(), self._sell()],
+            "2024-01-02", last_sell_prices={}, regime_state=regime_state,
+        )
+        assert "AAPL" not in regime_state  # flat 재시작
+
+    def test_no_reset_when_all_rejected(self, engine):
+        regime_state = {"AAPL": {"regime": "uptrend", "adds": 3, "last_add_swing_high": 200.0}}
+        rejected = [
+            self._sell(status=ExecutionStatus.REJECTED, qty=0),
+            self._sell(status=ExecutionStatus.REJECTED, qty=0),
+        ]
+        engine._update_positions(
+            self._positions(), self._liq_signals(), rejected,
+            "2024-01-02", last_sell_prices={}, regime_state=regime_state,
+        )
+        # 거절되면 상승 모드 유지 -> 다음 사이클 재시도
+        assert regime_state["AAPL"]["regime"] == "uptrend"
+
+
 class TestUpdatePositionsMultiSell:
     """추세 이탈 전량청산: 한 종목에 매도 신호가 여럿일 때 lot별로 모두 제거."""
 

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -1081,6 +1081,45 @@ class TestUpdatePositionsMultiSell:
         assert executions[1].level == 1
         assert executions[1].buy_price == 50.0
 
+    def test_rejected_sell_keeps_queue_aligned(self, engine):
+        # 전량청산 다중 매도 중 첫 건이 REJECTED여도, 거절된 lot은 유지되고
+        # 정상 체결된 lot만 각자의 신호와 올바르게 매칭되어 제거된다.
+        positions = [
+            PositionLot("lotA", "AAPL", 50.0, 5, "2024-01-01", level=1),
+            PositionLot("lotB", "AAPL", 60.0, 5, "2024-01-01", level=2),
+            PositionLot("lotC", "AAPL", 70.0, 5, "2024-01-01", level=3),
+        ]
+        signals = [  # 청산 순서: 높은 차수부터
+            SplitSignal("AAPL", "lotC", OrderAction.SELL, 5, 90.0, "청산 Lv3", 0.0, 3, 70.0),
+            SplitSignal("AAPL", "lotB", OrderAction.SELL, 5, 90.0, "청산 Lv2", 0.0, 2, 60.0),
+            SplitSignal("AAPL", "lotA", OrderAction.SELL, 5, 90.0, "청산 Lv1", 0.0, 1, 50.0),
+        ]
+        rejected = TradeExecution(
+            "AAPL", OrderAction.SELL, 0, 90.0, 0.0, "2024-01-01",
+            ExecutionStatus.REJECTED,
+        )
+        executions = [rejected, self._exe(5, 90.0), self._exe(5, 90.0)]
+        result = engine._update_positions(
+            positions, signals, executions, "2024-01-02", last_sell_prices={},
+        )
+        # lotC(첫 신호=거절)는 남고, lotB/lotA만 제거
+        assert [l.lot_id for l in result] == ["lotC"]
+
+    def test_rejected_enrich_keeps_queue_aligned(self, engine):
+        signals = [
+            SplitSignal("AAPL", "lotC", OrderAction.SELL, 5, 90.0, "Lv3", 0.0, 3, 70.0),
+            SplitSignal("AAPL", "lotB", OrderAction.SELL, 5, 90.0, "Lv2", 0.0, 2, 60.0),
+        ]
+        rejected = TradeExecution(
+            "AAPL", OrderAction.SELL, 0, 90.0, 0.0, "2024-01-01",
+            ExecutionStatus.REJECTED,
+        )
+        executions = [rejected, self._exe(5, 90.0)]
+        engine._enrich_executions(executions, signals)
+        # 두 번째(정상) 체결은 두 번째 신호(lotB, Lv2)와 매칭되어야 한다
+        assert executions[1].level == 2
+        assert executions[1].buy_price == 60.0
+
 
 class TestRegimeStateEngine:
     def test_load_regime_state_from_status(self, engine, mock_repo):

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -1080,3 +1080,21 @@ class TestUpdatePositionsMultiSell:
         assert executions[0].realized_pnl == round((90.0 - 60.0) * 5, 2)
         assert executions[1].level == 1
         assert executions[1].buy_price == 50.0
+
+
+class TestRegimeStateEngine:
+    def test_load_regime_state_from_status(self, engine, mock_repo):
+        rs = {"AAPL": {"regime": "uptrend", "adds": 1}}
+        mock_repo.load_status.return_value = {"regime_state_by_ticker": rs}
+        assert engine._load_regime_state() == rs
+
+    def test_load_regime_state_missing_returns_empty(self, engine, mock_repo):
+        mock_repo.load_status.return_value = {"last_run_date": "2026-04-10"}
+        assert engine._load_regime_state() == {}
+
+    def test_state_transition_resets_regime_state(self, engine, mock_repo):
+        # 이전 사이클엔 AAPL이 비활성 -> 이번에 활성(OFF->ON)
+        mock_repo.load_status.return_value = {"enabled_tickers": []}
+        regime_state = {"AAPL": {"regime": "uptrend", "adds": 3}}
+        engine._handle_state_transitions([], {}, regime_state)
+        assert "AAPL" not in regime_state

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -1110,6 +1110,20 @@ class TestBulkLiquidation:
         # (90-70)+(90-60)+(90-50) per 5주 = (20+30+40)*5 = 450
         assert exe.realized_pnl == 450.0
 
+    def test_breakdown_records_per_lot(self, engine):
+        exe = self._exe(15)
+        engine._update_positions(
+            self._positions(), [self._bulk_signal(15)], [exe],
+            "2024-01-02", last_sell_prices={}, regime_state={},
+        )
+        bd = exe.liquidation_lots
+        assert bd is not None and len(bd) == 3
+        # 고차수부터 차감: Lv3 -> Lv2 -> Lv1
+        assert [x["level"] for x in bd] == [3, 2, 1]
+        assert {x["lot_id"] for x in bd} == {"lotA", "lotB", "lotC"}
+        # lot별 손익 합 == 종목 누적용 aggregate (fee=0)
+        assert round(sum(x["realized_pnl"] for x in bd), 2) == exe.realized_pnl
+
     def test_partial_fill_consumes_high_level_first_and_keeps_mode(self, engine):
         regime_state = {"AAPL": {"regime": "uptrend", "adds": 3, "last_add_swing_high": 200.0}}
         # 7주만 체결 -> Lv3(5) 전량 + Lv2(2) 부분 차감

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -1072,141 +1072,96 @@ class TestRegimeAddCommitOnFill:
         assert regime_state["AAPL"]["adds"] == 2
 
 
-class TestRegimeLiquidationResetOnFill:
-    """추세이탈 전량청산: 매도 체결이 확정될 때만 regime_state를 리셋한다."""
+class TestBulkLiquidation:
+    """추세이탈 통합 전량청산(Bulk Sell): 단일 매도를 고차수부터 차감한다."""
 
     def _positions(self):
         return [
             PositionLot("lotA", "AAPL", 50.0, 5, "2024-01-01", level=1),
             PositionLot("lotB", "AAPL", 60.0, 5, "2024-01-01", level=2),
+            PositionLot("lotC", "AAPL", 70.0, 5, "2024-01-01", level=3),
         ]
 
-    def _liq_signals(self):
-        return [
-            SplitSignal("AAPL", "lotB", OrderAction.SELL, 5, 90.0, "청산", 0.0, 2, 60.0,
-                        regime_liquidation=True),
-            SplitSignal("AAPL", "lotA", OrderAction.SELL, 5, 90.0, "청산", 0.0, 1, 50.0,
-                        regime_liquidation=True),
-        ]
+    def _bulk_signal(self, total_qty=15, price=90.0):
+        # lot_id=None + regime_liquidation=True -> 통합 청산
+        return SplitSignal("AAPL", None, OrderAction.SELL, total_qty, price,
+                           "Bulk 청산", 0.0, 3, regime_liquidation=True)
 
-    def _sell(self, status=ExecutionStatus.FILLED, qty=5):
-        return TradeExecution("AAPL", OrderAction.SELL, qty, 90.0, 0.0, "2024-01-01", status)
+    def _exe(self, qty, price=90.0, status=ExecutionStatus.FILLED):
+        return TradeExecution("AAPL", OrderAction.SELL, qty, price, 0.0, "2024-01-01", status)
 
-    def test_reset_on_filled_liquidation(self, engine):
+    def test_full_fill_removes_all_and_resets(self, engine):
         regime_state = {"AAPL": {"regime": "uptrend", "adds": 3, "last_add_swing_high": 200.0}}
-        engine._update_positions(
-            self._positions(), self._liq_signals(), [self._sell(), self._sell()],
-            "2024-01-02", last_sell_prices={}, regime_state=regime_state,
+        last_sell = {}
+        result = engine._update_positions(
+            self._positions(), [self._bulk_signal(15)], [self._exe(15)],
+            "2024-01-02", last_sell_prices=last_sell, regime_state=regime_state,
         )
+        assert result == []
+        assert last_sell["AAPL"] == 90.0
         assert "AAPL" not in regime_state  # flat 재시작
 
-    def test_no_reset_when_all_rejected(self, engine):
-        regime_state = {"AAPL": {"regime": "uptrend", "adds": 3, "last_add_swing_high": 200.0}}
-        rejected = [
-            self._sell(status=ExecutionStatus.REJECTED, qty=0),
-            self._sell(status=ExecutionStatus.REJECTED, qty=0),
-        ]
+    def test_realized_pnl_aggregates_over_lots(self, engine):
+        exe = self._exe(15)
         engine._update_positions(
-            self._positions(), self._liq_signals(), rejected,
+            self._positions(), [self._bulk_signal(15)], [exe],
+            "2024-01-02", last_sell_prices={}, regime_state={},
+        )
+        # (90-70)+(90-60)+(90-50) per 5주 = (20+30+40)*5 = 450
+        assert exe.realized_pnl == 450.0
+
+    def test_partial_fill_consumes_high_level_first_and_keeps_mode(self, engine):
+        regime_state = {"AAPL": {"regime": "uptrend", "adds": 3, "last_add_swing_high": 200.0}}
+        # 7주만 체결 -> Lv3(5) 전량 + Lv2(2) 부분 차감
+        result = engine._update_positions(
+            self._positions(), [self._bulk_signal(15)],
+            [self._exe(7, status=ExecutionStatus.PARTIAL)],
             "2024-01-02", last_sell_prices={}, regime_state=regime_state,
         )
-        # 거절되면 상승 모드 유지 -> 다음 사이클 재시도
+        ids = sorted(l.lot_id for l in result)
+        assert ids == ["lotA", "lotB"]            # lotC 전량 제거
+        lotB = next(l for l in result if l.lot_id == "lotB")
+        assert lotB.quantity == 3                  # 5 - 2
+        # 잔여 포지션 있으므로 모드 유지 -> 다음 사이클 재청산
+        assert regime_state["AAPL"]["regime"] == "uptrend"
+
+    def test_rejected_keeps_all_and_mode(self, engine):
+        regime_state = {"AAPL": {"regime": "uptrend", "adds": 3, "last_add_swing_high": 200.0}}
+        result = engine._update_positions(
+            self._positions(), [self._bulk_signal(15)],
+            [self._exe(0, status=ExecutionStatus.REJECTED)],
+            "2024-01-02", last_sell_prices={}, regime_state=regime_state,
+        )
+        assert len(result) == 3                    # 아무것도 안 지워짐
         assert regime_state["AAPL"]["regime"] == "uptrend"
 
 
-class TestUpdatePositionsMultiSell:
-    """추세 이탈 전량청산: 한 종목에 매도 신호가 여럿일 때 lot별로 모두 제거."""
+class TestNormalSingleSell:
+    """일반(평균회귀) 단건 매도는 lot_id로 해당 lot만 제거한다."""
 
     def _exe(self, qty, price):
         return TradeExecution(
-            "AAPL", OrderAction.SELL, qty, price, 0.0,
-            "2024-01-01", ExecutionStatus.FILLED,
+            "AAPL", OrderAction.SELL, qty, price, 0.0, "2024-01-01", ExecutionStatus.FILLED,
         )
 
-    def test_all_lots_removed_and_last_sell_price_is_final_fill(self, engine):
-        positions = [
-            PositionLot("lotA", "AAPL", 50.0, 5, "2024-01-01", level=1),
-            PositionLot("lotB", "AAPL", 60.0, 5, "2024-01-01", level=2),
-            PositionLot("lotC", "AAPL", 70.0, 5, "2024-01-01", level=3),
-        ]
-        signals = [
-            SplitSignal("AAPL", "lotC", OrderAction.SELL, 5, 90.0, "청산 Lv3", 0.0, 3, 70.0),
-            SplitSignal("AAPL", "lotB", OrderAction.SELL, 5, 90.0, "청산 Lv2", 0.0, 2, 60.0),
-            SplitSignal("AAPL", "lotA", OrderAction.SELL, 5, 90.0, "청산 Lv1", 0.0, 1, 50.0),
-        ]
-        executions = [self._exe(5, 90.0), self._exe(5, 90.0), self._exe(5, 91.0)]
-        last_sell = {}
-        result = engine._update_positions(
-            positions, signals, executions, "2024-01-02", last_sell_prices=last_sell,
-        )
-        assert result == []
-        assert last_sell["AAPL"] == 91.0  # 마지막 체결가
-
-    def test_single_sell_path_unchanged(self, engine):
+    def test_single_sell_removes_targeted_lot(self, engine):
         positions = [
             PositionLot("lotA", "AAPL", 50.0, 5, "2024-01-01", level=1),
             PositionLot("lotB", "AAPL", 60.0, 5, "2024-01-01", level=2),
         ]
-        signals = [
-            SplitSignal("AAPL", "lotB", OrderAction.SELL, 5, 90.0, "익절 Lv2", 0.0, 2, 60.0),
-        ]
-        executions = [self._exe(5, 90.0)]
+        signals = [SplitSignal("AAPL", "lotB", OrderAction.SELL, 5, 90.0, "익절 Lv2", 0.0, 2, 60.0)]
         result = engine._update_positions(
-            positions, signals, executions, "2024-01-02", last_sell_prices={},
+            positions, signals, [self._exe(5, 90.0)], "2024-01-02", last_sell_prices={},
         )
         assert [l.lot_id for l in result] == ["lotA"]
 
-    def test_enrich_executions_matches_each_lot(self, engine):
-        signals = [
-            SplitSignal("AAPL", "lotB", OrderAction.SELL, 5, 90.0, "Lv2", 0.0, 2, 60.0),
-            SplitSignal("AAPL", "lotA", OrderAction.SELL, 5, 90.0, "Lv1", 0.0, 1, 50.0),
-        ]
-        executions = [self._exe(5, 90.0), self._exe(5, 90.0)]
+    def test_enrich_single_sell_pnl(self, engine):
+        signals = [SplitSignal("AAPL", "lotB", OrderAction.SELL, 5, 90.0, "Lv2", 0.0, 2, 60.0)]
+        executions = [self._exe(5, 90.0)]
         engine._enrich_executions(executions, signals)
         assert executions[0].level == 2
         assert executions[0].buy_price == 60.0
         assert executions[0].realized_pnl == round((90.0 - 60.0) * 5, 2)
-        assert executions[1].level == 1
-        assert executions[1].buy_price == 50.0
-
-    def test_rejected_sell_keeps_queue_aligned(self, engine):
-        # 전량청산 다중 매도 중 첫 건이 REJECTED여도, 거절된 lot은 유지되고
-        # 정상 체결된 lot만 각자의 신호와 올바르게 매칭되어 제거된다.
-        positions = [
-            PositionLot("lotA", "AAPL", 50.0, 5, "2024-01-01", level=1),
-            PositionLot("lotB", "AAPL", 60.0, 5, "2024-01-01", level=2),
-            PositionLot("lotC", "AAPL", 70.0, 5, "2024-01-01", level=3),
-        ]
-        signals = [  # 청산 순서: 높은 차수부터
-            SplitSignal("AAPL", "lotC", OrderAction.SELL, 5, 90.0, "청산 Lv3", 0.0, 3, 70.0),
-            SplitSignal("AAPL", "lotB", OrderAction.SELL, 5, 90.0, "청산 Lv2", 0.0, 2, 60.0),
-            SplitSignal("AAPL", "lotA", OrderAction.SELL, 5, 90.0, "청산 Lv1", 0.0, 1, 50.0),
-        ]
-        rejected = TradeExecution(
-            "AAPL", OrderAction.SELL, 0, 90.0, 0.0, "2024-01-01",
-            ExecutionStatus.REJECTED,
-        )
-        executions = [rejected, self._exe(5, 90.0), self._exe(5, 90.0)]
-        result = engine._update_positions(
-            positions, signals, executions, "2024-01-02", last_sell_prices={},
-        )
-        # lotC(첫 신호=거절)는 남고, lotB/lotA만 제거
-        assert [l.lot_id for l in result] == ["lotC"]
-
-    def test_rejected_enrich_keeps_queue_aligned(self, engine):
-        signals = [
-            SplitSignal("AAPL", "lotC", OrderAction.SELL, 5, 90.0, "Lv3", 0.0, 3, 70.0),
-            SplitSignal("AAPL", "lotB", OrderAction.SELL, 5, 90.0, "Lv2", 0.0, 2, 60.0),
-        ]
-        rejected = TradeExecution(
-            "AAPL", OrderAction.SELL, 0, 90.0, 0.0, "2024-01-01",
-            ExecutionStatus.REJECTED,
-        )
-        executions = [rejected, self._exe(5, 90.0)]
-        engine._enrich_executions(executions, signals)
-        # 두 번째(정상) 체결은 두 번째 신호(lotB, Lv2)와 매칭되어야 한다
-        assert executions[1].level == 2
-        assert executions[1].buy_price == 60.0
 
 
 class TestRegimeStateEngine:

--- a/tests/test_core_models.py
+++ b/tests/test_core_models.py
@@ -204,3 +204,62 @@ class TestExecutionStatus:
     def test_str(self):
         assert str(ExecutionStatus.FILLED) == "FILLED"
         assert str(ExecutionStatus.REJECTED) == "REJECTED"
+
+
+class TestStockRuleRegime:
+    def test_regime_defaults_off(self):
+        rule = StockRule("AAPL", -5.0, 10.0, 500, 10)
+        assert rule.regime_enabled is False
+        assert rule.regime_adx_trend == 25.0
+        assert rule.regime_adx_range == 20.0
+        assert rule.regime_min_bars == 200
+        assert rule.uptrend_max_adds == 3
+        assert rule.trendbreak_use_sma50 is True
+        assert rule.uptrend_add_amount is None
+        assert rule.uptrend_add_amounts is None
+
+    def test_uptrend_add_amount_fallback_to_buy_amount(self):
+        rule = StockRule("AAPL", -5.0, 10.0, 500, 10)
+        assert rule.uptrend_add_amount_at(1) == 500
+        assert rule.uptrend_add_amount_at(3) == 500
+
+    def test_uptrend_add_amount_scalar(self):
+        rule = StockRule("AAPL", -5.0, 10.0, 500, 10, uptrend_add_amount=800)
+        assert rule.uptrend_add_amount_at(1) == 800
+        assert rule.uptrend_add_amount_at(5) == 800
+
+    def test_uptrend_add_amounts_array_clamps(self):
+        rule = StockRule(
+            "AAPL", -5.0, 10.0, 500, 10,
+            uptrend_add_amounts=[1500.0, 1000.0, 600.0],
+        )
+        assert rule.uptrend_add_amount_at(1) == 1500.0
+        assert rule.uptrend_add_amount_at(2) == 1000.0
+        assert rule.uptrend_add_amount_at(3) == 600.0
+        assert rule.uptrend_add_amount_at(9) == 600.0  # clamp to last
+
+    def test_guard_rejects_inverted_adx_thresholds(self):
+        with pytest.raises(ValueError, match="regime_adx_range"):
+            StockRule(
+                "AAPL", -5.0, 10.0, 500, 10,
+                regime_enabled=True, regime_adx_trend=20.0, regime_adx_range=30.0,
+            )
+
+    def test_guard_rejects_negative_pullback_band(self):
+        with pytest.raises(ValueError, match="uptrend_pullback_band_pct"):
+            StockRule(
+                "AAPL", -5.0, 10.0, 500, 10,
+                regime_enabled=True, uptrend_pullback_band_pct=-1.0,
+            )
+
+    def test_guard_inactive_when_regime_disabled(self):
+        # regime_enabled=False면 비정상 값이어도 통과 (OFF)
+        rule = StockRule(
+            "AAPL", -5.0, 10.0, 500, 10,
+            regime_adx_trend=20.0, regime_adx_range=30.0,
+        )
+        assert rule.regime_enabled is False
+
+    def test_empty_uptrend_add_amounts_rejected(self):
+        with pytest.raises(ValueError, match="uptrend_add_amounts"):
+            StockRule("AAPL", -5.0, 10.0, 500, 10, uptrend_add_amounts=[])

--- a/tests/test_infra_repo.py
+++ b/tests/test_infra_repo.py
@@ -123,3 +123,11 @@ class TestStatus:
         assert len(loaded) == 2
         assert loaded[0].level == 1
         assert loaded[1].level == 2
+
+
+class TestRegimeStateRoundtrip:
+    def test_status_preserves_nested_regime_state(self, repo):
+        rs = {"AAPL": {"regime": "uptrend", "adds": 1, "last_add_swing_high": 150.5}}
+        repo.save_status({"last_run_date": "2026-04-10", "regime_state_by_ticker": rs})
+        loaded = repo.load_status()
+        assert loaded["regime_state_by_ticker"] == rs

--- a/tests/test_infra_repo.py
+++ b/tests/test_infra_repo.py
@@ -131,3 +131,30 @@ class TestRegimeStateRoundtrip:
         repo.save_status({"last_run_date": "2026-04-10", "regime_state_by_ticker": rs})
         loaded = repo.load_status()
         assert loaded["regime_state_by_ticker"] == rs
+
+
+class TestBulkLiquidationHistory:
+    def test_breakdown_expands_to_per_lot_records(self, repo):
+        exe = TradeExecution(
+            "AAPL", OrderAction.SELL, 10, 90.0, 0.0, "2024-01-02",
+            ExecutionStatus.FILLED, reason="Bulk 청산",
+            buy_price=55.0, realized_pnl=350.0,
+            liquidation_lots=[
+                {"lot_id": "lotB", "level": 2, "buy_price": 60.0, "quantity": 5, "realized_pnl": 150.0},
+                {"lot_id": "lotA", "level": 1, "buy_price": 50.0, "quantity": 5, "realized_pnl": 200.0},
+            ],
+        )
+        pf = Portfolio(total_cash=1000.0, holdings={}, current_prices={"AAPL": 90.0})
+        repo.save_trade_history([exe], pf, "Bulk 청산", sim_date="2024-01-02")
+
+        with open(repo.history_file, encoding="utf-8") as f:
+            history = json.load(f)
+        execs = history[-1]["executions"]
+        # 1건의 통합 청산이 lot별 2개 레코드로 분리됨
+        assert len(execs) == 2
+        assert {e["level"] for e in execs} == {1, 2}
+        assert {e["lot_id"] for e in execs} == {"lotA", "lotB"}
+        # 분리된 레코드엔 raw breakdown 필드가 남지 않는다
+        assert all("liquidation_lots" not in e for e in execs)
+        # 차수별 손익 합 보존
+        assert round(sum(e["realized_pnl"] for e in execs), 2) == 350.0

--- a/tests/test_regime.py
+++ b/tests/test_regime.py
@@ -1,0 +1,136 @@
+# tests/test_regime.py
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.core.logic.regime import (
+    Regime,
+    RegimeReading,
+    classify,
+    true_range,
+    atr,
+    ema,
+    adx,
+    swing_high,
+)
+
+
+def _ohlc(closes, spread=0.5):
+    closes = np.asarray(closes, dtype=float)
+    idx = pd.date_range("2025-01-01", periods=len(closes), freq="D")
+    return pd.DataFrame(
+        {"High": closes + spread, "Low": closes - spread, "Close": closes},
+        index=idx,
+    )
+
+
+def _ohlc_hl(highs, lows, closes):
+    idx = pd.date_range("2025-01-01", periods=len(closes), freq="D")
+    return pd.DataFrame(
+        {"High": highs, "Low": lows, "Close": closes}, index=idx
+    ).astype(float)
+
+
+def _uptrend(n=250, start=100.0, step=1.0):
+    return _ohlc([start + i * step for i in range(n)])
+
+
+def _downtrend(n=250, start=400.0, step=1.0):
+    return _ohlc([start - i * step for i in range(n)])
+
+
+def _sideways(n=250, base=100.0):
+    # 매 봉 방향이 뒤집히는 지그재그 -> 방향성(ADX) 거의 0, MA 정렬 안 됨
+    return _ohlc([base + (i % 2) * 2.0 for i in range(n)])
+
+
+class TestIndicators:
+    def test_true_range_exact(self):
+        df = _ohlc_hl(
+            highs=[10, 12, 11], lows=[8, 9, 7], closes=[9, 11, 8]
+        )
+        tr = true_range(df)
+        # bar0: prev_close NaN -> H-L=2; bar1: max(3,3,0)=3; bar2: max(4,0,4)=4
+        assert list(tr.values) == [2.0, 3.0, 4.0]
+
+    def test_atr_wilder_exact(self):
+        df = _ohlc_hl(highs=[10, 12, 11], lows=[8, 9, 7], closes=[9, 11, 8])
+        a = atr(df, period=2)
+        # TR=[2,3,4], ewm(alpha=0.5,adjust=False): 2 -> 2.5 -> 3.25
+        assert a.iloc[-1] == pytest.approx(3.25)
+
+    def test_ema_matches_pandas(self):
+        df = _uptrend(30)
+        expected = df["Close"].ewm(span=20, adjust=False).mean()
+        pd.testing.assert_series_equal(ema(df["Close"], 20), expected)
+
+    def test_adx_high_in_strong_uptrend(self):
+        df = _uptrend()
+        val = adx(df).iloc[-1]
+        assert np.isfinite(val)
+        assert val >= 25.0
+
+    def test_adx_low_in_choppy(self):
+        df = _sideways()
+        assert adx(df).iloc[-1] < 25.0
+
+    def test_swing_high(self):
+        df = _ohlc([100, 105, 103, 108, 101])
+        # 고가 = close+0.5; 최근 3봉 고가 max = 108.5
+        assert swing_high(df, lookback=3) == pytest.approx(108.5)
+
+
+class TestClassify:
+    def test_uptrend(self):
+        r = classify(_uptrend())
+        assert r.regime == Regime.UPTREND
+        assert r.aligned_up is True
+        assert r.n_bars == 250
+        assert r.adx >= 25.0
+
+    def test_downtrend(self):
+        r = classify(_downtrend())
+        assert r.regime == Regime.DOWNTREND
+        assert r.aligned_up is False
+
+    def test_sideways(self):
+        r = classify(_sideways())
+        assert r.regime == Regime.SIDEWAYS
+
+    def test_unknown_when_too_few_bars(self):
+        r = classify(_uptrend(150))  # default min_bars=200
+        assert r.regime == Regime.UNKNOWN
+        assert np.isnan(r.ema20)
+        assert r.n_bars == 150
+
+    def test_unknown_when_ma_nan(self):
+        # 봉수 게이트는 통과하지만 sma200 산출 불가(100봉) -> UNKNOWN
+        r = classify(_uptrend(100), min_bars=50)
+        assert r.regime == Regime.UNKNOWN
+        assert np.isnan(r.sma200)
+        assert not np.isnan(r.ema20)
+
+    def test_aligned_but_not_trending_is_sideways(self):
+        # 정렬 상승이지만 ADX 임계가 비현실적으로 높으면 비추세 -> SIDEWAYS
+        r = classify(_uptrend(), adx_trend_threshold=200.0)
+        assert r.aligned_up is True
+        assert r.regime == Regime.SIDEWAYS
+
+    def test_reading_fields(self):
+        df = _uptrend()
+        r = classify(df, chandelier_k=3.0, chandelier_lookback=22)
+        assert r.close == pytest.approx(float(df["Close"].iloc[-1]))
+        assert r.prev_close == pytest.approx(float(df["Close"].iloc[-2]))
+        highest_high = float(df["High"].tail(22).max())
+        assert r.chandelier_stop == pytest.approx(highest_high - 3.0 * r.atr)
+
+    def test_prev_close_single_bar(self):
+        r = classify(_uptrend(1))
+        assert r.regime == Regime.UNKNOWN
+        assert r.prev_close == r.close
+
+
+class TestRegimeEnum:
+    def test_str(self):
+        assert str(Regime.UPTREND) == "uptrend"
+        assert str(Regime.SIDEWAYS) == "sideways"

--- a/tests/test_regime.py
+++ b/tests/test_regime.py
@@ -74,6 +74,16 @@ class TestIndicators:
         df = _sideways()
         assert adx(df).iloc[-1] < 25.0
 
+    def test_adx_flat_series_no_divide_by_zero(self):
+        # 변동이 전혀 없는 평탄 시계열(거래정지 등): ATR=0 이어도 경고/NaN 없이 0.
+        import warnings
+        df = _ohlc([100.0] * 60, spread=0.0)  # High=Low=Close -> TR=0 -> ATR=0
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # RuntimeWarning을 에러로 승격
+            val = adx(df).iloc[-1]
+        assert np.isfinite(val)
+        assert val == pytest.approx(0.0)
+
     def test_swing_high(self):
         df = _ohlc([100, 105, 103, 108, 101])
         # 고가 = close+0.5; 최근 3봉 고가 max = 108.5

--- a/tests/test_split_evaluator_regime.py
+++ b/tests/test_split_evaluator_regime.py
@@ -192,9 +192,9 @@ class TestTrendBreakLiquidation:
         assert len(signals) == 3
         assert all(s.action == OrderAction.SELL for s in signals)
         assert {s.lot_id for s in signals} == {"lotA", "lotB", "lotC"}
-        # 상태가 초기화되어 다음 사이클 flat 재시작
-        assert state["AAPL"]["regime"] == "sideways"
-        assert state["AAPL"]["adds"] == 0
+        # 청산 표식이 실려야 하고, 리셋은 체결 시 엔진이 수행 -> 평가 시점엔 상승 유지
+        assert all(s.regime_liquidation for s in signals)
+        assert state["AAPL"]["regime"] == "uptrend"
 
 
 class TestResolveRegimeHysteresis:

--- a/tests/test_split_evaluator_regime.py
+++ b/tests/test_split_evaluator_regime.py
@@ -1,0 +1,177 @@
+# tests/test_split_evaluator_regime.py
+import numpy as np
+import pandas as pd
+import pytest
+
+from src.core.logic.split_evaluator import SplitEvaluator
+from src.core.logic.regime import classify
+from src.core.models import StockRule, PositionLot, Portfolio, OrderAction
+
+
+@pytest.fixture
+def evaluator():
+    return SplitEvaluator()
+
+
+def _uptrend_window(n=250, start=100.0, step=1.0, spread=0.5):
+    closes = np.array([start + i * step for i in range(n)], dtype=float)
+    idx = pd.date_range("2024-01-01", periods=n, freq="D")
+    return pd.DataFrame(
+        {"High": closes + spread, "Low": closes - spread, "Close": closes}, index=idx
+    )
+
+
+def _regime_rule(**over):
+    base = dict(
+        ticker="AAPL", buy_threshold_pct=-5.0, sell_threshold_pct=10.0,
+        buy_amount=500, max_lots=10, regime_enabled=True,
+    )
+    base.update(over)
+    return StockRule(**base)
+
+
+def _reading(window, rule):
+    return classify(
+        window,
+        adx_trend_threshold=rule.regime_adx_trend,
+        adx_range_threshold=rule.regime_adx_range,
+        chandelier_k=rule.trendbreak_chandelier_k,
+        chandelier_lookback=rule.trendbreak_chandelier_lookback,
+        swing_lookback=rule.uptrend_swing_lookback,
+        min_bars=rule.regime_min_bars,
+    )
+
+
+def _lot(level=1, buy_price=100.0, qty=5, lot_id=None):
+    return PositionLot(
+        lot_id=lot_id or f"lot_{level:03d}",
+        ticker="AAPL", buy_price=buy_price, quantity=qty,
+        buy_date="2024-01-01", level=level,
+    )
+
+
+def _pf(price, cash=100000.0, qty=5):
+    return Portfolio(total_cash=cash, holdings={"AAPL": qty}, current_prices={"AAPL": price})
+
+
+class TestRegimeBranchGating:
+    def test_disabled_falls_through_to_normal_harvest(self, evaluator):
+        # regime_enabled=False면 윈도우가 있어도 평균회귀 경로 -> 익절 매도 발생
+        rule = _regime_rule(regime_enabled=False)
+        window = _uptrend_window()
+        lot = _lot(level=1, buy_price=10.0)  # 큰 평가익
+        signals = evaluator.evaluate_stock(
+            rule, [lot], _pf(price=300.0), ohlc_window=window,
+            regime_state={"AAPL": {"regime": "uptrend"}},
+        )
+        assert any(s.action == OrderAction.SELL for s in signals)
+
+    def test_no_window_falls_through(self, evaluator):
+        rule = _regime_rule()
+        lot = _lot(level=1, buy_price=10.0)
+        signals = evaluator.evaluate_stock(rule, [lot], _pf(price=300.0))
+        assert any(s.action == OrderAction.SELL for s in signals)
+
+
+class TestUptrendLockSells:
+    def test_sells_locked_in_uptrend(self, evaluator):
+        rule = _regime_rule()
+        window = _uptrend_window()
+        r = _reading(window, rule)
+        price = r.ema20 * 1.10  # 밴드 밖(눌림 아님) -> 추가도 없음
+        lot = _lot(level=1, buy_price=10.0)  # 평균회귀라면 익절했을 큰 이익
+        state = {"AAPL": {"regime": "uptrend", "adds": 0, "last_add_swing_high": r.swing_high}}
+        signals = evaluator.evaluate_stock(
+            rule, [lot], _pf(price=price), ohlc_window=window, regime_state=state,
+        )
+        assert all(s.action != OrderAction.SELL for s in signals)
+
+
+class TestUptrendPullbackAdd:
+    def test_pullback_add_emits_buy(self, evaluator):
+        rule = _regime_rule()
+        window = _uptrend_window()
+        r = _reading(window, rule)
+        price = r.ema20 * 1.005  # 밴드 내 + 20EMA 위 -> 반등 확인
+        lot = _lot(level=1, buy_price=50.0)
+        state = {"AAPL": {"regime": "uptrend", "adds": 0,
+                          "last_add_swing_high": r.swing_high - 5}}
+        signals = evaluator.evaluate_stock(
+            rule, [lot], _pf(price=price), ohlc_window=window, regime_state=state,
+        )
+        buys = [s for s in signals if s.action == OrderAction.BUY and not s.is_blocked]
+        assert len(buys) == 1
+        assert buys[0].level == 2
+        assert buys[0].quantity >= 1
+        # 낙관적 상태 갱신
+        assert state["AAPL"]["adds"] == 1
+
+    def test_new_high_gate_blocks_add(self, evaluator):
+        rule = _regime_rule()
+        window = _uptrend_window()
+        r = _reading(window, rule)
+        price = r.ema20 * 1.005
+        lot = _lot(level=1, buy_price=50.0)
+        # 새 고점이 없으면(직전 add 고점 == 현재 스윙고점) 추가 차단
+        state = {"AAPL": {"regime": "uptrend", "adds": 0,
+                          "last_add_swing_high": r.swing_high}}
+        signals = evaluator.evaluate_stock(
+            rule, [lot], _pf(price=price), ohlc_window=window, regime_state=state,
+        )
+        assert signals == []
+
+    def test_max_adds_caps(self, evaluator):
+        rule = _regime_rule(uptrend_max_adds=2)
+        window = _uptrend_window()
+        r = _reading(window, rule)
+        price = r.ema20 * 1.005
+        lot = _lot(level=1, buy_price=50.0)
+        state = {"AAPL": {"regime": "uptrend", "adds": 2,
+                          "last_add_swing_high": r.swing_high - 5}}
+        signals = evaluator.evaluate_stock(
+            rule, [lot], _pf(price=price), ohlc_window=window, regime_state=state,
+        )
+        assert signals == []
+
+
+class TestTrendBreakLiquidation:
+    def test_full_liquidation_emits_sell_per_lot(self, evaluator):
+        rule = _regime_rule()
+        window = _uptrend_window()
+        r = _reading(window, rule)
+        price = r.sma50 * 0.9  # 50MA 하향 이탈 -> 전량 청산
+        lots = [
+            _lot(level=1, buy_price=50.0, lot_id="lotA"),
+            _lot(level=2, buy_price=60.0, lot_id="lotB"),
+            _lot(level=3, buy_price=70.0, lot_id="lotC"),
+        ]
+        state = {"AAPL": {"regime": "uptrend", "adds": 2, "last_add_swing_high": 999}}
+        signals = evaluator.evaluate_stock(
+            rule, lots, _pf(price=price), ohlc_window=window, regime_state=state,
+        )
+        assert len(signals) == 3
+        assert all(s.action == OrderAction.SELL for s in signals)
+        assert {s.lot_id for s in signals} == {"lotA", "lotB", "lotC"}
+        # 상태가 초기화되어 다음 사이클 flat 재시작
+        assert state["AAPL"]["regime"] == "sideways"
+        assert state["AAPL"]["adds"] == 0
+
+
+class TestResolveRegimeHysteresis:
+    def test_requires_confirm_bars_to_enter_uptrend(self, evaluator):
+        rule = _regime_rule()
+        window = _uptrend_window()
+        r = _reading(window, rule)
+        lot = _lot(level=1, buy_price=50.0)
+        state = {}
+        # 1회차: 아직 확정 전 -> 상승 미진입 (state에 uptrend 미기록)
+        evaluator.evaluate_stock(
+            rule, [lot], _pf(price=r.ema20 * 1.005), ohlc_window=window, regime_state=state,
+        )
+        assert state["AAPL"].get("regime") != "uptrend"
+        assert state["AAPL"]["uptrend_streak"] == 1
+        # 2회차: 연속 확정 -> 상승 진입
+        evaluator.evaluate_stock(
+            rule, [lot], _pf(price=r.ema20 * 1.005), ohlc_window=window, regime_state=state,
+        )
+        assert state["AAPL"]["regime"] == "uptrend"

--- a/tests/test_split_evaluator_regime.py
+++ b/tests/test_split_evaluator_regime.py
@@ -103,8 +103,9 @@ class TestUptrendPullbackAdd:
         assert len(buys) == 1
         assert buys[0].level == 2
         assert buys[0].quantity >= 1
-        # 낙관적 상태 갱신
-        assert state["AAPL"]["adds"] == 1
+        # 신호에 스윙고점이 실리고(체결 시 엔진이 커밋), 평가 시점엔 adds 미변경
+        assert buys[0].regime_add_swing_high == r.swing_high
+        assert state["AAPL"]["adds"] == 0
 
     def test_new_high_gate_blocks_add(self, evaluator):
         rule = _regime_rule()

--- a/tests/test_split_evaluator_regime.py
+++ b/tests/test_split_evaluator_regime.py
@@ -120,6 +120,45 @@ class TestUptrendPullbackAdd:
         )
         assert signals == []
 
+    def test_add_blocked_by_exposure(self, evaluator):
+        rule = _regime_rule(max_exposure_pct=0.001)  # 사실상 어떤 매수도 비중 초과
+        window = _uptrend_window()
+        r = _reading(window, rule)
+        price = r.ema20 * 1.005
+        lot = _lot(level=1, buy_price=50.0)
+        state = {"AAPL": {"regime": "uptrend", "adds": 0,
+                          "last_add_swing_high": r.swing_high - 5}}
+        signals = evaluator.evaluate_stock(
+            rule, [lot], _pf(price=price), ohlc_window=window, regime_state=state,
+        )
+        assert len(signals) == 1 and signals[0].is_blocked
+
+    def test_add_blocked_by_cash(self, evaluator):
+        rule = _regime_rule(uptrend_add_amount=100000)
+        window = _uptrend_window()
+        r = _reading(window, rule)
+        price = r.ema20 * 1.005
+        lot = _lot(level=1, buy_price=50.0)
+        state = {"AAPL": {"regime": "uptrend", "adds": 0,
+                          "last_add_swing_high": r.swing_high - 5}}
+        signals = evaluator.evaluate_stock(
+            rule, [lot], _pf(price=price, cash=50.0), ohlc_window=window, regime_state=state,
+        )
+        assert len(signals) == 1 and signals[0].is_blocked
+
+    def test_add_qty_zero_skips(self, evaluator):
+        rule = _regime_rule(uptrend_add_amount=1.0)  # 1주도 못 사는 금액
+        window = _uptrend_window()
+        r = _reading(window, rule)
+        price = r.ema20 * 1.005
+        lot = _lot(level=1, buy_price=50.0)
+        state = {"AAPL": {"regime": "uptrend", "adds": 0,
+                          "last_add_swing_high": r.swing_high - 5}}
+        signals = evaluator.evaluate_stock(
+            rule, [lot], _pf(price=price), ohlc_window=window, regime_state=state,
+        )
+        assert signals == []
+
     def test_max_adds_caps(self, evaluator):
         rule = _regime_rule(uptrend_max_adds=2)
         window = _uptrend_window()

--- a/tests/test_split_evaluator_regime.py
+++ b/tests/test_split_evaluator_regime.py
@@ -175,26 +175,47 @@ class TestUptrendPullbackAdd:
 
 
 class TestTrendBreakLiquidation:
-    def test_full_liquidation_emits_sell_per_lot(self, evaluator):
+    def test_full_liquidation_emits_bulk_sell(self, evaluator):
         rule = _regime_rule()
         window = _uptrend_window()
         r = _reading(window, rule)
         price = r.sma50 * 0.9  # 50MA 하향 이탈 -> 전량 청산
         lots = [
-            _lot(level=1, buy_price=50.0, lot_id="lotA"),
-            _lot(level=2, buy_price=60.0, lot_id="lotB"),
-            _lot(level=3, buy_price=70.0, lot_id="lotC"),
+            _lot(level=1, buy_price=50.0, qty=5, lot_id="lotA"),
+            _lot(level=2, buy_price=60.0, qty=5, lot_id="lotB"),
+            _lot(level=3, buy_price=70.0, qty=5, lot_id="lotC"),
         ]
         state = {"AAPL": {"regime": "uptrend", "adds": 2, "last_add_swing_high": 999}}
         signals = evaluator.evaluate_stock(
-            rule, lots, _pf(price=price), ohlc_window=window, regime_state=state,
+            rule, lots, _pf(price=price, qty=15), ohlc_window=window, regime_state=state,
         )
-        assert len(signals) == 3
-        assert all(s.action == OrderAction.SELL for s in signals)
-        assert {s.lot_id for s in signals} == {"lotA", "lotB", "lotC"}
-        # 청산 표식이 실려야 하고, 리셋은 체결 시 엔진이 수행 -> 평가 시점엔 상승 유지
-        assert all(s.regime_liquidation for s in signals)
+        # 통합 매도 1건: 총 보유 수량, lot_id 없음, 청산 표식
+        assert len(signals) == 1
+        s = signals[0]
+        assert s.action == OrderAction.SELL
+        assert s.lot_id is None
+        assert s.quantity == 15  # 5+5+5
+        assert s.regime_liquidation is True
+        # 리셋은 체결 시 엔진이 수행 -> 평가 시점엔 상승 유지
         assert state["AAPL"]["regime"] == "uptrend"
+
+
+class TestNanGuard:
+    def test_nan_indicator_holds_and_warns(self):
+        from unittest.mock import MagicMock
+        logger = MagicMock()
+        ev = SplitEvaluator(logger=logger)
+        rule = _regime_rule()
+        window = _uptrend_window(50)  # < min_bars(200) -> UNKNOWN -> sma50 NaN
+        lot = _lot(level=1, buy_price=50.0)
+        # 이미 상승 래치 상태라 _resolve_regime은 UPTREND 유지 -> _evaluate_uptrend 진입
+        state = {"AAPL": {"regime": "uptrend", "adds": 0, "last_add_swing_high": 0.0}}
+        signals = ev.evaluate_stock(
+            rule, [lot], _pf(price=100.0), ohlc_window=window, regime_state=state,
+        )
+        # 지표 NaN -> 이탈 판단 불가 -> 평가 보류(빈 신호) + 경고 로그
+        assert signals == []
+        assert logger.warning.called
 
 
 class TestResolveRegimeHysteresis:

--- a/tests/test_status_builder.py
+++ b/tests/test_status_builder.py
@@ -54,3 +54,31 @@ class TestStatusMarketType:
         assert "positions" in status
         assert "risk_summary" in status
         assert status["market_type"] == "overseas"
+
+
+class TestRegimeStatePersistence:
+    def test_regime_state_included_in_status(self):
+        rs = {"AAPL": {"regime": "uptrend", "adds": 2, "last_add_swing_high": 198.4}}
+        status = build_dashboard_status(
+            portfolio=_empty_portfolio(),
+            positions=[],
+            reason="-",
+            old_realized_pnl_by_ticker={},
+            recent_executions=[],
+            enabled_tickers=["AAPL"],
+            sim_date="2026-04-10",
+            regime_state_by_ticker=rs,
+        )
+        assert status["regime_state_by_ticker"] == rs
+
+    def test_regime_state_defaults_empty(self):
+        status = build_dashboard_status(
+            portfolio=_empty_portfolio(),
+            positions=[],
+            reason="-",
+            old_realized_pnl_by_ticker={},
+            recent_executions=[],
+            enabled_tickers=[],
+            sim_date="2026-04-10",
+        )
+        assert status["regime_state_by_ticker"] == {}

--- a/tests/test_strategy_config.py
+++ b/tests/test_strategy_config.py
@@ -344,3 +344,82 @@ class TestTrailingDropConfig:
         assert rule.trailing_drop_at(2) == 1.5
         assert rule.trailing_drop_at(10) == 2.0  # clamp to last
 
+
+class TestStrategyConfigRegime:
+    def test_regime_absent_defaults_off(self, tmp_path):
+        config = {"stocks": [{"ticker": "AAPL"}]}
+        config_file = tmp_path / "config_overseas.json"
+        config_file.write_text(json.dumps(config))
+
+        rule = StrategyConfig(str(config_file)).rules[0]
+        assert rule.regime_enabled is False
+        assert rule.regime_adx_trend == 25.0
+        assert rule.uptrend_add_amounts is None
+
+    def test_regime_fields_parsed_from_stock(self, tmp_path):
+        config = {
+            "stocks": [{
+                "ticker": "AAPL",
+                "regime_enabled": True,
+                "regime_adx_trend": 30,
+                "regime_adx_range": 18,
+                "regime_min_bars": 150,
+                "uptrend_pullback_band_pct": 2.0,
+                "uptrend_max_adds": 4,
+                "uptrend_add_amounts": [1500, 1000, 600],
+                "uptrend_swing_lookback": 12,
+                "trendbreak_chandelier_k": 2.5,
+                "trendbreak_chandelier_lookback": 20,
+                "trendbreak_use_sma50": False,
+            }]
+        }
+        config_file = tmp_path / "config_overseas.json"
+        config_file.write_text(json.dumps(config))
+
+        rule = StrategyConfig(str(config_file)).rules[0]
+        assert rule.regime_enabled is True
+        assert rule.regime_adx_trend == 30.0
+        assert rule.regime_adx_range == 18.0
+        assert rule.regime_min_bars == 150
+        assert rule.uptrend_pullback_band_pct == 2.0
+        assert rule.uptrend_max_adds == 4
+        assert rule.uptrend_add_amounts == [1500.0, 1000.0, 600.0]
+        assert rule.uptrend_swing_lookback == 12
+        assert rule.trendbreak_chandelier_k == 2.5
+        assert rule.trendbreak_chandelier_lookback == 20
+        assert rule.trendbreak_use_sma50 is False
+
+    def test_regime_global_inheritance_and_override(self, tmp_path):
+        config = {
+            "stocks": [
+                {"ticker": "AAPL"},                          # 글로벌 상속
+                {"ticker": "MSFT", "regime_adx_trend": 35},  # 개별 오버라이드
+            ],
+            "global": {"regime_enabled": True, "regime_adx_trend": 28},
+        }
+        config_file = tmp_path / "config_overseas.json"
+        config_file.write_text(json.dumps(config))
+
+        rules = StrategyConfig(str(config_file)).rules
+        assert rules[0].regime_enabled is True
+        assert rules[0].regime_adx_trend == 28.0   # 글로벌
+        assert rules[1].regime_enabled is True      # 글로벌 상속
+        assert rules[1].regime_adx_trend == 35.0    # 개별 오버라이드
+
+    def test_regime_via_preset(self, tmp_path):
+        presets = {
+            "trend_us": {
+                "buy_amount": 1000,
+                "regime_enabled": True,
+                "uptrend_add_amounts": [1500, 1000, 600],
+            }
+        }
+        config = {"stocks": [{"ticker": "AAPL", "preset": "trend_us"}]}
+        (tmp_path / "presets.json").write_text(json.dumps(presets))
+        config_file = tmp_path / "config_overseas.json"
+        config_file.write_text(json.dumps(config))
+
+        rule = StrategyConfig(str(config_file)).rules[0]
+        assert rule.regime_enabled is True
+        assert rule.uptrend_add_amounts == [1500.0, 1000.0, 600.0]
+

--- a/tests/test_strategy_config.py
+++ b/tests/test_strategy_config.py
@@ -1,7 +1,10 @@
 # tests/test_strategy_config.py
 import json
+import os
 import pytest
 from src.strategy_config import StrategyConfig
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 class TestStrategyConfig:
@@ -423,3 +426,23 @@ class TestStrategyConfigRegime:
         assert rule.regime_enabled is True
         assert rule.uptrend_add_amounts == [1500.0, 1000.0, 600.0]
 
+
+
+class TestRepoConfigRegimeSeparation:
+    """라이브 config는 레짐 OFF, 백테스트 전용 config_test_*는 레짐 ON 불변식."""
+
+    def test_live_overseas_regime_off(self):
+        sc = StrategyConfig(os.path.join(REPO_ROOT, "config_overseas.json"))
+        assert sc.rules and all(r.regime_enabled is False for r in sc.rules)
+
+    def test_live_domestic_regime_off(self):
+        sc = StrategyConfig(os.path.join(REPO_ROOT, "config_domestic.json"))
+        assert sc.rules and all(r.regime_enabled is False for r in sc.rules)
+
+    def test_backtest_overseas_regime_on(self):
+        sc = StrategyConfig(os.path.join(REPO_ROOT, "config_test_overseas.json"))
+        assert sc.rules and all(r.regime_enabled is True for r in sc.rules)
+
+    def test_backtest_domestic_regime_on(self):
+        sc = StrategyConfig(os.path.join(REPO_ROOT, "config_test_domestic.json"))
+        assert sc.rules and all(r.regime_enabled is True for r in sc.rules)


### PR DESCRIPTION
## 배경

핵심 알고리즘(평균회귀: 저점 분할매수 / 고점 차수 매도)은 **횡보장에서 수익이 최대화**되지만, 강한 **상승 추세에선 노출을 줄여 추세 연장 수익을 포기**합니다. 이를 보완하기 위해 종목별 **레짐 필터**를 추가해 국면에 따라 동작을 전환합니다.

여러 차례의 설계 논의 끝에 합의한 범위로 구현했습니다.

## 동작

- **횡보(on)**: 현재 동작 그대로 (평균회귀 + 기존 차수별 트레일링 스톱). **레짐 OFF/데이터 부족 시 바이트 단위로 동일.**
- **상승(off-상승)**: 차수별 매도를 **잠그고**, *추세 내 눌림(20EMA 근처 + 반등 확인 + 새 고점 게이트)*에 누적 매수하다가, **추세 이탈(50MA 하향) 시 전 차수 전량 청산** 후 flat 복귀(레짐 상태머신 재시작).
- **하락 / 지수 오버레이**: 이번 범위에서 제외 (하락은 감지만 하고 no-op).

## 주요 변경

- `src/core/logic/regime.py` (신규): pandas 기반 EMA/ADX/ATR + 레짐 분류기(횡보/상승/하락/불명). 외부 의존성 없음, 순수 함수.
- `src/core/models.py` · `src/strategy_config.py`: `StockRule`에 레짐 파라미터(옵셔널, **기본값 OFF**) 추가 + config/preset 배선(개별 > 글로벌 > 기본).
- `src/backtest/` (cache/fetcher/runner/components): OHLC 캐시(`ohlc.parquet`) 추가, 매 거래일 종목별 추세 윈도우를 엔진에 공급(룩어헤드 없음).
- `src/core/engine/base.py`: OHLC 윈도우 + 레짐 상태 스레딩, 전량청산용 다중 매도 처리(`_update_positions`·`_enrich_executions`를 순서 큐로 매칭, 단일 매도 경로 불변), `status.json`에 레짐 상태 영속.
- `src/core/logic/split_evaluator.py`: 상승 레짐 분기(매도 잠금 / 20EMA 눌림 누적 매수 / 추세이탈 전량청산 + 히스테리시스).

## 안전 불변식

- **레짐 OFF 또는 OHLC 윈도우 없음(라이브)** → `classify` 미호출 → **기존 동작과 완전히 동일**. 라이브 KIS 일봉 배선은 다음 단계.
- 상승 진입은 연속 확정(confirm bars) 후에만, 탈출은 추세이탈 전량청산으로만(매도 churn 없음).
- 눌림 매수(20EMA 근처)는 추세이탈 깊이(50MA)보다 항상 얕아 정상 눌림에 오청산되지 않음.

## 테스트

- 335 passed, 16 skipped / 커버리지 89% (게이트 80% 충족). `regime.py` 100%.
- 단위: 지표/분류기, 상승 매도 잠금, 눌림 매수, 새 고점 게이트, max_adds, 가드 차단, 전량청산, 히스테리시스, config/모델 배선, OHLC 캐시/브로커 윈도우, 엔진 다중 매도, 상태 영속.
- 통합: 합성 횡보→상승→급락 시계열로 누적 후 같은 날 다중 lot 전량 청산 확인 + **regime OFF 대조군**(종목당 하루 최대 1매도)으로 횡보 경로 불변 검증.

## 테스트 플랜

- [x] `pytest --cov=src tests/` (80% 이상)
- [x] 합성 OHLC 백테스트 end-to-end (누적 → 이탈 전량청산 → 재진입)
- [x] `regime_enabled=False` 대조군 회귀 확인

https://claude.ai/code/session_01QAmBqgW763ipsm7QyFae4N

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAmBqgW763ipsm7QyFae4N)_