### PR TITLE
fix(positions): heatmap sync with current positions and view isolation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -101,15 +101,15 @@
 
     <script src="js/utils/format-utils.js?v=20260512-1"></script>
     <script src="js/services/data-repository.js?v=20260512-1"></script>
-    <script src="js/models/dashboard-model.js?v=20260512-1"></script>
+    <script src="js/models/dashboard-model.js?v=20260528-1"></script>
     <script src="js/models/history-model.js?v=20260512-1"></script>
     <script src="js/models/decision-model.js?v=20260512-1"></script>
-    <script src="js/views/dashboard-view.js?v=20260512-1"></script>
+    <script src="js/views/dashboard-view.js?v=20260528-1"></script>
     <script src="js/views/history-view.js?v=20260512-1"></script>
     <script src="js/views/decision-view.js?v=20260512-1"></script>
     <script src="js/views/charts-view.js?v=20260512-1"></script>
     <script src="js/views/risk-view.js?v=20260512-1"></script>
-    <script src="js/controllers/dashboard-controller.js?v=20260512-1"></script>
+    <script src="js/controllers/dashboard-controller.js?v=20260528-1"></script>
     <script src="js/controllers/risk-controller.js?v=20260512-1"></script>
     <script src="js/main.js?v=20260512-1"></script>
 </body>

