### PR TITLE
refactor: unify backtest data cache to OHLCV (remove legacy close cache)

### DIFF
--- a/.github/workflows/download-market-data.yml
+++ b/.github/workflows/download-market-data.yml
@@ -50,14 +50,15 @@ jobs:
 
         cache = BacktestDataCache(logger=TradeLogger())
         cache.clear()
-        close_df = cache.get_data(tickers, real_start_str, end_date)
+        ohlc_df = cache.get_ohlc(tickers, real_start_str, end_date)
 
-        print(f'Close shape: {close_df.shape}')
-        print(f'Close range: {close_df.index.min()} ~ {close_df.index.max()}')
-        print(f'Close columns: {list(close_df.columns)}')
-        print(close_df.head(10))
+        print(f'OHLC shape: {ohlc_df.shape}')
+        print(f'OHLC range: {ohlc_df.index.min()} ~ {ohlc_df.index.max()}')
+        print(f'OHLC columns: {list(ohlc_df.columns)}')
+        print(ohlc_df.head(10))
         print('')
         print('=== NaN 진단 (Close 기준) ===')
+        close_df = ohlc_df["Close"]
         total_rows = len(close_df)
         for ticker in tickers:
             try:

--- a/src/backtest/cache.py
+++ b/src/backtest/cache.py
@@ -18,65 +18,18 @@ class _NullLogger:
 
 class BacktestDataCache:
     """
-    yfinance로 종가(Close) 데이터를 다운로드하고 Parquet으로 캐시한다.
+    yfinance로 OHLC(High/Low/Close) 데이터를 다운로드하고 Parquet으로 캐시한다.
 
     캐시 파일이 존재하고 요청 기간·티커를 모두 포함하면 다운로드를 건너뛴다.
     캐시가 없거나 범위가 부족하면 전체 재다운로드 후 저장한다.
 
-    저장 위치: src/backtest/cache/close.parquet
+    저장 위치: src/backtest/cache/ohlc.parquet
     """
 
     def __init__(self, cache_dir: Path = CACHE_DIR, logger: Optional[ILogger] = None):
         self.cache_dir = Path(cache_dir)
-        self.close_path = self.cache_dir / "close.parquet"
         self.ohlc_path = self.cache_dir / "ohlc.parquet"
         self._logger: ILogger = logger if logger is not None else _NullLogger()
