### PR TITLE
feat(backtest): 시뮬레이션 날짜 로그 출력

### DIFF
--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -128,6 +128,7 @@ def run_backtest(
     last_result: Optional[DayResult] = None
 
     for today in sim_days:
+        logger.info(f"{today.strftime('%Y-%m-%d')} 시뮬시작")
         # 종가 추출
         try:
             row = close_df.loc[today]

--- a/src/backtest/runner.py
+++ b/src/backtest/runner.py
@@ -128,7 +128,8 @@ def run_backtest(
     last_result: Optional[DayResult] = None
 
     for today in sim_days:
-        logger.info(f"{today.strftime('%Y-%m-%d')} 시뮬시작")
+        sim_date = f"{today:%Y-%m-%d}"
+        logger.info(f"{sim_date} 시뮬시작")
         # 종가 추출
         try:
             row = close_df.loc[today]
@@ -141,10 +142,8 @@ def run_backtest(
             }
             prev_prices = current_prices
         except Exception as e:
-            logger.warning(f"[{today.date()}] 종가 추출 실패, 건너뜀: {e}")
+            logger.warning(f"[{sim_date}] 종가 추출 실패, 건너뜀: {e}")
             continue
-
-        sim_date = today.strftime("%Y-%m-%d")
 
         broker.set_date(today)
         broker.set_prices(current_prices)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- 백테스트 루프 진입 시 `YYYY-MM-DD 시뮬시작` 형태로 거래일을 로그에 출력
- 기존 로그에는 시뮬레이션 날짜가 없어 특정 이벤트(트레일링 활성화, 매도 발동 등)가 어느 날짜에 발생했는지 봉 번호로 역산해야 했던 문제 해결

## Test plan

- [ ] 백테스트 실행 후 로그에 `2020-01-02 시뮬시작` 형태의 라인이 각 거래일마다 출력되는지 확인
- [ ] 기존 테스트 통과 확인

https://claude.ai/code/session_011RgoUwio19ikrA3SsbwkCo
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011RgoUwio19ikrA3SsbwkCo)_