### PR TITLE
feat: 수동매매 매수금액 직접 지정 기능 추가

### DIFF
--- a/.github/workflows/manual-trade.yml
+++ b/.github/workflows/manual-trade.yml
@@ -21,6 +21,11 @@ on:
         options:
           - buy
           - sell
+      amount:
+        description: 'Buy amount override (KRW or USD). Leave empty to use config buy_amount.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: write
@@ -62,9 +67,17 @@ jobs:
         KIS_ACC_NO: ${{ secrets.KIS_ACC_NO }}
         IS_LIVE: 'true'
       run: |
-        python scripts/manual_trade.py \
-          --ticker "${{ github.event.inputs.ticker }}" \
-          --action "${{ github.event.inputs.action }}"
+        AMOUNT="${{ github.event.inputs.amount }}"
+        if [ -n "$AMOUNT" ]; then
+          python scripts/manual_trade.py \
+            --ticker "${{ github.event.inputs.ticker }}" \
+            --action "${{ github.event.inputs.action }}" \
+            --amount "$AMOUNT"
+        else
+          python scripts/manual_trade.py \
+            --ticker "${{ github.event.inputs.ticker }}" \
+            --action "${{ github.event.inputs.action }}"
+        fi
 
     - name: Save KIS token cache
       if: always()

--- a/docs/js/manual-trade.js
+++ b/docs/js/manual-trade.js
@@ -24,7 +24,7 @@
     const cancelTradeBtn = document.getElementById('cancel-trade-btn');
     const statusFeedback = document.getElementById('status-feedback');
 
-    let activeOrderParams = null; // { ticker, alias, action, marketType }
+    let activeOrderParams = null; // { ticker, alias, action, marketType, configAmount }
 
     /** market_type에 맞춰 통화 단위와 함께 금액을 포매팅한다. */
     function formatAmount(value, marketType) {
@@ -263,15 +263,8 @@
     }
 
     function openOrderModal(tickerObj, action) {
-        activeOrderParams = {
-            ticker: tickerObj.ticker,
-            alias: tickerObj.alias,
-            action: action,
-            marketType: currentMarket,
-        };
-
-        const displayName = tickerObj.alias !== tickerObj.ticker 
-            ? `${tickerObj.alias} (${tickerObj.ticker})` 
+        const displayName = tickerObj.alias !== tickerObj.ticker
+            ? `${tickerObj.alias} (${tickerObj.ticker})`
             : tickerObj.ticker;
 
         modalTitle.textContent = `${displayName} ${action === 'buy' ? '매수' : '매도'}`;
@@ -279,15 +272,36 @@
         confirmTradeBtn.disabled = false;
         confirmTradeBtn.textContent = '실행';
 
+        // Remove previous amount input if any
+        const prevInput = document.getElementById('override-amount-group');
+        if (prevInput) prevInput.remove();
+
+        let configAmount = 0;
         if (action === 'buy') {
             const nextLv = tickerObj.currentLevel + 1;
             const lvAmount = tickerObj.config.buy_amounts && tickerObj.config.buy_amounts[nextLv - 1];
-            const cfgAmount = lvAmount || tickerObj.config.buy_amount || 0;
+            configAmount = lvAmount || tickerObj.config.buy_amount || 0;
+
             orderSummary.innerHTML =
-                `현재 <b>Lv${tickerObj.currentLevel}</b> -> <b>Lv${nextLv}</b> 매수<br>` +
-                `1회 매수 금액(설정): <b>${formatAmount(cfgAmount, currentMarket)}</b>`;
-            inputHint.textContent =
-                '실제 주문 수량은 엔진이 [설정 금액 / 현재가]로 자동 계산합니다 (자동매매와 동일).';
+                `현재 <b>Lv${tickerObj.currentLevel}</b> -> <b>Lv${nextLv}</b> 매수`;
+            inputHint.textContent = '실제 주문 수량은 엔진이 [입력 금액 / 현재가]로 자동 계산합니다.';
+
+            // Inject amount input field
+            const amountGroup = document.createElement('div');
+            amountGroup.id = 'override-amount-group';
+            amountGroup.className = 'form-group';
+            amountGroup.style.marginTop = '14px';
+            amountGroup.innerHTML = `
+                <label style="font-size:0.875rem; font-weight:600; display:block; margin-bottom:4px;">
+                    매수 금액 (${currentMarket === 'domestic' ? '원' : 'USD'})
+                </label>
+                <input type="number" id="override-amount-input" class="form-control"
+                    value="${configAmount}" min="1" step="1"
+                    style="width:100%; box-sizing:border-box;">
+                <small style="color:var(--text-muted); font-size:0.8rem; display:block; margin-top:4px;">
+                    설정값: ${formatAmount(configAmount, currentMarket)} — 변경하면 해당 금액으로 주문합니다.
+                </small>`;
+            inputHint.parentNode.insertBefore(amountGroup, inputHint);
         } else {
             const sellQty = tickerObj.highestLvQty || 0;
             orderSummary.innerHTML =
@@ -295,6 +309,14 @@
             inputHint.textContent =
                 '매도 수량은 엔진이 최고 차수 lot 전량으로 자동 결정합니다 (자동매매와 동일).';
         }
+
+        activeOrderParams = {
+            ticker: tickerObj.ticker,
+            alias: tickerObj.alias,
+            action: action,
+            marketType: currentMarket,
+            configAmount: configAmount,
+        };
 
         orderModal.style.display = 'flex';
     }