-
-    def get_data(
-        self, tickers: List[str], start_date: str, end_date: str
-    ) -> pd.DataFrame:
-        """
-        종가 데이터를 반환한다. 캐시가 유효하면 재사용하고, 아니면 새로 다운로드한다.
-
-        1. 캐시 파일이 존재하고 요청 기간·티커를 포함하면 캐시 반환
-        2. 캐시 미스 시 기존 캐시 삭제 -> 전체 다운로드
-        3. 가장 늦은 상장 티커 기준으로 시작일 조정 (로그 출력)
-        4. 남은 NaN을 이전 값으로 채움 (ffill)
-        5. 저장 후 반환
-
-        Returns:
-            Close 가격 DataFrame (index=DatetimeIndex, columns=tickers)
-        """
-        self.cache_dir.mkdir(parents=True, exist_ok=True)
-
-        # 1. 캐시 히트 확인
-        cached = self._try_load_cache(tickers, start_date, end_date)
-        if cached is not None:
-            return cached
-
-        # 2. 캐시 미스 -> 기존 캐시 삭제 후 전체 다운로드
-        self.clear()
-        self._logger.info(f"종가 다운로드 시작: {tickers} ({start_date} ~ {end_date})")
-        close_df = self._download_close(tickers, start_date, end_date)
-
-        if close_df is None or close_df.empty:
-            raise ValueError(f"종가 다운로드 실패: {tickers} ({start_date} ~ {end_date})")
-
-        # 3. 상장일 기준 시작일 조정
-        close_df = self._trim_to_latest_ipo(close_df, tickers)
-
-        # 4. 남은 NaN -> 이전 값으로 채움
-        nan_before = int(close_df.isna().sum().sum())
-        if nan_before > 0:
-            close_df = close_df.ffill()
-            nan_after = int(close_df.isna().sum().sum())
-            filled = nan_before - nan_after
-            self._logger.info(f"NaN ffill 처리: {filled}개 채움, 잔여 {nan_after}개")
-
-        # 5. 저장
-        self._save_parquet(close_df, self.close_path)
-
-        return close_df
 
     def get_ohlc(
         self, tickers: List[str], start_date: str, end_date: str
@@ -85,7 +38,6 @@ class BacktestDataCache:
 
         반환 형태는 컬럼이 MultiIndex (field, ticker)인 DataFrame이며
         field 는 'High'/'Low'/'Close'. 저장 위치는 src/backtest/cache/ohlc.parquet.
-        close.parquet(get_data)과는 독립적으로 캐시한다.
         """
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
@@ -190,49 +142,7 @@ class BacktestDataCache:
             self._logger.warning(f"OHLC 다운로드 실패: {e}")
             return None
 
-    # ── 캐시 히트 검사 ─────────────────────────────────────
 
-    def _try_load_cache(
-        self, tickers: List[str], start_date: str, end_date: str
-    ) -> Optional[pd.DataFrame]:
-        """캐시 파일이 요청 기간·티커를 모두 포함하면 DataFrame을 반환, 아니면 None."""
-        if not self.close_path.exists():
-            return None
-
-        try:
-            cached_df = pd.read_parquet(self.close_path)
-        except Exception as e:
-            self._logger.warning(f"캐시 파일 읽기 실패, 재다운로드합니다: {e}")
-            return None
-
-        # 티커 확인
-        missing_tickers = [t for t in tickers if t not in cached_df.columns]
-        if missing_tickers:
-            self._logger.info(
-                f"캐시에 누락된 티커 {missing_tickers} -> 재다운로드"
-            )
-            return None
-
-        # 날짜 범위 확인 (비영업일 허용: 요청일 ±5일 이내면 OK)
-        cache_start_ts = cached_df.index.min()
-        cache_end_ts = cached_df.index.max()
-        req_start_ts = pd.Timestamp(start_date)
-        req_end_ts = pd.Timestamp(end_date)
-        slack = pd.Timedelta(days=5)
-
-        if cache_start_ts > req_start_ts + slack or cache_end_ts < req_end_ts - slack:
-            self._logger.info(
-                f"캐시 범위 부족 ({cache_start_ts.date()}~{cache_end_ts.date()}), "
-                f"요청 ({start_date}~{end_date}) -> 재다운로드"
-            )
-            return None
-
-        # 캐시 히트 — 요청 범위로 슬라이싱하여 반환
-        self._logger.info(
-            f"✅ 캐시 히트: {self.close_path.name} "
-            f"({cache_start_ts.date()}~{cache_end_ts.date()}, {len(cached_df.columns)}개 티커)"
-        )
-        return cached_df.loc[start_date:end_date, tickers]
 
     # ── 상장일 조정 ────────────────────────────────────────
 
@@ -267,49 +177,7 @@ class BacktestDataCache:
 
         return close_df
 
-    # ── 다운로드 ───────────────────────────────────────────
 
-    def _download_close(
-        self, tickers: List[str], start_date: str, end_date: str
-    ) -> Optional[pd.DataFrame]:
-        """yfinance로 종가를 다운로드한다.
-
-        MagicSplit 표준 티커(접미사 없음)를 yfinance용 (.KS/.KQ 부여) 으로 변환한 뒤
-        호출하고, 반환되는 DataFrame의 컬럼은 다시 MagicSplit 표준 티커로 환원한다.
-        """
-        yf_to_std = {to_yfinance_ticker(t): t for t in tickers}
-        yf_tickers = list(yf_to_std.keys())
-        try:
-            df = yf.download(
-                yf_tickers, start=start_date, end=end_date,
-                auto_adjust=False, progress=False,
-            )
-            if df is None or df.empty:
-                return None
-
-            # 단일 티커 + SingleIndex -> 정규화 (입력 tickers에 중복이 있어도
-            # yf_tickers 길이를 기준으로 컬럼명을 맞춰 ValueError를 회피)
-            if not isinstance(df.columns, pd.MultiIndex) and len(yf_tickers) == 1:
-                if "Close" in df.columns:
-                    close_df = df[["Close"]].copy()
-                    close_df.columns = [yf_to_std[t] for t in yf_tickers]
-                    return close_df
-                return None
-
-            # MultiIndex DataFrame: ('Close', ticker) 형태
-            if "Close" not in df.columns.get_level_values(0):
-                return None
-            close_df = df["Close"]
-
-            # Series -> DataFrame 변환 (단일 티커의 경우)
-            if isinstance(close_df, pd.Series):
-                close_df = close_df.to_frame(name=yf_tickers[0])
-
-            close_df = close_df.rename(columns=yf_to_std)
-            return close_df
-        except Exception as e:
-            self._logger.warning(f"종가 다운로드 실패: {e}")
-            return None
 
     def _save_parquet(self, df: pd.DataFrame, path: Path):
         if df is not None and not df.empty:
@@ -320,8 +188,6 @@ class BacktestDataCache:
 
     def clear(self):
         """캐시 파일 삭제"""
-        if self.close_path.exists():
-            self.close_path.unlink()
-            self._logger.info("기존 캐시 삭제 완료")
         if self.ohlc_path.exists():
             self.ohlc_path.unlink()
+            self._logger.info("OHLC 캐시 삭제 완료")

--- a/src/backtest/fetcher.py
+++ b/src/backtest/fetcher.py
@@ -3,30 +3,6 @@ import pandas as pd
 from src.backtest.cache import BacktestDataCache
 
 
-def download_historical_data(
-    tickers: list,
-    start_date: str,
-    end_date: str,
-    cache: BacktestDataCache = None,
-) -> pd.DataFrame:
-    """
-    백테스트용 종가 데이터 다운로드 (캐시 활용).
-
-    Args:
-        tickers: 종목 코드 리스트
-        start_date: 시작일 'YYYY-MM-DD'
-        end_date: 종료일 'YYYY-MM-DD'
-        cache: BacktestDataCache 인스턴스. None이면 기본 인스턴스를 생성한다.
-
-    Returns:
-        Close 가격 DataFrame (index=DatetimeIndex, columns=tickers)
-    """
-    if cache is None:
-        cache = BacktestDataCache()
-
-    return cache.get_data(tickers, start_date, end_date)
-
-
 def download_ohlc_data(
     tickers: list,
     start_date: str,

--- a/tests/test_backtest_cache.py
+++ b/tests/test_backtest_cache.py
@@ -48,84 +48,6 @@ def _make_yf_response(tickers, days=5):
         return df
 
 
-class TestBacktestDataCache:
-    def test_get_data_single_ticker(self, cache, tmp_cache_dir):
-        """단일 티커 다운로드 및 캐시 저장"""
-        mock_df = _make_yf_response(["AAPL"], days=5)
-
-        with patch("src.backtest.cache.yf.download", return_value=mock_df):
-            result = cache.get_data(["AAPL"], "2024-01-01", "2024-01-10")
-
-        assert isinstance(result, pd.DataFrame)
-        assert "AAPL" in result.columns
-        assert len(result) == 5
-        assert (tmp_cache_dir / "close.parquet").exists()
-
-    def test_get_data_multi_ticker(self, cache, tmp_cache_dir):
-        """멀티 티커 다운로드 및 캐시 저장"""
-        mock_df = _make_yf_response(["AAPL", "MSFT"], days=5)
-
-        with patch("src.backtest.cache.yf.download", return_value=mock_df):
-            result = cache.get_data(["AAPL", "MSFT"], "2024-01-01", "2024-01-10")
-
-        assert "AAPL" in result.columns
-        assert "MSFT" in result.columns
-        assert len(result) == 5
-
-    def test_get_data_ffill_nan(self, cache):
-        """NaN 값이 ffill로 처리되는지 확인"""
-        dates = pd.bdate_range("2024-01-02", periods=3)
-        cols = pd.MultiIndex.from_product([["Close"], ["AAPL"]])
-        data = {("Close", "AAPL"): [100.0, float("nan"), 102.0]}
-        mock_df = pd.DataFrame(data, index=dates)
-        mock_df.columns = cols
-
-        # Open, High 등을 추가하여 yfinance 응답처럼 만듦
-        for field in ["Open", "High", "Low", "Volume"]:
-            mock_df[(field, "AAPL")] = 100.0
-        mock_df.columns = pd.MultiIndex.from_tuples(mock_df.columns)
-
-        with patch("src.backtest.cache.yf.download", return_value=mock_df):
-            result = cache.get_data(["AAPL"], "2024-01-01", "2024-01-10")
-
-        # NaN이 ffill로 100.0이 되어야 함
-        assert result["AAPL"].iloc[1] == 100.0
-
-    def test_get_data_raises_on_empty(self, cache):
-        """빈 데이터 다운로드 시 ValueError 발생"""
-        with patch("src.backtest.cache.yf.download", return_value=pd.DataFrame()):
-            with pytest.raises(ValueError, match="종가 다운로드 실패"):
-                cache.get_data(["AAPL"], "2024-01-01", "2024-01-10")
-
-    def test_clear(self, cache, tmp_cache_dir):
-        """캐시 삭제"""
-        tmp_cache_dir.mkdir(parents=True, exist_ok=True)
-        parquet_path = tmp_cache_dir / "close.parquet"
-        parquet_path.write_text("dummy")
-
-        cache.clear()
-        assert not parquet_path.exists()
-
-    def test_clear_no_file(self, cache):
-        """파일이 없을 때 clear가 오류 없이 동작"""
-        cache.clear()  # 예외 없이 완료
-
-    def test_get_data_deletes_existing_cache(self, cache, tmp_cache_dir):
-        """get_data 호출 시 기존 캐시가 삭제되는지 확인"""
-        tmp_cache_dir.mkdir(parents=True, exist_ok=True)
-        parquet_path = tmp_cache_dir / "close.parquet"
-        parquet_path.write_text("old data")
-
-        mock_df = _make_yf_response(["AAPL"], days=3)
-        with patch("src.backtest.cache.yf.download", return_value=mock_df):
-            cache.get_data(["AAPL"], "2024-01-01", "2024-01-05")
-
-        # 파일이 새로 생성됨 (parquet 형식)
-        assert parquet_path.exists()
-        content = parquet_path.read_bytes()
-        assert content != b"old data"
-
-
 class TestIpoTrim:
     """가장 늦은 상장 티커 기준으로 시작일 조정"""
 
@@ -150,13 +72,13 @@ class TestIpoTrim:
         )
 
         with patch("src.backtest.cache.yf.download", return_value=yf_response):
-            result = cache.get_data(["SPY", "IEF"], "2022-01-01", "2023-06-30")
+            result = cache.get_ohlc(["SPY", "IEF"], "2022-01-01", "2023-06-30")
 
         assert result.index.min() >= ipo_date
-        assert "SPY" in result.columns
-        assert "IEF" in result.columns
+        assert "SPY" in result["Close"].columns
+        assert "IEF" in result["Close"].columns
         # ffill 후 NaN 없어야 함
-        assert not result["IEF"].isna().any()
+        assert not result["Close"]["IEF"].isna().any()
 
     def test_trim_logs_warning(self, tmp_cache_dir):
         """시작일 조정 시 logger.warning 호출"""
@@ -168,7 +90,7 @@ class TestIpoTrim:
         logger = MagicMock()
         cache = BacktestDataCache(cache_dir=tmp_cache_dir, logger=logger)
         with patch("src.backtest.cache.yf.download", return_value=yf_response):
-            cache.get_data(["SPY", "IEF"], "2022-01-01", "2023-06-30")
+            cache.get_ohlc(["SPY", "IEF"], "2022-01-01", "2023-06-30")
 
         warning_msgs = [c.args[0] for c in logger.warning.call_args_list]
         assert any("조정" in m for m in warning_msgs)
@@ -178,7 +100,7 @@ class TestIpoTrim:
         yf_response = _make_yf_response(["SPY", "IEF"], days=20)
 
         with patch("src.backtest.cache.yf.download", return_value=yf_response):
-            result = cache.get_data(["SPY", "IEF"], "2024-01-01", "2024-02-01")
+            result = cache.get_ohlc(["SPY", "IEF"], "2024-01-01", "2024-02-01")
 
         # 트림 없이 yf 응답의 첫 날짜가 그대로 유지
         assert result.index.min() == pd.Timestamp("2024-01-02")
@@ -224,8 +146,32 @@ class TestBacktestDataCacheOHLC:
             with pytest.raises(ValueError, match="OHLC 다운로드 실패"):
                 cache.get_ohlc(["AAPL"], "2024-01-01", "2024-01-10")
 
+    def test_get_ohlc_ffill_nan(self, cache):
+        """NaN 값이 ffill로 처리되는지 확인"""
+        dates = pd.bdate_range("2024-01-02", periods=3)
+        cols = pd.MultiIndex.from_product([["High", "Low", "Close"], ["AAPL"]])
+        data = {
+            ("High", "AAPL"): [101.0, 102.0, 103.0],
+            ("Low", "AAPL"): [99.0, 99.0, 99.0],
+            ("Close", "AAPL"): [100.0, float("nan"), 102.0]
+        }
+        mock_df = pd.DataFrame(data, index=dates)
+        mock_df.columns = cols
+        mock_df[("Volume", "AAPL")] = 1000.0
+        mock_df.columns = pd.MultiIndex.from_tuples(mock_df.columns)
+
+        with patch("src.backtest.cache.yf.download", return_value=mock_df):
+            result = cache.get_ohlc(["AAPL"], "2024-01-01", "2024-01-10")
+
+        # NaN이 ffill로 100.0이 되어야 함
+        assert result[("Close", "AAPL")].iloc[1] == 100.0
+
     def test_clear_removes_ohlc(self, cache, tmp_cache_dir):
         tmp_cache_dir.mkdir(parents=True, exist_ok=True)
         (tmp_cache_dir / "ohlc.parquet").write_text("dummy")
         cache.clear()
         assert not (tmp_cache_dir / "ohlc.parquet").exists()
+
+    def test_clear_no_file(self, cache):
+        """파일이 없을 때 clear가 오류 없이 동작"""
+        cache.clear()  # 예외 없이 완료


### PR DESCRIPTION
## 💡 개요
- 백테스트 시뮬레이션 및 레짐 지표 계산 과정에서 종가 단독 캐시(`close.parquet`)와 OHLCV 캐시(`ohlc.parquet`)가 분리되어 혼재하던 부분을 **OHLCV 캐시 하나로 완전히 단일화**하였습니다.
- 사용되지 않는 기존 종가 전용 API 및 관련 테스트 코드를 정리하여 코드베이스의 무결성을 개선했습니다.

## 🛠️ 변경 내용
1. **캐시 및 Fetcher 모듈 리팩토링** (`src/backtest/cache.py`, `src/backtest/fetcher.py`)
   - `close_path` 정의와 `get_data()`, `_try_load_cache()`, `_download_close()` 및 `download_historical_data()` API를 삭제했습니다.
   - `clear()` 메소드가 `ohlc.parquet` 만을 정리하도록 수정했습니다.
2. **GitHub Actions 스크립트 수정** (`.github/workflows/download-market-data.yml`)
   - `cache.get_data()` 호출을 `cache.get_ohlc()`로 대체했습니다.
   - 받아온 MultiIndex DataFrame에서 `Close` 컬럼을 명시적으로 추출하여 기존 NaN 자가진단 및 리포트가 정상 동작하도록 조치했습니다.
3. **단위 테스트 재구축** (`tests/test_backtest_cache.py`)
   - 삭제된 `get_data()` 대신 `get_ohlc()` 및 `_trim_to_latest_ipo` 상장일 트림 로직, 결측치 ffill 처리가 OHLCV 프레임에서도 안전하게 작동함을 확인하는 테스트 시나리오로 개편했습니다.

## 🧪 검증 결과
- **로컬 단위 테스트**: `pytest tests/test_backtest_cache.py -v` (10개 통과)
- **전체 통합 테스트**: `pytest tests/ -v` (346개 통과, 16개 스킵) - 기존 백테스트 실행 엔진과의 호환성 문제 없음 확인
