### PR TITLE
fix: 수동매매 실행 버튼 클릭 시 무반응 버그 수정

### DIFF
--- a/docs/js/manual-trade.js
+++ b/docs/js/manual-trade.js
@@ -327,6 +327,21 @@
         const isBuy = activeOrderParams.action === 'buy';
         const actionLabel = isBuy ? '매수' : '매도';
 
+        const inputs = {
+            market_type: activeOrderParams.marketType,
+            ticker: activeOrderParams.ticker,
+            action: activeOrderParams.action,
+        };
+
+        if (isBuy) {
+            const amountInput = document.getElementById('override-amount-input');
+            const enteredAmount = amountInput ? parseFloat(amountInput.value) : NaN;
+            if (!isNaN(enteredAmount) && enteredAmount > 0
+                    && enteredAmount !== activeOrderParams.configAmount) {
+                inputs.amount = String(enteredAmount);
+            }
+        }
+
         let confirmMsg = `${activeOrderParams.alias} 종목을 ${actionLabel} 하시겠습니까?`;
         if (isBuy && inputs.amount) {
             confirmMsg += `\n매수 금액: ${formatAmount(parseFloat(inputs.amount), activeOrderParams.marketType)}`;
@@ -339,21 +354,6 @@
         try {
             setLoading(true);
             showFeedback('GitHub Action 트리거 중...', 'info');
-
-            const inputs = {
-                market_type: activeOrderParams.marketType,
-                ticker: activeOrderParams.ticker,
-                action: activeOrderParams.action,
-            };
-
-            if (activeOrderParams.action === 'buy') {
-                const amountInput = document.getElementById('override-amount-input');
-                const enteredAmount = amountInput ? parseFloat(amountInput.value) : NaN;
-                if (!isNaN(enteredAmount) && enteredAmount > 0
-                        && enteredAmount !== activeOrderParams.configAmount) {
-                    inputs.amount = String(enteredAmount);
-                }
-            }
 
             await githubApi.triggerWorkflow('manual-trade.yml', inputs);
 

--- a/docs/manual-trade.html
+++ b/docs/manual-trade.html
@@ -255,7 +255,7 @@
 
     <script src="js/services/data-repository.js?v=20260512-2"></script>
     <script src="js/services/github-api.js?v=20260512-2"></script>
-    <script src="js/manual-trade.js?v=20260602-1"></script>
+    <script src="js/manual-trade.js?v=20260602-2"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## 원인

`executeTrade()` 함수에서 `const inputs`가 선언(line 343)되기 전에 `inputs.amount`를 참조(line 331)하고 있었습니다.

JavaScript `'use strict'` 모드에서 `const`의 temporal dead zone(TDZ) 규칙으로 인해 `ReferenceError`가 발생하고, 이 에러가 외부 try/catch 밖에서 발생해 조용히 실패 — 실행 버튼을 눌러도 아무 반응이 없던 현상의 원인입니다.

## 수정

`inputs` 객체를 먼저 구성한 뒤 `confirmMsg`를 조합하도록 순서 변경:

```js
// Before (broken)
let confirmMsg = `... ${inputs.amount} ...`;  // inputs 미선언 상태에서 참조 -> ReferenceError
const inputs = { ... };

// After (fixed)
const inputs = { ... };                        // 먼저 선언
let confirmMsg = `... ${inputs.amount} ...`;   // 정상 참조
```

## Test plan

- [ ] CI 통과
- [ ] 매수 버튼 클릭 -> 금액 입력 -> 실행 클릭 시 confirm 다이얼로그 정상 표시
- [ ] confirm 후 GitHub Action 트리거 정상 동작

https://claude.ai/code/session_01HXbgpwGqn4nZ4tCW6Gt2AE

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXbgpwGqn4nZ4tCW6Gt2AE)_