--- a/docs/js/controllers/dashboard-controller.js
+++ b/docs/js/controllers/dashboard-controller.js
@@ -57,13 +57,10 @@ window.DashboardController = (function () {
             
             const buckets = DashboardModel.buildLevelBuckets();
             ChartsView.renderLevelHeatmap(buckets, mode, onHeatmapSelect);
-            // Heatmap belongs only to the positions view; hide it in all other views
+            // Re-apply view visibility so heatmap doesn't bleed into non-positions views
             const activeViewBtn = document.querySelector('.view-link.active');
             const currentView = activeViewBtn ? activeViewBtn.dataset.view : 'risk';
-            if (currentView !== 'positions') {
-                const heatmapSection = document.getElementById('level-heatmap-section');
-                if (heatmapSection) heatmapSection.style.display = 'none';
-            }
+            DashboardView.showView(currentView);
             
             const decData = await DataRepository.loadDecisions(mode);
             DecisionModel.setDecisions(decData);

--- a/docs/js/controllers/dashboard-controller.js
+++ b/docs/js/controllers/dashboard-controller.js
@@ -10,9 +10,14 @@ window.DashboardController = (function () {
         const urlParams = new URLSearchParams(window.location.search);
         const modeParam = urlParams.get('mode') || '';
         DashboardModel.setMode(modeParam);
-        
+
         DashboardView.applyModeUI(DashboardModel.getMode());
-        
+
+        // Enforce initial view visibility before first data load
+        const initialViewBtn = document.querySelector('.view-link.active');
+        const initialView = initialViewBtn ? initialViewBtn.dataset.view : 'risk';
+        DashboardView.showView(initialView);
+
         await doRefresh();
         
         initRefreshControls();
@@ -52,6 +57,13 @@ window.DashboardController = (function () {
             
             const buckets = DashboardModel.buildLevelBuckets();
             ChartsView.renderLevelHeatmap(buckets, mode, onHeatmapSelect);
+            // Heatmap belongs only to the positions view; hide it in all other views
+            const activeViewBtn = document.querySelector('.view-link.active');
+            const currentView = activeViewBtn ? activeViewBtn.dataset.view : 'risk';
+            if (currentView !== 'positions') {
+                const heatmapSection = document.getElementById('level-heatmap-section');
+                if (heatmapSection) heatmapSection.style.display = 'none';
+            }
             
             const decData = await DataRepository.loadDecisions(mode);
             DecisionModel.setDecisions(decData);

--- a/docs/js/models/dashboard-model.js
+++ b/docs/js/models/dashboard-model.js
@@ -165,7 +165,10 @@ window.DashboardModel = (function () {
         }
 
         const firstMonth = monthKey(execs[0].date);
-        const lastMonth = monthKey(execs[execs.length - 1].date);
+        const historyLastMonth = monthKey(execs[execs.length - 1].date);
+        // Always extend to today's month so heatmap stays current for open positions
+        const todayMonth = new Date().toISOString().slice(0, 7);
+        const lastMonth = historyLastMonth < todayMonth ? todayMonth : historyLastMonth;
         const months = enumerateMonths(firstMonth, lastMonth);
 
         const grid = {};
@@ -186,7 +189,21 @@ window.DashboardModel = (function () {
             }
         }
 
-        const tickers = Array.from(tickersSeen).sort();
+        // Supplement aliases from current status positions
+        if (statusData) {
+            for (const [t, info] of Object.entries(statusData.positions || {})) {
+                if (info.alias && !aliasMap[t]) aliasMap[t] = info.alias;
+            }
+        }
+
+        // Only show tickers currently held; sold-out tickers are excluded
+        const currentPositionSet = statusData ? new Set(Object.keys(statusData.positions || {})) : null;
+        let tickers = Array.from(tickersSeen);
+        if (currentPositionSet && currentPositionSet.size > 0) {
+            tickers = tickers.filter(t => currentPositionSet.has(t));
+        }
+        tickers.sort();
+
         return { months, tickers, grid, trades, aliasMap };
     }
 

--- a/docs/js/models/dashboard-model.js
+++ b/docs/js/models/dashboard-model.js
@@ -167,7 +167,8 @@ window.DashboardModel = (function () {
         const firstMonth = monthKey(execs[0].date);
         const historyLastMonth = monthKey(execs[execs.length - 1].date);
         // Always extend to today's month so heatmap stays current for open positions
-        const todayMonth = new Date().toISOString().slice(0, 7);
+        const _today = new Date();
+        const todayMonth = _today.getFullYear() + '-' + String(_today.getMonth() + 1).padStart(2, '0');
         const lastMonth = historyLastMonth < todayMonth ? todayMonth : historyLastMonth;
         const months = enumerateMonths(firstMonth, lastMonth);
 
@@ -199,7 +200,7 @@ window.DashboardModel = (function () {
         // Only show tickers currently held; sold-out tickers are excluded
         const currentPositionSet = statusData ? new Set(Object.keys(statusData.positions || {})) : null;
         let tickers = Array.from(tickersSeen);
-        if (currentPositionSet && currentPositionSet.size > 0) {
+        if (currentPositionSet) {
             tickers = tickers.filter(t => currentPositionSet.has(t));
         }
         tickers.sort();

--- a/docs/js/views/dashboard-view.js
+++ b/docs/js/views/dashboard-view.js
@@ -179,9 +179,10 @@ window.DashboardView = (function () {
 
             let lotsHtml = '';
             for (const lot of lots) {
-                const isPositive = lot.pct_change >= 0;
+                const pctVal = lot.pct_change != null ? Number(lot.pct_change) : 0;
+                const isPositive = pctVal >= 0;
                 const pctClass = isPositive ? 'pct-positive' : 'pct-negative';
-                const pctStr = (isPositive ? '+' : '') + lot.pct_change.toFixed(1) + '%';
+                const pctStr = (isPositive ? '+' : '') + pctVal.toFixed(1) + '%';
                 const indicator = isPositive ? '▲' : '▼';
                 const lvLabel = lot.level != null ? `<span class="lot-level">Lv${lot.level}</span>` : '<span class="lot-level"></span>';
                 lotsHtml += `


### PR DESCRIPTION
## Summary

- **히트맵 날짜 최신화**: `buildLevelBuckets`에서 `lastMonth`를 오늘 날짜 기준으로 연장 → 마지막 거래 이후 거래가 없어도 현재 달까지 표시
- **히트맵 종목 필터**: 현재 `status.json`의 positions에 있는 종목만 표시 → 전량 매도된 종목 제거
- **히트맵 탭 격리**: `doRefresh` 후 positions 탭이 아닐 때 `level-heatmap-section`을 강제로 숨김 → Risk/History 탭에 히트맵이 겹쳐 보이는 버그 수정
- **초기 뷰 설정**: `init()`에서 `showView(initialView)` 호출 추가 → 첫 로드 시 올바른 섹션만 표시
- **종목 카드 렌더링 안전화**: `lot.pct_change`가 null일 때 TypeError로 전체 카드 렌더링이 실패하는 버그 방지

## Test plan

- [ ] Positions 탭 진입 시 히트맵이 오늘 달(YYYY-MM)까지 표시되는지 확인
- [ ] positions에 없는 종목(전량 매도)이 히트맵에서 사라지는지 확인
- [ ] Risk 탭에서 히트맵이 보이지 않는지 확인
- [ ] Positions 탭에서 각 종목 카드(현황)가 정상 렌더링되는지 확인
- [ ] 페이지 첫 로드 시 Risk 탭이 기본 뷰로 올바르게 표시되는지 확인

https://claude.ai/code/session_01RPEbxTxFcV5PQRi3ff4BgR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPEbxTxFcV5PQRi3ff4BgR)_