@@ -305,7 +327,12 @@
         const isBuy = activeOrderParams.action === 'buy';
         const actionLabel = isBuy ? '매수' : '매도';
 
-        if (!confirm(`${activeOrderParams.alias} 종목을 ${actionLabel} 하시겠습니까?\n(수량은 자동매매 정책에 따라 엔진이 결정합니다)`)) {
+        let confirmMsg = `${activeOrderParams.alias} 종목을 ${actionLabel} 하시겠습니까?`;
+        if (isBuy && inputs.amount) {
+            confirmMsg += `\n매수 금액: ${formatAmount(parseFloat(inputs.amount), activeOrderParams.marketType)}`;
+        }
+        confirmMsg += '\n(수량은 [금액 / 현재가]로 엔진이 자동 계산합니다)';
+        if (!confirm(confirmMsg)) {
             return;
         }
 
@@ -318,6 +345,15 @@
                 ticker: activeOrderParams.ticker,
                 action: activeOrderParams.action,
             };
+
+            if (activeOrderParams.action === 'buy') {
+                const amountInput = document.getElementById('override-amount-input');
+                const enteredAmount = amountInput ? parseFloat(amountInput.value) : NaN;
+                if (!isNaN(enteredAmount) && enteredAmount > 0
+                        && enteredAmount !== activeOrderParams.configAmount) {
+                    inputs.amount = String(enteredAmount);
+                }
+            }
 
             await githubApi.triggerWorkflow('manual-trade.yml', inputs);
 

--- a/docs/manual-trade.html
+++ b/docs/manual-trade.html
@@ -255,7 +255,7 @@
 
     <script src="js/services/data-repository.js?v=20260512-2"></script>
     <script src="js/services/github-api.js?v=20260512-2"></script>
-    <script src="js/manual-trade.js?v=20260512-2"></script>
+    <script src="js/manual-trade.js?v=20260602-1"></script>
 </body>
 
 </html>

--- a/scripts/manual_trade.py
+++ b/scripts/manual_trade.py
@@ -5,11 +5,12 @@
 주문 -> 포지션 반영 -> 저장 파이프라인을 사용한다. 신호 평가(evaluate_stock)만
 우회하고, 사용자가 지정한 ticker/action으로 즉시 매매를 강제한다.
 수량은 자동매매와 동일하게 엔진이 도출한다:
-  - BUY: rule.buy_amount_at(next_level) / 현재가
+  - BUY: --amount 지정 시 해당 금액, 없으면 rule.buy_amount_at(next_level) / 현재가
   - SELL: 최고 차수 lot 전량
 
 사용법:
     python scripts/manual_trade.py --ticker 005930 --action buy
+    python scripts/manual_trade.py --ticker 005930 --action buy --amount 500000
     python scripts/manual_trade.py --ticker TSLA --action sell
 """
 import argparse
@@ -34,6 +35,10 @@ def parse_args():
     parser.add_argument(
         "--action", required=True, choices=["buy", "sell"],
         help="매수(buy) 또는 매도(sell). 수량은 자동 도출됨.",
+    )
+    parser.add_argument(
+        "--amount", type=float, default=None,
+        help="매수 금액 직접 지정 (원 또는 USD). 생략 시 config buy_amount 사용.",
     )
     return parser.parse_args()
 
@@ -64,8 +69,9 @@ def main():
 
     log_dir = os.path.join(config.LOG_PATH, market_type)
     logger = TradeLogger(log_dir)
+    amount_info = f" amount={args.amount}" if args.amount is not None else ""
     logger.info(
-        f"=== Manual Trade CLI: {args.ticker} {args.action.upper()} ==="
+        f"=== Manual Trade CLI: {args.ticker} {args.action.upper()}{amount_info} ==="
     )
 
     broker = _create_broker(
@@ -98,7 +104,11 @@ def main():
     action = OrderAction.BUY if args.action == "buy" else OrderAction.SELL
 
     try:
-        result = engine.run_manual_trade(ticker=args.ticker, action=action)
+        result = engine.run_manual_trade(
+            ticker=args.ticker,
+            action=action,
+            override_amount=args.amount,
+        )
     except Exception as e:
         logger.error(f"수동매매 중단: {e}")
         sys.exit(1)

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -262,11 +262,12 @@ class MagicSplitEngine:
         ticker: str,
         action: OrderAction,
         sim_date: Optional[str] = None,
+        override_amount: Optional[float] = None,
     ) -> DayResult:
         """수동매매 1건을 실행한다.
 
         evaluate_stock 단계만 우회하고, 자동매매와 동일한 방식으로 모든 수량을 도출한다.
