### PR TITLE
feat(docs): Earnings 탭 - 월별/연도별 실현수익 필터링

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -994,3 +994,67 @@ h2 { font-size: 1.1rem; margin-bottom: 8px; color: var(--text-muted); }
 .stale-name { font-weight: 700; font-size: 0.95rem; }
 .stale-date { font-size: 0.75rem; color: var(--text-muted); display: block; }
 .stale-days { font-weight: 800; font-size: 0.9rem; }
+
+/* Earnings Tab */
+.earnings-filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+.earnings-filter-label {
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    min-width: 28px;
+}
+.filter-chip.dim {
+    opacity: 0.35;
+    cursor: default;
+}
+.earnings-cards {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+    margin-bottom: 24px;
+}
+@media (max-width: 600px) {
+    .earnings-cards { grid-template-columns: 1fr; }
+}
+.earnings-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 20px 20px 16px;
+    box-shadow: var(--shadow-sm);
+}
+.earnings-card-label {
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    margin-bottom: 6px;
+}
+.earnings-card-value {
+    font-size: 1.5rem;
+    font-weight: 800;
+    line-height: 1.2;
+    margin-bottom: 4px;
+}
+.earnings-card-note {
+    font-size: 0.72rem;
+    color: var(--text-muted);
+}
+.earnings-bar-svg {
+    width: 100%;
+    display: block;
+}
+.earnings-bar-axis {
+    font-size: 11px;
+    fill: var(--text-muted);
+    font-family: 'Inter', sans-serif;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -43,6 +43,7 @@
         <button class="view-link" data-view="positions">Positions</button>
         <button class="view-link" data-view="decisions">Decisions</button>
         <button class="view-link" data-view="history">History</button>
+        <button class="view-link" data-view="earnings">Earnings</button>
     </nav>
 
     <div id="reason-banner" class="reason-banner" style="display:none"></div>
@@ -68,6 +69,20 @@
 
     <div id="decisions-section" style="display:none">
         <div id="decisions-list"></div>
+    </div>
+
+    <div id="earnings-section" style="display:none">
+        <div id="earnings-year-filter" class="earnings-filter-bar"></div>
+        <div id="earnings-month-filter" class="earnings-filter-bar"></div>
+        <div id="earnings-summary-cards" class="earnings-cards"></div>
+        <section class="heatmap-section">
+            <h2>월별 실현수익</h2>
+            <div id="earnings-bar-chart"></div>
+        </section>
+        <section class="heatmap-section">
+            <h2>종목별 실현수익</h2>
+            <div id="earnings-ticker-table"></div>
+        </section>
     </div>
 
     <div id="risk-section">
@@ -104,12 +119,14 @@
     <script src="js/models/dashboard-model.js?v=20260528-1"></script>
     <script src="js/models/history-model.js?v=20260512-1"></script>
     <script src="js/models/decision-model.js?v=20260512-1"></script>
-    <script src="js/views/dashboard-view.js?v=20260528-1"></script>
+    <script src="js/models/earnings-model.js?v=20260602-1"></script>
+    <script src="js/views/dashboard-view.js?v=20260602-1"></script>
     <script src="js/views/history-view.js?v=20260512-1"></script>
     <script src="js/views/decision-view.js?v=20260512-1"></script>
     <script src="js/views/charts-view.js?v=20260512-1"></script>
     <script src="js/views/risk-view.js?v=20260512-1"></script>
-    <script src="js/controllers/dashboard-controller.js?v=20260528-1"></script>
+    <script src="js/views/earnings-view.js?v=20260602-1"></script>
+    <script src="js/controllers/dashboard-controller.js?v=20260602-1"></script>
     <script src="js/controllers/risk-controller.js?v=20260512-1"></script>
     <script src="js/main.js?v=20260512-1"></script>
 </body>

--- a/docs/js/controllers/dashboard-controller.js
+++ b/docs/js/controllers/dashboard-controller.js
@@ -56,7 +56,6 @@ window.DashboardController = (function () {
             HistoryModel.setHistoryData(histData || []);
             EarningsModel.setHistoryData(histData || []);
             EarningsModel.setStatusData(data);
-            EarningsView.reset();
             
             const buckets = DashboardModel.buildLevelBuckets();
             ChartsView.renderLevelHeatmap(buckets, mode, onHeatmapSelect);

--- a/docs/js/controllers/dashboard-controller.js
+++ b/docs/js/controllers/dashboard-controller.js
@@ -54,6 +54,9 @@ window.DashboardController = (function () {
             const histData = await DataRepository.loadHistory(mode);
             DashboardModel.setHistoryData(histData);
             HistoryModel.setHistoryData(histData || []);
+            EarningsModel.setHistoryData(histData || []);
+            EarningsModel.setStatusData(data);
+            EarningsView.reset();
             
             const buckets = DashboardModel.buildLevelBuckets();
             ChartsView.renderLevelHeatmap(buckets, mode, onHeatmapSelect);
@@ -71,11 +74,17 @@ window.DashboardController = (function () {
                 DecisionView.renderDecisions(DecisionModel.getDecisions());
             } else if (document.querySelector('.view-link[data-view="risk"]').classList.contains('active')) {
                 window.RiskController.renderRisk();
+            } else if (document.querySelector('.view-link[data-view="earnings"]').classList.contains('active')) {
+                renderEarningsView();
             }
 
         } finally {
             isRefreshing = false;
         }
+    }
+
+    function renderEarningsView() {
+        EarningsView.render(DashboardModel.getCurrencyMode());
     }
 
     function renderHistoryView() {
@@ -154,6 +163,8 @@ window.DashboardController = (function () {
                     DecisionView.renderDecisions(DecisionModel.getDecisions());
                 } else if (view === 'risk') {
                     window.RiskController.renderRisk();
+                } else if (view === 'earnings') {
+                    renderEarningsView();
                 }
             });
         });

--- a/docs/js/models/earnings-model.js
+++ b/docs/js/models/earnings-model.js
@@ -1,0 +1,144 @@
+// docs/js/models/earnings-model.js
+window.EarningsModel = (function () {
+    'use strict';
+
+    // { "2026-05": { realized_pnl, sell_count, tickers: { ticker: { pnl, count, alias } } } }
+    let monthlyData = {};
+    let sortedYears = [];
+    let currentUnrealized = { total: 0, byTicker: {} };
+
+    function setHistoryData(histData) {
+        monthlyData = {};
+        if (!Array.isArray(histData)) {
+            sortedYears = [];
+            return;
+        }
+
+        for (const tx of histData) {
+            const executions = Array.isArray(tx.executions) ? tx.executions : [];
+            for (const ex of executions) {
+                if ((ex.action || '').toUpperCase() !== 'SELL') continue;
+                if (ex.realized_pnl == null) continue;
+
+                const dateStr = ex.date || tx.date || '';
+                const yearMonth = dateStr.slice(0, 7); // "YYYY-MM"
+                if (yearMonth.length < 7) continue;
+
+                if (!monthlyData[yearMonth]) {
+                    monthlyData[yearMonth] = { realized_pnl: 0, sell_count: 0, tickers: {} };
+                }
+                const bucket = monthlyData[yearMonth];
+                bucket.realized_pnl += Number(ex.realized_pnl);
+                bucket.sell_count += 1;
+
+                const ticker = ex.ticker || '';
+                if (!bucket.tickers[ticker]) {
+                    bucket.tickers[ticker] = { pnl: 0, count: 0, alias: ex.alias || '' };
+                }
+                bucket.tickers[ticker].pnl += Number(ex.realized_pnl);
+                bucket.tickers[ticker].count += 1;
+                if (!bucket.tickers[ticker].alias && ex.alias) {
+                    bucket.tickers[ticker].alias = ex.alias;
+                }
+            }
+        }
+
+        const yearSet = new Set();
+        for (const key of Object.keys(monthlyData)) {
+            yearSet.add(key.slice(0, 4));
+        }
+        sortedYears = Array.from(yearSet).sort();
+    }
+
+    function setStatusData(statusData) {
+        currentUnrealized = { total: 0, byTicker: {} };
+        if (!statusData || !statusData.positions) return;
+
+        for (const [ticker, info] of Object.entries(statusData.positions)) {
+            if (info.unrealized_pnl == null) continue;
+            const pnl = Number(info.unrealized_pnl);
+            currentUnrealized.total += pnl;
+            currentUnrealized.byTicker[ticker] = {
+                unrealized_pnl: pnl,
+                alias: info.alias || ''
+            };
+        }
+    }
+
+    function getAvailableYears() {
+        return sortedYears;
+    }
+
+    // Returns 12-element array for the year (all months, zero if no data)
+    function getYearMonthly(year) {
+        return Array.from({ length: 12 }, (_, i) => {
+            const month = String(i + 1).padStart(2, '0');
+            const key = `${year}-${month}`;
+            const bucket = monthlyData[key];
+            return {
+                month,
+                realized_pnl: bucket ? bucket.realized_pnl : 0,
+                sell_count: bucket ? bucket.sell_count : 0,
+                has_data: !!bucket
+            };
+        });
+    }
+
+    // year=null -> all years; month=null -> all months in year
+    function getPeriodSummary(year, month) {
+        let realized_pnl = 0;
+        let sell_count = 0;
+        const tickerMap = {};
+
+        for (const [key, bucket] of Object.entries(monthlyData)) {
+            const keyYear = key.slice(0, 4);
+            const keyMonth = key.slice(5, 7);
+            if (year && keyYear !== year) continue;
+            if (month && keyMonth !== month) continue;
+
+            realized_pnl += bucket.realized_pnl;
+            sell_count += bucket.sell_count;
+
+            for (const [ticker, td] of Object.entries(bucket.tickers)) {
+                if (!tickerMap[ticker]) {
+                    tickerMap[ticker] = { pnl: 0, count: 0, alias: td.alias };
+                }
+                tickerMap[ticker].pnl += td.pnl;
+                tickerMap[ticker].count += td.count;
+                if (!tickerMap[ticker].alias && td.alias) {
+                    tickerMap[ticker].alias = td.alias;
+                }
+            }
+        }
+
+        const ticker_breakdown = Object.entries(tickerMap)
+            .map(([ticker, td]) => ({ ticker, ...td }))
+            .sort((a, b) => b.pnl - a.pnl);
+
+        return { realized_pnl, sell_count, ticker_breakdown };
+    }
+
+    function getMonthsWithData(year) {
+        const set = new Set();
+        for (const key of Object.keys(monthlyData)) {
+            if (!year || key.slice(0, 4) === year) {
+                set.add(key.slice(5, 7));
+            }
+        }
+        return set;
+    }
+
+    function getCurrentUnrealized() {
+        return currentUnrealized;
+    }
+
+    return {
+        setHistoryData,
+        setStatusData,
+        getAvailableYears,
+        getYearMonthly,
+        getPeriodSummary,
+        getMonthsWithData,
+        getCurrentUnrealized
+    };
+})();

--- a/docs/js/views/dashboard-view.js
+++ b/docs/js/views/dashboard-view.js
@@ -252,7 +252,8 @@ window.DashboardView = (function () {
             'positions': ['positions-container', 'level-heatmap-section', 'reason-banner'],
             'history': ['history-section'],
             'decisions': ['decisions-section'],
-            'risk': ['risk-section']
+            'risk': ['risk-section'],
+            'earnings': ['earnings-section']
         };
 
         Object.keys(sections).forEach(key => {

--- a/docs/js/views/earnings-view.js
+++ b/docs/js/views/earnings-view.js
@@ -4,7 +4,7 @@ window.EarningsView = (function () {
 
     const { escapeHtml, formatTickerLabel } = window.FormatUtils;
 
-    let selectedYear = null;  // "2026" or null (all)
+    let selectedYear = undefined;  // undefined=not init, null=all, "2026"=specific year
     let selectedMonth = null; // "05" or null (all)
     let _currencyMode = 'domestic';
 
@@ -139,7 +139,6 @@ window.EarningsView = (function () {
         const MONTH_SHORT = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
 
         const values = months.map(m => m.realized_pnl);
-        const maxAbs = Math.max(...values.map(Math.abs), 1);
 
         const W = 560, H = 200;
         const PAD = { top: 24, right: 12, bottom: 36, left: 64 };
@@ -152,11 +151,8 @@ window.EarningsView = (function () {
         const DANGER = '#ef4444';
         const MUTED = '#6b7280';
 
-        // y-axis: zero line position
-        const allPositive = values.every(v => v >= 0);
-        const allNegative = values.every(v => v <= 0);
-        const yMin = allPositive ? 0 : (allNegative ? Math.min(...values) * 1.15 : Math.min(...values) * 1.15);
-        const yMax = allNegative ? 0 : (allPositive ? Math.max(...values) * 1.15 : Math.max(...values) * 1.15);
+        const yMin = Math.min(0, ...values) * 1.15;
+        const yMax = Math.max(0, ...values) * 1.15;
         const yRange = (yMax - yMin) || 1;
 
         function yPos(v) {
@@ -326,10 +322,5 @@ window.EarningsView = (function () {
             </div>`;
     }
 
-    function reset() {
-        selectedYear = undefined;
-        selectedMonth = null;
-    }
-
-    return { render, reset };
+    return { render };
 })();

--- a/docs/js/views/earnings-view.js
+++ b/docs/js/views/earnings-view.js
@@ -1,0 +1,335 @@
+// docs/js/views/earnings-view.js
+window.EarningsView = (function () {
+    'use strict';
+
+    const { escapeHtml, formatTickerLabel } = window.FormatUtils;
+
+    let selectedYear = null;  // "2026" or null (all)
+    let selectedMonth = null; // "05" or null (all)
+    let _currencyMode = 'domestic';
+
+    function formatAmt(value, mode) {
+        const isDomestic = (mode || 'domestic') === 'domestic';
+        return new Intl.NumberFormat(isDomestic ? 'ko-KR' : 'en-US', {
+            style: 'currency',
+            currency: isDomestic ? 'KRW' : 'USD',
+            minimumFractionDigits: isDomestic ? 0 : 2,
+            maximumFractionDigits: isDomestic ? 0 : 2,
+        }).format(Number(value));
+    }
+
+    function render(currencyMode) {
+        _currencyMode = currencyMode || 'domestic';
+
+        const years = EarningsModel.getAvailableYears();
+
+        // Default: select latest year on first render if not set
+        if (selectedYear === undefined || (selectedYear !== null && years.length > 0 && !years.includes(selectedYear))) {
+            selectedYear = years.length > 0 ? years[years.length - 1] : null;
+            selectedMonth = null;
+        }
+
+        renderYearFilter(years);
+        renderMonthFilter();
+        renderSummaryCards();
+        renderBarChart();
+        renderTickerTable();
+    }
+
+    function renderYearFilter(years) {
+        const container = document.getElementById('earnings-year-filter');
+        if (!container) return;
+
+        const allBtn = `<button class="filter-chip${selectedYear === null ? ' active' : ''}" data-year="">전체</button>`;
+        const yearBtns = years.map(y =>
+            `<button class="filter-chip${selectedYear === y ? ' active' : ''}" data-year="${escapeHtml(y)}">${escapeHtml(y)}</button>`
+        ).join('');
+
+        container.innerHTML = `<span class="earnings-filter-label">연도</span>${allBtn}${yearBtns}`;
+
+        container.querySelectorAll('.filter-chip').forEach(btn => {
+            btn.addEventListener('click', () => {
+                selectedYear = btn.dataset.year || null;
+                selectedMonth = null;
+                render(_currencyMode);
+            });
+        });
+    }
+
+    function renderMonthFilter() {
+        const container = document.getElementById('earnings-month-filter');
+        if (!container) return;
+
+        const monthsWithData = EarningsModel.getMonthsWithData(selectedYear);
+        const MONTH_LABELS = ['1월','2월','3월','4월','5월','6월','7월','8월','9월','10월','11월','12월'];
+
+        const allBtn = `<button class="filter-chip${selectedMonth === null ? ' active' : ''}" data-month="">전체</button>`;
+        const monthBtns = Array.from({ length: 12 }, (_, i) => {
+            const m = String(i + 1).padStart(2, '0');
+            const hasData = monthsWithData.has(m);
+            const isActive = selectedMonth === m;
+            const dimClass = hasData ? '' : ' dim';
+            return `<button class="filter-chip${isActive ? ' active' : ''}${dimClass}" data-month="${m}" ${hasData ? '' : 'disabled'}>${MONTH_LABELS[i]}</button>`;
+        }).join('');
+
+        container.innerHTML = `<span class="earnings-filter-label">월</span>${allBtn}${monthBtns}`;
+
+        container.querySelectorAll('.filter-chip:not([disabled])').forEach(btn => {
+            btn.addEventListener('click', () => {
+                selectedMonth = btn.dataset.month || null;
+                render(_currencyMode);
+            });
+        });
+    }
+
+    function renderSummaryCards() {
+        const container = document.getElementById('earnings-summary-cards');
+        if (!container) return;
+
+        const summary = EarningsModel.getPeriodSummary(selectedYear, selectedMonth);
+        const unrealized = EarningsModel.getCurrentUnrealized();
+        const mode = _currencyMode;
+
+        const rPnl = summary.realized_pnl;
+        const rClass = rPnl >= 0 ? 'pct-positive' : 'pct-negative';
+        const rSign = rPnl > 0 ? '+' : '';
+
+        const uPnl = unrealized.total;
+        const uClass = uPnl >= 0 ? 'pct-positive' : 'pct-negative';
+        const uSign = uPnl > 0 ? '+' : '';
+
+        let periodLabel = '전체';
+        if (selectedYear && selectedMonth) periodLabel = `${selectedYear}-${selectedMonth}`;
+        else if (selectedYear) periodLabel = selectedYear;
+
+        container.innerHTML = `
+            <div class="earnings-card">
+                <div class="earnings-card-label">실현수익 (${escapeHtml(periodLabel)})</div>
+                <div class="earnings-card-value ${rClass}">${rSign}${escapeHtml(formatAmt(rPnl, mode))}</div>
+                <div class="earnings-card-note">SELL 체결 기준 누적</div>
+            </div>
+            <div class="earnings-card">
+                <div class="earnings-card-label">매도 건수 (${escapeHtml(periodLabel)})</div>
+                <div class="earnings-card-value">${summary.sell_count}건</div>
+                <div class="earnings-card-note">SELL 체결 횟수</div>
+            </div>
+            <div class="earnings-card">
+                <div class="earnings-card-label">현재 평가손익</div>
+                <div class="earnings-card-value ${uClass}">${uSign}${escapeHtml(formatAmt(uPnl, mode))}</div>
+                <div class="earnings-card-note">현재 시점 기준 (과거 월 소급 불가)</div>
+            </div>`;
+    }
+
+    function renderBarChart() {
+        const container = document.getElementById('earnings-bar-chart');
+        if (!container) return;
+
+        // Bar chart only makes sense for a specific year or all-time with monthly breakdown
+        const year = selectedYear;
+        if (!year) {
+            // Show all-years summary bar chart (one bar per year)
+            renderYearBarChart(container);
+            return;
+        }
+        renderMonthBarChart(container, year);
+    }
+
+    function renderMonthBarChart(container, year) {
+        const months = EarningsModel.getYearMonthly(year);
+        const MONTH_SHORT = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+        const values = months.map(m => m.realized_pnl);
+        const maxAbs = Math.max(...values.map(Math.abs), 1);
+
+        const W = 560, H = 200;
+        const PAD = { top: 24, right: 12, bottom: 36, left: 64 };
+        const chartW = W - PAD.left - PAD.right;
+        const chartH = H - PAD.top - PAD.bottom;
+        const barW = Math.floor(chartW / 12) - 4;
+
+        const mode = _currencyMode;
+        const SUCCESS = '#10b981';
+        const DANGER = '#ef4444';
+        const MUTED = '#6b7280';
+
+        // y-axis: zero line position
+        const allPositive = values.every(v => v >= 0);
+        const allNegative = values.every(v => v <= 0);
+        const yMin = allPositive ? 0 : (allNegative ? Math.min(...values) * 1.15 : Math.min(...values) * 1.15);
+        const yMax = allNegative ? 0 : (allPositive ? Math.max(...values) * 1.15 : Math.max(...values) * 1.15);
+        const yRange = (yMax - yMin) || 1;
+
+        function yPos(v) {
+            return PAD.top + chartH - ((v - yMin) / yRange) * chartH;
+        }
+
+        const zeroY = yPos(0).toFixed(1);
+
+        const compactLabel = (v) => {
+            const abs = Math.abs(v);
+            const sym = mode === 'domestic' ? '₩' : '$';
+            if (abs >= 1_000_000_000) return sym + (v / 1_000_000_000).toFixed(1) + 'B';
+            if (abs >= 1_000_000) return sym + (v / 1_000_000).toFixed(1) + 'M';
+            if (abs >= 1_000) return sym + (v / 1_000).toFixed(1) + 'K';
+            return sym + v.toFixed(0);
+        };
+
+        let barsHtml = '';
+        let xLabelsHtml = '';
+
+        months.forEach((m, i) => {
+            const x = PAD.left + i * (chartW / 12) + (chartW / 12 - barW) / 2;
+            const v = m.realized_pnl;
+            const color = v >= 0 ? SUCCESS : DANGER;
+            const barTop = Math.min(yPos(v), Number(zeroY));
+            const barH = Math.abs(yPos(v) - Number(zeroY));
+
+            const isSelected = selectedMonth === m.month;
+            const opacity = (!selectedMonth || isSelected) ? '1' : '0.35';
+
+            if (m.has_data) {
+                barsHtml += `<rect x="${x.toFixed(1)}" y="${barTop.toFixed(1)}" width="${barW}" height="${Math.max(barH, 1).toFixed(1)}" fill="${color}" opacity="${opacity}" rx="2">
+                    <title>${MONTH_SHORT[i]}: ${formatAmt(v, mode)}</title>
+                </rect>`;
+            }
+
+            const labelX = (x + barW / 2).toFixed(1);
+            const labelY = (PAD.top + chartH + 14).toFixed(1);
+            const labelFill = m.has_data ? (mode === 'domestic' ? '#374151' : MUTED) : MUTED;
+            xLabelsHtml += `<text x="${labelX}" y="${labelY}" text-anchor="middle" class="earnings-bar-axis" fill="${labelFill}">${MONTH_SHORT[i]}</text>`;
+        });
+
+        // y-axis ticks
+        const tickValues = [yMin, (yMin + yMax) / 2, yMax].filter((v, i, a) => a.indexOf(v) === i);
+        const yTicksHtml = tickValues.map(v => {
+            const y = yPos(v).toFixed(1);
+            return `<text x="${(PAD.left - 6).toFixed(1)}" y="${y}" text-anchor="end" dominant-baseline="middle" class="earnings-bar-axis">${compactLabel(v)}</text>`;
+        }).join('');
+
+        container.innerHTML = `
+            <svg viewBox="0 0 ${W} ${H}" class="earnings-bar-svg" role="img" aria-label="${escapeHtml(year)} 월별 실현수익">
+                <line x1="${PAD.left}" y1="${zeroY}" x2="${(PAD.left + chartW).toFixed(1)}" y2="${zeroY}" stroke="#d1d5db" stroke-width="1"/>
+                ${barsHtml}
+                ${yTicksHtml}
+                ${xLabelsHtml}
+            </svg>`;
+    }
+
+    function renderYearBarChart(container) {
+        const years = EarningsModel.getAvailableYears();
+        if (years.length === 0) {
+            container.innerHTML = '<p class="empty-state">데이터 없음</p>';
+            return;
+        }
+
+        const yearData = years.map(y => {
+            const s = EarningsModel.getPeriodSummary(y, null);
+            return { year: y, realized_pnl: s.realized_pnl };
+        });
+
+        const W = 560, H = 180;
+        const PAD = { top: 24, right: 12, bottom: 36, left: 64 };
+        const chartW = W - PAD.left - PAD.right;
+        const chartH = H - PAD.top - PAD.bottom;
+        const barW = Math.min(60, Math.floor(chartW / yearData.length) - 8);
+        const mode = _currencyMode;
+        const SUCCESS = '#10b981';
+        const DANGER = '#ef4444';
+
+        const values = yearData.map(d => d.realized_pnl);
+        const yMin = Math.min(0, ...values) * 1.15;
+        const yMax = Math.max(0, ...values) * 1.15 || 1;
+        const yRange = (yMax - yMin) || 1;
+
+        function yPos(v) {
+            return PAD.top + chartH - ((v - yMin) / yRange) * chartH;
+        }
+        const zeroY = yPos(0).toFixed(1);
+
+        const compactLabel = (v) => {
+            const abs = Math.abs(v);
+            const sym = mode === 'domestic' ? '₩' : '$';
+            if (abs >= 1_000_000_000) return sym + (v / 1_000_000_000).toFixed(1) + 'B';
+            if (abs >= 1_000_000) return sym + (v / 1_000_000).toFixed(1) + 'M';
+            if (abs >= 1_000) return sym + (v / 1_000).toFixed(1) + 'K';
+            return sym + v.toFixed(0);
+        };
+
+        let barsHtml = '';
+        let xLabelsHtml = '';
+
+        yearData.forEach((d, i) => {
+            const x = PAD.left + i * (chartW / yearData.length) + (chartW / yearData.length - barW) / 2;
+            const v = d.realized_pnl;
+            const color = v >= 0 ? SUCCESS : DANGER;
+            const barTop = Math.min(yPos(v), Number(zeroY));
+            const barH = Math.abs(yPos(v) - Number(zeroY));
+            barsHtml += `<rect x="${x.toFixed(1)}" y="${barTop.toFixed(1)}" width="${barW}" height="${Math.max(barH, 1).toFixed(1)}" fill="${color}" rx="2">
+                <title>${escapeHtml(d.year)}: ${formatAmt(v, mode)}</title>
+            </rect>`;
+            const labelX = (x + barW / 2).toFixed(1);
+            xLabelsHtml += `<text x="${labelX}" y="${(PAD.top + chartH + 14).toFixed(1)}" text-anchor="middle" class="earnings-bar-axis">${escapeHtml(d.year)}</text>`;
+        });
+
+        const tickValues = [yMin, (yMin + yMax) / 2, yMax].filter((v, i, a) => a.indexOf(v) === i);
+        const yTicksHtml = tickValues.map(v => {
+            const y = yPos(v).toFixed(1);
+            return `<text x="${(PAD.left - 6).toFixed(1)}" y="${y}" text-anchor="end" dominant-baseline="middle" class="earnings-bar-axis">${compactLabel(v)}</text>`;
+        }).join('');
+
+        container.innerHTML = `
+            <svg viewBox="0 0 ${W} ${H}" class="earnings-bar-svg" role="img" aria-label="연도별 실현수익">
+                <line x1="${PAD.left}" y1="${zeroY}" x2="${(PAD.left + chartW).toFixed(1)}" y2="${zeroY}" stroke="#d1d5db" stroke-width="1"/>
+                ${barsHtml}
+                ${yTicksHtml}
+                ${xLabelsHtml}
+            </svg>`;
+    }
+
+    function renderTickerTable(container) {
+        const el = document.getElementById('earnings-ticker-table');
+        if (!el) return;
+
+        const summary = EarningsModel.getPeriodSummary(selectedYear, selectedMonth);
+        const breakdown = summary.ticker_breakdown;
+        const mode = _currencyMode;
+
+        if (breakdown.length === 0) {
+            el.innerHTML = '<p class="empty-state">해당 기간에 매도 기록이 없습니다.</p>';
+            return;
+        }
+
+        const rows = breakdown.map(td => {
+            const pnl = td.pnl;
+            const cls = pnl >= 0 ? 'pct-positive' : 'pct-negative';
+            const sign = pnl > 0 ? '+' : '';
+            const label = escapeHtml(formatTickerLabel(td.ticker, td.alias));
+            return `<tr>
+                <td><strong>${label}</strong></td>
+                <td class="${cls}" style="text-align:right">${sign}${escapeHtml(formatAmt(pnl, mode))}</td>
+                <td style="text-align:center;color:var(--text-muted)">${td.count}건</td>
+            </tr>`;
+        }).join('');
+
+        el.innerHTML = `
+            <div class="card" style="padding:0;overflow-x:auto">
+                <table class="history-table">
+                    <thead>
+                        <tr>
+                            <th>종목</th>
+                            <th style="text-align:right">실현수익</th>
+                            <th style="text-align:center">매도건수</th>
+                        </tr>
+                    </thead>
+                    <tbody>${rows}</tbody>
+                </table>
+            </div>`;
+    }
+
+    function reset() {
+        selectedYear = undefined;
+        selectedMonth = null;
+    }
+
+    return { render, reset };
+})();


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `EarningsModel`: `history.json`의 SELL execution `realized_pnl`을 연월·종목별로 집계. `status.json`에서 현재 평가손익 추출
- `EarningsView`: 연도/월 pill 필터, 요약 카드 3개(실현수익·매도건수·현재평가손익), SVG 바 차트, 종목별 테이블
- `dashboard-controller`: 데이터 refresh 시 EarningsModel 초기화, Earnings 탭 클릭 핸들링
- `dashboard-view`: `showView()`에 earnings 라우팅 추가
- `style.css`: earnings 전용 스타일 (필터 바, 카드 3열 그리드, SVG 바 차트)

## 동작 방식

- **연도 필터**: 데이터가 있는 연도만 pill 버튼으로 표시. 기본값은 최신 연도
- **월 필터**: 1~12월 pill. 해당 연도에 데이터 없는 월은 dim/disabled 처리
- **실현수익**: `history.json` SELL execution의 `realized_pnl` 합산 (기간 필터 적용)
- **평가손익**: `status.json` 현재 시점 값만 표시. 과거 월 snapshot 없으므로 소급 불가 → 카드 하단에 안내 문구 표시
- **바 차트**: 연도 선택 시 월별 12칸, 전체 선택 시 연도별 막대. 양수=초록, 음수=빨강
- **종목별 테이블**: 선택 기간 기준 실현수익 내림차순 정렬

## Test plan

- [ ] Earnings 탭 버튼 클릭 시 섹션이 표시되고 다른 탭 섹션은 숨겨지는지 확인
- [ ] 연도 pill 클릭 → 월 필터·카드·차트·테이블이 해당 연도로 갱신되는지 확인
- [ ] 월 pill 클릭 → 카드·테이블이 해당 월 기준으로 필터링되는지 확인
- [ ] domestic/overseas/backtest 모드 전환 후 Earnings 탭이 각각 정상 표시되는지 확인
- [ ] 데이터 없는 기간 선택 시 "데이터 없음" 표시 확인
- [ ] `pytest` 383 passed (JS 변경이므로 Python 테스트 영향 없음)

https://claude.ai/code/session_011r9Wf1PXaqnLS5d2jC6TpU
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011r9Wf1PXaqnLS5d2jC6TpU)_