### PR TITLE
feat: multi-lot trailing stop concurrent tracking with bulk sell

### DIFF
--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -737,6 +737,13 @@ class MagicSplitEngine:
                     )
                     continue
 
+                # 횡보장 trailing 벌크 매도
+                if sig is not None and sig.trailing_bulk and sig.lot_id is None:
+                    updated = self._apply_trailing_bulk(
+                        updated, exe, disp, last_sell_prices, regime_state
+                    )
+                    continue
+
                 # 일반 단건 매도: 신호의 lot_id로 해당 차수 lot 제거
                 target_lot = None
                 if sig and sig.lot_id:
@@ -781,29 +788,28 @@ class MagicSplitEngine:
 
         return updated
 
-    def _apply_bulk_liquidation(
+    def _drain_lots_by_qty(
         self,
         updated: List[PositionLot],
+        ticker: str,
+        qty: int,
         exe: TradeExecution,
-        disp: str,
-        last_sell_prices: Optional[dict],
-        regime_state: Optional[dict],
-    ) -> List[PositionLot]:
-        """통합 전량청산 체결을 고차수부터 순차 차감하여 반영한다.
+    ) -> tuple:
+        """고차수부터 qty만큼 lot을 차감하고, exe에 손익을 기록한다.
 
-        - 체결 수량만큼 고레벨 lot부터 소진(전량 소진 lot은 제거, 마지막은 부분 잔량).
-        - 실현 손익은 소진한 각 lot의 매수가 기준으로 합산해 exe에 기록.
-        - 잔여 포지션이 0이 될 때만 레짐 상태를 리셋(부분체결/거절 시 모드 유지).
+        Returns: (updated_positions, consumed)
+        exe.buy_price, exe.realized_pnl, exe.liquidation_lots 를 in-place 갱신.
+        last_sell_prices 갱신 및 regime_state 처리는 호출부 책임.
         """
-        qty_left = exe.quantity
+        qty_left = qty
         lots_desc = sorted(
-            [l for l in updated if l.ticker == exe.ticker],
+            [l for l in updated if l.ticker == ticker],
             key=lambda l: l.level, reverse=True,
         )
         total_pnl = 0.0
         total_cost = 0.0
         consumed = 0
-        breakdown = []  # 소진 lot별 분해(차수별 손익 기록용)
+        breakdown = []
         for lot in lots_desc:
             if qty_left <= 0:
                 break
@@ -825,13 +831,31 @@ class MagicSplitEngine:
         if consumed > 0:
             exe.buy_price = round(total_cost / consumed, 4)
             exe.realized_pnl = round(total_pnl - exe.fee, 2)
-            # 수수료를 소진 수량 비례로 배분해 lot별 실현손익을 확정(합 = 순실현손익).
             for item in breakdown:
                 lot_fee = exe.fee * (item["quantity"] / consumed)
                 item["realized_pnl"] = round(item.pop("_gross") - lot_fee, 2)
             exe.liquidation_lots = breakdown
-            if last_sell_prices is not None:
-                last_sell_prices[exe.ticker] = exe.price
+
+        return updated, consumed
+
+    def _apply_bulk_liquidation(
+        self,
+        updated: List[PositionLot],
+        exe: TradeExecution,
+        disp: str,
+        last_sell_prices: Optional[dict],
+        regime_state: Optional[dict],
+    ) -> List[PositionLot]:
+        """통합 전량청산 체결을 고차수부터 순차 차감하여 반영한다.
+
+        - 체결 수량만큼 고레벨 lot부터 소진(전량 소진 lot은 제거, 마지막은 부분 잔량).
+        - 실현 손익은 소진한 각 lot의 매수가 기준으로 합산해 exe에 기록.
+        - 잔여 포지션이 0이 될 때만 레짐 상태를 리셋(부분체결/거절 시 모드 유지).
+        """
+        updated, consumed = self._drain_lots_by_qty(updated, exe.ticker, exe.quantity, exe)
+        qty_left = exe.quantity - consumed
+        if consumed > 0 and last_sell_prices is not None:
+            last_sell_prices[exe.ticker] = exe.price
 
         remaining = [l for l in updated if l.ticker == exe.ticker]
         self.logger.info(
@@ -865,43 +889,10 @@ class MagicSplitEngine:
         - 체결 확정 시 regime_state에 trailing_lock 상태를 활성화한다.
         - 잔량이 남아 있으므로 레짐 상태를 리셋(pop)하지 않는다.
         """
-        qty_left = exe.quantity
-        lots_desc = sorted(
-            [l for l in updated if l.ticker == exe.ticker],
-            key=lambda l: l.level, reverse=True,
-        )
-        total_pnl = 0.0
-        total_cost = 0.0
-        consumed = 0
-        breakdown = []  # 소진 lot별 분해(차수별 손익 기록용)
-        for lot in lots_desc:
-            if qty_left <= 0:
-                break
-            take = min(qty_left, lot.quantity)
-            gross = (exe.price - lot.buy_price) * take
-            total_pnl += gross
-            total_cost += lot.buy_price * take
-            consumed += take
-            breakdown.append({
-                "lot_id": lot.lot_id, "level": lot.level,
-                "buy_price": lot.buy_price, "quantity": take, "_gross": gross,
-            })
-            if take >= lot.quantity:
-                updated.remove(lot)
-            else:
-                updated[updated.index(lot)] = replace(lot, quantity=lot.quantity - take)
-            qty_left -= take
-
-        if consumed > 0:
-            exe.buy_price = round(total_cost / consumed, 4)
-            exe.realized_pnl = round(total_pnl - exe.fee, 2)
-            # 수수료를 소진 수량 비례로 배분해 lot별 실현손익을 확정(합 = 순실현손익).
-            for item in breakdown:
-                lot_fee = exe.fee * (item["quantity"] / consumed)
-                item["realized_pnl"] = round(item.pop("_gross") - lot_fee, 2)
-            exe.liquidation_lots = breakdown
-            if last_sell_prices is not None:
-                last_sell_prices[exe.ticker] = exe.price
+        updated, consumed = self._drain_lots_by_qty(updated, exe.ticker, exe.quantity, exe)
+        qty_left = exe.quantity - consumed
+        if consumed > 0 and last_sell_prices is not None:
+            last_sell_prices[exe.ticker] = exe.price
 
         remaining = [l for l in updated if l.ticker == exe.ticker]
         self.logger.info(
@@ -941,6 +932,41 @@ class MagicSplitEngine:
                     f"하락 허용치 {drop_pct}%)"
                 )
 
+        return updated
+
+    def _apply_trailing_bulk(
+        self,
+        updated: List[PositionLot],
+        exe: TradeExecution,
+        disp: str,
+        last_sell_prices: Optional[dict],
+        regime_state: Optional[dict],
+    ) -> List[PositionLot]:
+        """횡보장 trailing 벌크 매도 체결 반영.
+
+        - 고차수부터 exe.quantity만큼 lot 차감 (_drain_lots_by_qty 재사용)
+        - last_sell_prices 갱신
+        - regime_state 변경 없음 (trailing_lock 미생성, 레짐 리셋 없음)
+        - 잔여 lot 없을 시 regime_state 잔재 정리
+        """
+        updated, consumed = self._drain_lots_by_qty(updated, exe.ticker, exe.quantity, exe)
+        qty_left = exe.quantity - consumed
+        if consumed > 0 and last_sell_prices is not None:
+            last_sell_prices[exe.ticker] = exe.price
+
+        remaining = [l for l in updated if l.ticker == exe.ticker]
+        self.logger.info(
+            f"[Position] Trailing 벌크 청산: {disp} {consumed}주 소진 "
+            f"(잔여 {sum(l.quantity for l in remaining)}주), "
+            f"실현손익 {format_money(exe.realized_pnl, self.market_type)}"
+        )
+        if qty_left > 0:
+            self.logger.warning(
+                f"[Position] Trailing 벌크 청산 초과 체결: {disp} 미차감 {qty_left}주 -- "
+                f"scripts/reconcile_positions.py 로 정합성 확인 권장."
+            )
+        if regime_state is not None and not remaining:
+            regime_state.pop(exe.ticker, None)
         return updated
 
     def _enrich_executions(self, executions: List[TradeExecution], signals: List[SplitSignal]) -> None:

--- a/src/core/logic/split_evaluator.py
+++ b/src/core/logic/split_evaluator.py
@@ -164,18 +164,23 @@ class SplitEvaluator:
 
         # 마지막 차수(가장 높은 level) lot 찾기
         last_lot = max(ticker_lots, key=lambda l: l.level)
-
-        # 매도 확인 (우선 - 하락 중에도 이익실현/트레일링 매도는 정상 작동)
-        self._trailing_info_signal = None
-        sell_signal = self._evaluate_sell(rule, last_lot, current_price)
-        if sell_signal is not None:
-            return [sell_signal]
-
-        # 트레일링 스톱 활성화 시 info 신호 수집
         result: List[SplitSignal] = []
-        if self._trailing_info_signal is not None:
-            result.append(self._trailing_info_signal)
+
+        if rule.trailing_drop_at(last_lot.level) is not None:
+            # 새 경로: 멀티-lot trailing 동시 추적
+            trailing_signals = self._evaluate_trailing_multi(rule, ticker_lots, current_price)
+            if trailing_signals is not None:
+                return trailing_signals
+            # None -> last_lot 미활성화 -> buy eval로 진행
+        else:
+            # 기존 경로: 단건 고정 익절 (trailing OFF)
             self._trailing_info_signal = None
+            sell_signal = self._evaluate_sell(rule, last_lot, current_price)
+            if sell_signal is not None:
+                return [sell_signal]
+            if self._trailing_info_signal is not None:
+                result.append(self._trailing_info_signal)
+                self._trailing_info_signal = None
 
         # 하락 레짐 추가 매수 차단
         if downtrend_blocked:
@@ -207,6 +212,120 @@ class SplitEvaluator:
             result.append(buy_signal)
 
         return result
+
+    def _evaluate_trailing_multi(
+        self,
+        rule: StockRule,
+        ticker_lots: List[PositionLot],
+        current_price: float,
+    ) -> Optional[List[SplitSignal]]:
+        """모든 활성화된 lot을 동시 추적하여 drop 조건 충족 lot을 벌크 매도 신호로 반환한다.
+
+        Returns:
+            None  -> last_lot 미활성화, 호출부가 buy eval로 진행
+            []    -> 활성화됐지만 미발동, buy eval skip
+            [sig] -> 활성화 info 신호 또는 벌크 매도 신호
+        """
+        sorted_lots = sorted(ticker_lots, key=lambda l: l.level, reverse=True)
+        last_lot = sorted_lots[0]
+
+        # 1단계: last_lot 활성화 확인
+        pct = (current_price - last_lot.buy_price) / last_lot.buy_price * 100
+        if (last_lot.trailing_highest_price is None
+                and pct < rule.sell_threshold_at(last_lot.level)):
+            return None
+
+        # 2단계: 고차수->저차수 순차 탐색
+        fired_lots: List[PositionLot] = []
+        info_signals: List[SplitSignal] = []
+
+        for lot in sorted_lots:
+            t_drop = rule.trailing_drop_at(lot.level)
+            if t_drop is None:
+                break
+
+            pct_lot = (current_price - lot.buy_price) / lot.buy_price * 100
+            s_thr = rule.sell_threshold_at(lot.level)
+            lot_activated = lot.trailing_highest_price is not None or pct_lot >= s_thr
+
+            if not lot_activated:
+                break
+
+            was_inactive = lot.trailing_highest_price is None
+            updated_high = was_inactive or current_price > lot.trailing_highest_price
+
+            if updated_high:
+                lot.trailing_highest_price = current_price
+
+            stop_price = lot.trailing_highest_price * (1 - t_drop / 100)
+
+            if self._logger:
+                if was_inactive:
+                    self._logger.info(
+                        f"[{display_ticker(rule.ticker)}] Lv{lot.level}: "
+                        f"trailing 활성화 "
+                        f"(매수가 대비 {pct_lot:+.1f}%, "
+                        f"스톱가 {format_money(stop_price, rule.market_type)})"
+                    )
+                elif updated_high:
+                    self._logger.info(
+                        f"[{display_ticker(rule.ticker)}] Lv{lot.level}: "
+                        f"trailing 고점 갱신 -> "
+                        f"{format_money(current_price, rule.market_type)} "
+                        f"(스톱가 {format_money(stop_price, rule.market_type)})"
+                    )
+
+            if was_inactive:
+                info_signals.append(SplitSignal(
+                    ticker=rule.ticker,
+                    lot_id=lot.lot_id,
+                    action=OrderAction.SELL,
+                    quantity=0,
+                    price=current_price,
+                    reason=(
+                        f"Lv{lot.level}: trailing 활성화 "
+                        f"(매수가 대비 {pct_lot:+.1f}%, "
+                        f"스톱가 {format_money(stop_price, rule.market_type)})"
+                    ),
+                    pct_change=pct_lot,
+                    level=lot.level,
+                    is_info=True,
+                ))
+
+            drop = (lot.trailing_highest_price - current_price) / lot.trailing_highest_price * 100
+            if drop >= t_drop:
+                fired_lots.append(lot)
+
+        # 3단계: 결과 반환
+        if not fired_lots:
+            return info_signals
+
+        fired_qty = sum(l.quantity for l in fired_lots)
+        total_cost = sum(l.buy_price * l.quantity for l in fired_lots)
+        avg_buy = total_cost / fired_qty
+        pct_change = (current_price - avg_buy) / avg_buy * 100
+        min_lv = min(l.level for l in fired_lots)
+        max_lv = max(l.level for l in fired_lots)
+
+        if self._logger:
+            self._logger.info(
+                f"[{display_ticker(rule.ticker)}] trailing 벌크 매도 발동: "
+                f"Lv{min_lv}~Lv{max_lv} {fired_qty}주 ({pct_change:+.1f}%)"
+            )
+
+        bulk_signal = SplitSignal(
+            ticker=rule.ticker,
+            lot_id=None,
+            action=OrderAction.SELL,
+            quantity=fired_qty,
+            price=current_price,
+            reason=f"trailing 벌크 매도 Lv{min_lv}~Lv{max_lv} ({fired_qty}주 {pct_change:+.1f}%)",
+            pct_change=pct_change,
+            level=max_lv,
+            buy_price=avg_buy,
+            trailing_bulk=True,
+        )
+        return info_signals + [bulk_signal]
 
     def _evaluate_sell(
         self,

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -242,6 +242,9 @@ class SplitSignal:
     # 추세이탈 분할청산(Trailing Lock 1단계) 매도 표식.
     # 체결 시 잔량은 유지하고 trailing_lock 상태를 활성화한다.
     regime_partial_liquidation: bool = False
+    # 횡보장 trailing 벌크 매도 표식. 엔진이 _apply_trailing_bulk()로 라우팅.
+    # regime_state 변경 없이 fired lot만 고차수부터 차감한다.
+    trailing_bulk: bool = False
 
 
 @dataclass

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -1240,3 +1240,76 @@ class TestRegimeStateEngine:
         regime_state = {"AAPL": {"regime": "uptrend", "adds": 3}}
         engine._handle_state_transitions([], {}, regime_state)
         assert "AAPL" not in regime_state
+
+
+class TestTrailingBulk:
+    """횡보장 trailing 벌크 매도 체결 반영."""
+
+    def _positions(self):
+        return [
+            PositionLot("lot1", "AAPL", 50.0, 5, "2024-01-01", level=1),
+            PositionLot("lot2", "AAPL", 60.0, 5, "2024-01-01", level=2),
+            PositionLot("lot3", "AAPL", 70.0, 5, "2024-01-01", level=3),
+            PositionLot("lot4", "AAPL", 80.0, 5, "2024-01-01", level=4),
+        ]
+
+    def _bulk_sig(self, qty, price=90.0):
+        return SplitSignal("AAPL", None, OrderAction.SELL, qty, price,
+                           "trailing 벌크 매도", 0.0, 4, trailing_bulk=True)
+
+    def _exe(self, qty, price=90.0, status=ExecutionStatus.FILLED):
+        return TradeExecution("AAPL", OrderAction.SELL, qty, price, 0.0, "2024-01-01", status)
+
+    def test_partial_fire_removes_high_levels_only(self, engine):
+        # Lv4+Lv3(10주)만 발동
+        result = engine._update_positions(
+            self._positions(), [self._bulk_sig(10)], [self._exe(10)],
+            "2024-01-02", last_sell_prices={}, regime_state={},
+        )
+        ids = sorted(l.lot_id for l in result)
+        assert ids == ["lot1", "lot2"]
+
+    def test_full_fire_removes_all_lots(self, engine):
+        result = engine._update_positions(
+            self._positions(), [self._bulk_sig(20)], [self._exe(20)],
+            "2024-01-02", last_sell_prices={}, regime_state={},
+        )
+        assert result == []
+
+    def test_regime_state_not_modified(self, engine):
+        regime_state = {"AAPL": {"regime": "sideways", "some_key": 42}}
+        engine._update_positions(
+            self._positions(), [self._bulk_sig(10)], [self._exe(10)],
+            "2024-01-02", last_sell_prices={}, regime_state=regime_state,
+        )
+        # trailing_lock 미생성, 기존 키 유지
+        assert regime_state["AAPL"]["regime"] == "sideways"
+        assert "trailing_lock" not in regime_state["AAPL"]
+
+    def test_last_sell_prices_updated(self, engine):
+        last_sell = {}
+        engine._update_positions(
+            self._positions(), [self._bulk_sig(10)], [self._exe(10)],
+            "2024-01-02", last_sell_prices=last_sell, regime_state={},
+        )
+        assert last_sell["AAPL"] == 90.0
+
+    def test_realized_pnl_and_breakdown(self, engine):
+        exe = self._exe(10, 90.0)  # Lv4(5주 @80) + Lv3(5주 @70)
+        engine._update_positions(
+            self._positions(), [self._bulk_sig(10)], [exe],
+            "2024-01-02", last_sell_prices={}, regime_state={},
+        )
+        # (90-80)*5 + (90-70)*5 = 50 + 100 = 150
+        assert exe.realized_pnl == 150.0
+        bd = exe.liquidation_lots
+        assert bd is not None and len(bd) == 2
+        assert [x["level"] for x in bd] == [4, 3]
+
+    def test_regime_state_cleaned_when_all_lots_removed(self, engine):
+        regime_state = {"AAPL": {"regime": "sideways"}}
+        engine._update_positions(
+            self._positions(), [self._bulk_sig(20)], [self._exe(20)],
+            "2024-01-02", last_sell_prices={}, regime_state=regime_state,
+        )
+        assert "AAPL" not in regime_state

--- a/tests/test_trailing_multi.py
+++ b/tests/test_trailing_multi.py
@@ -1,0 +1,185 @@
+# tests/test_trailing_multi.py
+"""_evaluate_trailing_multi: 멀티-lot trailing 동시 추적 및 벌크 매도 평가기 테스트."""
+import pytest
+from src.core.models import StockRule, PositionLot, Portfolio, SplitSignal, OrderAction
+from src.core.logic.split_evaluator import SplitEvaluator
+
+
+def _portfolio(ticker, price):
+    return Portfolio(total_cash=1_000_000.0, holdings={},
+                     current_prices={ticker: price})
+
+
+def _lot(level, buy_price, qty=10, trailing_highest=None):
+    return PositionLot(
+        lot_id=f"lot_{level:03d}", ticker="005930",
+        buy_price=buy_price, quantity=qty,
+        buy_date="2024-01-01", level=level,
+        trailing_highest_price=trailing_highest,
+    )
+
+
+def _rule(**kw):
+    base = dict(
+        ticker="005930", buy_threshold_pct=-5.0,
+        sell_threshold_pct=10.0, buy_amount=500_000,
+        trailing_drop_pct=5.0,
+    )
+    base.update(kw)
+    return StockRule(**base)
+
+
+@pytest.fixture
+def ev():
+    return SplitEvaluator()
+
+
+class TestEvaluateTrailingMulti:
+    # -- None 반환: last_lot 미활성화 ------------------------------------------
+
+    def test_returns_none_when_last_lot_not_activated(self, ev):
+        rule = _rule()
+        lots = [_lot(1, 100.0), _lot(2, 95.0)]
+        # current_price=102 < buy_price*(1+10%) = 104.5 -> 미활성
+        result = ev._evaluate_trailing_multi(rule, lots, 102.0)
+        assert result is None
+
+    def test_returns_none_when_price_barely_below_threshold(self, ev):
+        rule = _rule(sell_threshold_pct=10.0)
+        lots = [_lot(1, 100.0), _lot(2, 100.0)]
+        # 9.9% -> 미활성
+        result = ev._evaluate_trailing_multi(rule, lots, 109.9)
+        assert result is None
+
+    # -- 빈 리스트 반환: 활성화됐지만 미발동 ------------------------------------
+
+    def test_returns_empty_list_when_activated_but_no_fire(self, ev):
+        rule = _rule(sell_threshold_pct=10.0, trailing_drop_pct=5.0)
+        # trailing_highest=115 설정 -> 이미 활성화, 현재가 112 -> drop=2.6% < 5%
+        lots = [_lot(1, 100.0, trailing_highest=115.0)]
+        result = ev._evaluate_trailing_multi(rule, lots, 112.0)
+        assert result == []
+
+    def test_returns_info_only_for_newly_activated_lot(self, ev):
+        rule = _rule(sell_threshold_pct=10.0, trailing_drop_pct=5.0)
+        # Lv1: buy=100, price=110 -> 10% 도달 -> 신규 활성화
+        lots = [_lot(1, 100.0)]
+        result = ev._evaluate_trailing_multi(rule, lots, 110.0)
+        # 활성화됐지만 drop=0 -> 미발동 -> info 신호만
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].is_info is True
+        assert result[0].quantity == 0
+        assert result[0].ticker == "005930"
+
+    # -- 벌크 매도 신호 반환 --------------------------------------------------
+
+    def test_bulk_sell_signal_on_fired_lot(self, ev):
+        rule = _rule(sell_threshold_pct=10.0, trailing_drop_pct=5.0)
+        # trailing_highest=115, price=109 -> drop=5.2% >= 5% -> 발동
+        lots = [_lot(1, 100.0, trailing_highest=115.0)]
+        result = ev._evaluate_trailing_multi(rule, lots, 109.0)
+        assert result is not None and len(result) == 1
+        sig = result[0]
+        assert sig.trailing_bulk is True
+        assert sig.action == OrderAction.SELL
+        assert sig.quantity == 10
+        assert sig.lot_id is None
+
+    def test_partial_fire_high_levels_only(self, ev):
+        rule = _rule(sell_threshold_pct=10.0, trailing_drop_pct=5.0)
+        # Lv3(highest=115, drop=5.2% -> 발동), Lv2(highest=115, drop=5.2% -> 발동),
+        # Lv1(buy=100, price=109 -> 9% < 10% -> 미활성 -> 탐색 중단)
+        lots = [
+            _lot(1, 100.0),                    # 미활성
+            _lot(2, 95.0, trailing_highest=115.0),  # 활성, 발동
+            _lot(3, 90.0, trailing_highest=115.0),  # 활성, 발동
+        ]
+        result = ev._evaluate_trailing_multi(rule, lots, 109.0)
+        assert result is not None
+        bulk = [s for s in result if s.trailing_bulk]
+        assert len(bulk) == 1
+        assert bulk[0].quantity == 20  # Lv2+Lv3 각 10주
+        assert bulk[0].level == 3
+
+    def test_all_lots_fired(self, ev):
+        rule = _rule(sell_threshold_pct=10.0, trailing_drop_pct=5.0)
+        lots = [
+            _lot(1, 80.0, trailing_highest=115.0),
+            _lot(2, 90.0, trailing_highest=115.0),
+            _lot(3, 100.0, trailing_highest=115.0),
+        ]
+        result = ev._evaluate_trailing_multi(rule, lots, 109.0)
+        assert result is not None
+        bulk = [s for s in result if s.trailing_bulk]
+        assert len(bulk) == 1
+        assert bulk[0].quantity == 30
+        assert bulk[0].trailing_bulk is True
+
+    # -- 배열 기반 trailing_drop_pcts -----------------------------------------
+
+    def test_array_drop_per_lot_level(self, ev):
+        # Lv3: drop_pcts=[3.0, 4.0, 6.0] -> Lv3=6%, Lv2=4%, Lv1=3%
+        rule = _rule(trailing_drop_pct=None, trailing_drop_pcts=[3.0, 4.0, 6.0],
+                     sell_threshold_pct=10.0)
+        # drop=5.2%: Lv1(3% -> 발동), Lv2(4% -> 발동), Lv3(6% -> 미발동)
+        lots = [
+            _lot(1, 80.0, trailing_highest=115.0),
+            _lot(2, 90.0, trailing_highest=115.0),
+            _lot(3, 100.0, trailing_highest=115.0),
+        ]
+        result = ev._evaluate_trailing_multi(rule, lots, 109.0)
+        assert result is not None
+        bulk = [s for s in result if s.trailing_bulk]
+        assert len(bulk) == 1
+        # Lv1+Lv2만 발동 (Lv3은 6% 미충족)
+        assert bulk[0].quantity == 20
+        assert bulk[0].level == 2
+
+    # -- trailing OFF 종목 경로 불변 ------------------------------------------
+
+    def test_trailing_off_goes_through_evaluate_sell(self, ev):
+        # trailing_drop_pct=None -> trailing_drop_at returns None -> evaluate_stock이
+        # evaluate_sell 경로를 타야 함 (직접 _evaluate_trailing_multi 호출은 안 됨)
+        rule = _rule(trailing_drop_pct=None, sell_threshold_pct=10.0)
+        lots = [_lot(1, 100.0)]
+        result = ev._evaluate_trailing_multi(rule, lots, 115.0)
+        # trailing OFF 종목에서 호출해도 last_lot 미활성화로 None 아님(활성화 조건 충족)
+        # 발동은 trailing_drop이 None이면 break -> fired_lots 없음 -> []
+        assert result == []
+
+    # -- 조기 종료: 미활성 lot 이하 탐색 안 함 --------------------------------
+
+    def test_early_stop_on_inactive_lot(self, ev):
+        rule = _rule(sell_threshold_pct=10.0, trailing_drop_pct=5.0)
+        lots = [
+            _lot(1, 100.0),                        # 미활성 (9% < 10%)
+            _lot(2, 90.0, trailing_highest=115.0),  # 활성, 발동 대상이지만 탐색 순서 때문
+            _lot(3, 80.0, trailing_highest=115.0),  # 활성
+        ]
+        # 고차수(Lv3)부터: Lv3 활성+발동, Lv2 활성+발동, Lv1 미활성 -> break
+        result = ev._evaluate_trailing_multi(rule, lots, 109.0)
+        bulk = [s for s in result if s.trailing_bulk]
+        assert bulk[0].quantity == 20  # Lv3+Lv2만 발동
+        # Lv1은 탐색 안 함 -> trailing_highest_price 여전히 None
+        assert lots[0].trailing_highest_price is None
+
+    # -- evaluate_stock 경로 분기 검증 ----------------------------------------
+
+    def test_evaluate_stock_uses_trailing_multi_when_trailing_on(self, ev):
+        rule = _rule(sell_threshold_pct=10.0, trailing_drop_pct=5.0)
+        # trailing 미활성화 상태 -> evaluate_stock이 buy eval로 넘어가야 함 (빈 결과)
+        lots = [_lot(1, 100.0)]
+        portfolio = _portfolio("005930", 102.0)
+        result = ev.evaluate_stock(rule, lots, portfolio)
+        # 미활성화 -> _evaluate_trailing_multi returns None -> buy eval 진행
+        # buy_threshold_pct=-5%, 현재가 102 -> 매수 조건 미충족
+        assert all(not s.trailing_bulk for s in result)
+
+    def test_evaluate_stock_returns_bulk_when_trailing_fires(self, ev):
+        rule = _rule(sell_threshold_pct=10.0, trailing_drop_pct=5.0)
+        lots = [_lot(1, 100.0, trailing_highest=115.0)]
+        portfolio = _portfolio("005930", 109.0)
+        # drop=5.2% >= 5% -> 발동
+        result = ev.evaluate_stock(rule, lots, portfolio)
+        assert any(s.trailing_bulk for s in result)


### PR DESCRIPTION
## Summary

- **문제**: 기존 trailing stop은 `last_lot`(최고 차수) 하나만 평가하여, N개 lot을 전량 청산하려면 `N × trailing_drop_pct` 낙폭이 필요했음 (청산이 지나치게 느림)
- **해결**: 모든 활성화된 lot을 동시 추적하고, drop 조건 충족 lot을 한 번의 벌크 주문으로 매도

## 변경 내용

### `src/core/models.py`
- `SplitSignal`에 `trailing_bulk: bool = False` 필드 추가 — 엔진이 횡보장 trailing 경로로 라우팅하는 마커

### `src/core/logic/split_evaluator.py`
- `_evaluate_trailing_multi()` 신규 추가:
  - 고차수→저차수 순차 탐색, 미활성 lot에서 조기 종료
  - 반환값 규약: `None`=미활성, `[]`=활성화·미발동(buy eval skip), `[sig...]`=신호
- `evaluate_stock()` 분기 변경: `trailing_drop_pct` 설정 시 새 경로, 없으면 기존 단건 경로

### `src/core/engine/base.py`
- `_drain_lots_by_qty()` 헬퍼 추출 — bulk/partial/trailing_bulk 세 함수가 공유
- `_apply_bulk_liquidation()`, `_apply_partial_liquidation()` 헬퍼 재사용으로 리팩터 (동작 변경 없음)
- `_apply_trailing_bulk()` 신규 추가 — regime_state 변경 없이 fired lot만 고차수부터 차감
- `_update_positions()` 분기 추가: `trailing_bulk=True` 시 새 함수로 라우팅

### `tests/`
- `test_trailing_multi.py` (신규, 12 케이스): 평가기 전 경로 검증
- `test_core_engine.py`에 `TestTrailingBulk` 클래스 추가 (6 케이스): 엔진 체결 반영 검증

## Test plan
- [x] `pytest tests/` — 382 passed, 17 skipped (기존 364 + 신규 18)
- [x] 커버리지 89% (>= 80% 기준 충족)
- [x] 기존 `TestBulkLiquidation`, `TestPartialLiquidation` 전체 통과 (리팩터 무결성)
- [x] trailing OFF 종목의 기존 단건 익절 경로 불변 확인

https://claude.ai/code/session_01BCwNybCDx7ndwhGpdmLbnL

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCwNybCDx7ndwhGpdmLbnL)_