-        - BUY: rule.buy_amount_at(next_level) / 현재가 -> 주문 수량 (사용자 입력 없음)
+        - BUY: override_amount 지정 시 해당 금액, 없으면 rule.buy_amount_at(next_level) / 현재가
         - SELL: 최고 차수 lot.quantity 전량 매도 (사용자 입력 없음)
 
         후반부 파이프라인(주문 실행 -> 포지션 반영 -> 저장)은 자동매매와 100% 동일.
@@ -277,6 +278,7 @@ class MagicSplitEngine:
                     SELL은 비활성 종목도 청산 목적으로 허용)
             action: OrderAction.BUY 또는 OrderAction.SELL
             sim_date: 시뮬레이션 날짜 ("YYYY-MM-DD")
+            override_amount: 매수 금액 직접 지정 (None이면 config buy_amount 사용)
         """
         today = sim_date or datetime.now().strftime("%Y-%m-%d")
         disp = display_ticker(ticker)
@@ -314,15 +316,19 @@ class MagicSplitEngine:
             target_buy_price: float = 0.0
 
             if action == OrderAction.BUY:
-                # 매수: 자동 evaluator와 동일하게 rule.buy_amount_at(next_level)에서 금액
-                # 도출 후 현재가로 수량 환산. 사용자 수량/금액 지정 없음.
                 level = highest_level + 1
                 if level > target_rule.max_lots:
                     raise RuntimeError(
                         f"{disp} max_lots({target_rule.max_lots}) 도달 — "
                         f"현재 최고 차수 Lv{highest_level}, 다음 차수 Lv{level}는 매수 불가."
                     )
-                buy_amount = target_rule.buy_amount_at(level)
+                if override_amount is not None:
+                    buy_amount = override_amount
+                    self.logger.info(
+                        f"매수 금액 수동 지정: {format_money(buy_amount, self.market_type)}"
+                    )
+                else:
+                    buy_amount = target_rule.buy_amount_at(level)
                 order_qty = int(buy_amount / current_price)
                 if order_qty <= 0:
                     raise RuntimeError(
@@ -331,7 +337,7 @@ class MagicSplitEngine:
                         f"현재가({format_money(current_price, self.market_type)})보다 작음."
                     )
                 self.logger.info(
-                    f"매수 수량 자동 도출: Lv{level} buy_amount="
+                    f"매수 수량 도출: Lv{level} buy_amount="
                     f"{format_money(buy_amount, self.market_type)} / 현재가="
                     f"{format_money(current_price, self.market_type)} = {order_qty}주"
                 )


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **UI**: 수동매매 모달에 매수 금액 입력 필드 추가 (config 설정값으로 미리 채워짐, 수정 가능)
- **engine**: `run_manual_trade(override_amount=...)` 파라미터 추가 — 지정 시 config `buy_amount_at()` 대신 사용
- **script**: `manual_trade.py --amount` 선택 인자 추가
- **workflow**: `manual-trade.yml`에 `amount` 선택 입력 추가 (비어있으면 config값 사용)

## Flow

```
UI 금액 입력
  -> (config값과 다를 때만) workflow inputs.amount 포함
  -> manual_trade.py --amount <value>
  -> engine.run_manual_trade(override_amount=value)
  -> 수량 = override_amount / 현재가
```

금액을 변경하지 않으면 기존 동작(config `buy_amount_at(next_level)`)과 완전히 동일합니다.

## Test plan

- [ ] 테스트 전체 통과 (364 passed, 17 skipped)
- [ ] 모달에서 금액 미변경 -> workflow `amount` 입력 없음 -> config 금액 사용
- [ ] 모달에서 금액 변경 -> workflow `amount` 입력 포함 -> override 금액 사용
- [ ] `--amount` 없이 CLI 실행 -> 기존 동작 동일

https://claude.ai/code/session_01HXbgpwGqn4nZ4tCW6Gt2AE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXbgpwGqn4nZ4tCW6Gt2AE)_