### PR TITLE
feat: Slack 체결 알림에 종목별 매수/매도 상세 정보 추가

### DIFF
--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -226,8 +226,8 @@ class MagicSplitEngine:
                 price_str = format_money(exe.price, self.market_type)
                 line = f"  {action_str} {name} {exe.quantity}주 @{price_str} [Lv{exe.level}]"
                 if exe.action == OrderAction.SELL and exe.realized_pnl != 0:
-                    pnl_str = format_money(exe.realized_pnl, self.market_type)
-                    sign = "+" if exe.realized_pnl > 0 else ""
+                    sign = "+" if exe.realized_pnl > 0 else "-"
+                    pnl_str = format_money(abs(exe.realized_pnl), self.market_type)
                     line += f" ({sign}{pnl_str})"
                 exec_lines.append(line)
             exec_summary = "\n".join(exec_lines)

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -219,9 +219,21 @@ class MagicSplitEngine:
         rejected_count = len(all_executions) - len(filled_execs)
         reject_suffix = f" (거절: {rejected_count}건)" if rejected_count > 0 else ""
         if filled_execs:
+            exec_lines = []
+            for exe in filled_execs:
+                name = display_ticker(exe.ticker)
+                action_str = "BUY" if exe.action == OrderAction.BUY else "SELL"
+                price_str = format_money(exe.price, self.market_type)
+                line = f"  {action_str} {name} {exe.quantity}주 @{price_str} [Lv{exe.level}]"
+                if exe.action == OrderAction.SELL and exe.realized_pnl != 0:
+                    pnl_str = format_money(exe.realized_pnl, self.market_type)
+                    sign = "+" if exe.realized_pnl > 0 else ""
+                    line += f" ({sign}{pnl_str})"
+                exec_lines.append(line)
+            exec_summary = "\n".join(exec_lines)
             self._notify_message(
                 f"Orders Executed. Count: {len(filled_execs)}"
-                f"{reject_suffix}{fail_suffix}",
+                f"{reject_suffix}{fail_suffix}\n{exec_summary}",
                 detail=all_detail
             )
         elif portfolio is not None:


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- 슬랙 체결 알림 메시지에 종목별 상세 정보를 추가
- 기존: `Orders Executed. Count: 1` (어떤 종목인지 알 수 없음)
- 변경 후:
  ```
  Orders Executed. Count: 1
    BUY 삼성전자(005930) 10주 @70,500 [Lv2]
  ```
- SELL 체결 시 실현손익(realized_pnl)이 있으면 함께 표시
  ```
  Orders Executed. Count: 1
    SELL AAPL 5주 @$180.25 [Lv3] (+$45.50)
  ```

## Changes

- `src/core/engine/base.py`: `filled_execs` 루프를 돌며 종목명(`display_ticker`), 액션, 수량, 가격(`format_money`), 차수를 한 줄씩 요약해 메시지에 추가

## Test plan

- [ ] `pytest` 383 passed, 17 skipped 확인 완료
- [ ] SELL 체결에서 `realized_pnl != 0`이면 손익 표시 확인

https://claude.ai/code/session_01FbMVTcCBAYVTRgz9kySQAM
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbMVTcCBAYVTRgz9kySQAM)_