### PR TITLE
feat(earnings): 종목별 종합수익 섹션 추가 (실현+평가, 승률, 상세 패널)

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1144,3 +1144,19 @@ h2 { font-size: 1.1rem; margin-bottom: 8px; color: var(--text-muted); }
     margin-bottom: 6px;
 }
 .ticker-detail-chart { margin-bottom: 8px; }
+
+/* Level win-rate dot indicator */
+.win-dots {
+    display: inline-flex;
+    gap: 3px;
+    vertical-align: middle;
+    margin-right: 4px;
+}
+.win-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--border);
+}
+.win-dot.filled { background: var(--success); }

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1058,3 +1058,89 @@ h2 { font-size: 1.1rem; margin-bottom: 8px; color: var(--text-muted); }
     fill: var(--text-muted);
     font-family: 'Inter', sans-serif;
 }
+
+/* Ticker Summary Table */
+.ticker-summary-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 12px;
+}
+.ticker-search-input {
+    flex: 1 1 180px;
+    padding: 6px 12px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    font-size: 0.875rem;
+    background: var(--card-bg);
+    color: var(--text);
+    outline: none;
+}
+.ticker-search-input:focus {
+    border-color: var(--primary);
+    box-shadow: 0 0 0 2px rgba(59,130,246,0.15);
+}
+.ts-table .ts-th {
+    white-space: nowrap;
+    user-select: none;
+}
+.ts-table .ts-th:hover { background: rgba(59,130,246,0.06); }
+.ts-table .ts-th-active { color: var(--primary); }
+.ts-row:hover { background: rgba(59,130,246,0.04); }
+.ts-row-selected { background: rgba(59,130,246,0.08) !important; }
+.ts-status-badge {
+    display: inline-block;
+    font-size: 0.72rem;
+    font-weight: 700;
+    padding: 2px 7px;
+    border-radius: 10px;
+}
+.ts-status-held    { background: #d1fae5; color: #065f46; }
+.ts-status-closed  { background: #f3f4f6; color: #6b7280; }
+.ts-note {
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    text-align: right;
+    padding: 8px 16px;
+    border-top: 1px solid var(--border);
+}
+
+/* Ticker Detail Panel */
+.ticker-detail-panel {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 20px;
+    margin-top: 12px;
+    box-shadow: var(--shadow-md);
+}
+.ticker-detail-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+}
+.ticker-detail-title {
+    font-size: 1.05rem;
+    font-weight: 700;
+}
+.ticker-detail-close {
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 3px 10px;
+    cursor: pointer;
+}
+.ticker-detail-close:hover { background: var(--bg); }
+.ticker-detail-section-title {
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    margin-bottom: 6px;
+}
+.ticker-detail-chart { margin-bottom: 8px; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -80,8 +80,12 @@
             <div id="earnings-bar-chart"></div>
         </section>
         <section class="heatmap-section">
-            <h2>종목별 실현수익</h2>
+            <h2>종목별 실현수익 (기간 필터 적용)</h2>
             <div id="earnings-ticker-table"></div>
+        </section>
+        <section class="heatmap-section">
+            <h2>종목별 종합수익</h2>
+            <div id="earnings-ticker-summary-section"></div>
         </section>
     </div>
 
@@ -119,13 +123,13 @@
     <script src="js/models/dashboard-model.js?v=20260528-1"></script>
     <script src="js/models/history-model.js?v=20260512-1"></script>
     <script src="js/models/decision-model.js?v=20260512-1"></script>
-    <script src="js/models/earnings-model.js?v=20260602-1"></script>
+    <script src="js/models/earnings-model.js?v=20260603-1"></script>
     <script src="js/views/dashboard-view.js?v=20260602-1"></script>
     <script src="js/views/history-view.js?v=20260512-1"></script>
     <script src="js/views/decision-view.js?v=20260512-1"></script>
     <script src="js/views/charts-view.js?v=20260512-1"></script>
     <script src="js/views/risk-view.js?v=20260512-1"></script>
-    <script src="js/views/earnings-view.js?v=20260602-1"></script>
+    <script src="js/views/earnings-view.js?v=20260603-1"></script>
     <script src="js/controllers/dashboard-controller.js?v=20260602-1"></script>
     <script src="js/controllers/risk-controller.js?v=20260512-1"></script>
     <script src="js/main.js?v=20260512-1"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -87,6 +87,10 @@
             <h2>종목별 종합수익</h2>
             <div id="earnings-ticker-summary-section"></div>
         </section>
+        <section class="heatmap-section">
+            <h2>차수별 실현수익 분석</h2>
+            <div id="earnings-level-section"></div>
+        </section>
     </div>
 
     <div id="risk-section">
@@ -123,13 +127,13 @@
     <script src="js/models/dashboard-model.js?v=20260528-1"></script>
     <script src="js/models/history-model.js?v=20260512-1"></script>
     <script src="js/models/decision-model.js?v=20260512-1"></script>
-    <script src="js/models/earnings-model.js?v=20260603-1"></script>
+    <script src="js/models/earnings-model.js?v=20260603-2"></script>
     <script src="js/views/dashboard-view.js?v=20260602-1"></script>
     <script src="js/views/history-view.js?v=20260512-1"></script>
     <script src="js/views/decision-view.js?v=20260512-1"></script>
     <script src="js/views/charts-view.js?v=20260512-1"></script>
     <script src="js/views/risk-view.js?v=20260512-1"></script>
-    <script src="js/views/earnings-view.js?v=20260603-1"></script>
+    <script src="js/views/earnings-view.js?v=20260603-2"></script>
     <script src="js/controllers/dashboard-controller.js?v=20260602-1"></script>
     <script src="js/controllers/risk-controller.js?v=20260512-1"></script>
     <script src="js/main.js?v=20260512-1"></script>

--- a/docs/js/models/earnings-model.js
+++ b/docs/js/models/earnings-model.js
@@ -187,10 +187,14 @@ window.EarningsModel = (function () {
             // Prefer positions.alias, then tickerSellStats.alias
             const alias = (posInfo && posInfo.alias) || ts.alias || '';
 
-            // realized_pnl: prefer positions.realized_pnl (most accurate), fallback to realized_pnl_by_ticker
+            // realized_pnl: positions > realized_pnl_by_ticker > history trades sum (backtest/incomplete data fallback)
             const realized_pnl = posInfo
                 ? Number(posInfo.realized_pnl || 0)
-                : Number(realizedByTicker[ticker] || 0);
+                : (realizedByTicker[ticker] != null
+                    ? Number(realizedByTicker[ticker])
+                    : (tickerSellStats[ticker]
+                        ? tickerSellStats[ticker].trades.reduce((sum, t) => sum + t.realized_pnl, 0)
+                        : 0));
 
             const unrealized_pnl = posInfo ? Number(posInfo.unrealized_pnl || 0) : 0;
             const total_pnl = realized_pnl + unrealized_pnl;
@@ -210,7 +214,7 @@ window.EarningsModel = (function () {
 
         const monthly = Object.entries(ts.monthly)
             .map(([ym, d]) => ({ yearMonth: ym, pnl: d.pnl, count: d.count }))
-            .sort((a, b) => (a.yearMonth < b.yearMonth ? -1 : 1));
+            .sort((a, b) => a.yearMonth.localeCompare(b.yearMonth));
 
         const lots = posInfo ? (posInfo.lots || []) : [];
         const alias = (posInfo && posInfo.alias) || ts.alias || ticker;

--- a/docs/js/models/earnings-model.js
+++ b/docs/js/models/earnings-model.js
@@ -11,9 +11,13 @@ window.EarningsModel = (function () {
     let tickerSellStats = {};
     let _rawStatusData = null;
 
+    // { "YYYY-MM": { level: { total_pnl, sell_count, win_count, rates: [] } } }
+    let levelMonthlyData = {};
+
     function setHistoryData(histData) {
         monthlyData = {};
         tickerSellStats = {};
+        levelMonthlyData = {};
         if (!Array.isArray(histData)) {
             sortedYears = [];
             return;
@@ -74,6 +78,20 @@ window.EarningsModel = (function () {
                 if (!ts.monthly[yearMonth]) ts.monthly[yearMonth] = { pnl: 0, count: 0 };
                 ts.monthly[yearMonth].pnl += Number(ex.realized_pnl);
                 ts.monthly[yearMonth].count += 1;
+
+                // -- level monthly buckets --
+                const level = ex.level != null ? ex.level : null;
+                if (level != null) {
+                    if (!levelMonthlyData[yearMonth]) levelMonthlyData[yearMonth] = {};
+                    if (!levelMonthlyData[yearMonth][level]) {
+                        levelMonthlyData[yearMonth][level] = { total_pnl: 0, sell_count: 0, win_count: 0, rates: [] };
+                    }
+                    const lb = levelMonthlyData[yearMonth][level];
+                    lb.total_pnl += Number(ex.realized_pnl);
+                    lb.sell_count += 1;
+                    if (Number(ex.realized_pnl) > 0) lb.win_count += 1;
+                    if (profitRate != null) lb.rates.push(profitRate);
+                }
             }
         }
 
@@ -207,6 +225,36 @@ window.EarningsModel = (function () {
         return result.sort((a, b) => b.total_pnl - a.total_pnl);
     }
 
+    // Returns level-aggregated stats filtered by year/month
+    // Returns array sorted by level asc: [{ level, total_pnl, sell_count, win_count, win_rate, avg_profit_rate }]
+    function getLevelStats(year, month) {
+        const map = {};
+        for (const [ym, levels] of Object.entries(levelMonthlyData)) {
+            const keyYear = ym.slice(0, 4);
+            const keyMonth = ym.slice(5, 7);
+            if (year && keyYear !== year) continue;
+            if (month && keyMonth !== month) continue;
+            for (const [lv, lb] of Object.entries(levels)) {
+                const lvNum = Number(lv);
+                if (!map[lvNum]) map[lvNum] = { total_pnl: 0, sell_count: 0, win_count: 0, rates: [] };
+                map[lvNum].total_pnl += lb.total_pnl;
+                map[lvNum].sell_count += lb.sell_count;
+                map[lvNum].win_count += lb.win_count;
+                map[lvNum].rates = map[lvNum].rates.concat(lb.rates);
+            }
+        }
+        return Object.entries(map)
+            .map(([lv, d]) => ({
+                level: Number(lv),
+                total_pnl: d.total_pnl,
+                sell_count: d.sell_count,
+                win_count: d.win_count,
+                win_rate: d.sell_count > 0 ? (d.win_count / d.sell_count) * 100 : null,
+                avg_profit_rate: d.rates.length > 0 ? d.rates.reduce((s, r) => s + r, 0) / d.rates.length : null
+            }))
+            .sort((a, b) => a.level - b.level);
+    }
+
     // Returns sell trade history + monthly breakdown + current lots for a single ticker
     function getTickerDetail(ticker) {
         const ts = tickerSellStats[ticker] || { trades: [], monthly: {}, alias: '' };
@@ -231,6 +279,7 @@ window.EarningsModel = (function () {
         getMonthsWithData,
         getCurrentUnrealized,
         getTickerSummaries,
-        getTickerDetail
+        getTickerDetail,
+        getLevelStats
     };
 })();

--- a/docs/js/models/earnings-model.js
+++ b/docs/js/models/earnings-model.js
@@ -7,8 +7,13 @@ window.EarningsModel = (function () {
     let sortedYears = [];
     let currentUnrealized = { total: 0, byTicker: {} };
 
+    // { ticker: { sell_count, win_count, alias, trades: [...], monthly: { "YYYY-MM": { pnl, count } } } }
+    let tickerSellStats = {};
+    let _rawStatusData = null;
+
     function setHistoryData(histData) {
         monthlyData = {};
+        tickerSellStats = {};
         if (!Array.isArray(histData)) {
             sortedYears = [];
             return;
@@ -24,6 +29,7 @@ window.EarningsModel = (function () {
                 const yearMonth = dateStr.slice(0, 7); // "YYYY-MM"
                 if (yearMonth.length < 7) continue;
 
+                // -- global monthly buckets --
                 if (!monthlyData[yearMonth]) {
                     monthlyData[yearMonth] = { realized_pnl: 0, sell_count: 0, tickers: {} };
                 }
@@ -40,17 +46,49 @@ window.EarningsModel = (function () {
                 if (!bucket.tickers[ticker].alias && ex.alias) {
                     bucket.tickers[ticker].alias = ex.alias;
                 }
+
+                // -- per-ticker sell stats --
+                if (!tickerSellStats[ticker]) {
+                    tickerSellStats[ticker] = { sell_count: 0, win_count: 0, alias: ex.alias || '', trades: [], monthly: {} };
+                }
+                const ts = tickerSellStats[ticker];
+                ts.sell_count += 1;
+                if (Number(ex.realized_pnl) > 0) ts.win_count += 1;
+                if (!ts.alias && ex.alias) ts.alias = ex.alias;
+
+                const buyPrice = ex.buy_price != null ? Number(ex.buy_price) : null;
+                const qty = ex.quantity || 0;
+                const profitRate = (buyPrice && buyPrice > 0 && qty > 0)
+                    ? (Number(ex.realized_pnl) / (buyPrice * qty)) * 100 : null;
+                ts.trades.push({
+                    date: dateStr,
+                    level: ex.level != null ? ex.level : '',
+                    qty,
+                    sell_price: ex.price || 0,
+                    buy_price: buyPrice,
+                    fee: ex.fee || 0,
+                    realized_pnl: Number(ex.realized_pnl),
+                    profit_rate: profitRate
+                });
+
+                if (!ts.monthly[yearMonth]) ts.monthly[yearMonth] = { pnl: 0, count: 0 };
+                ts.monthly[yearMonth].pnl += Number(ex.realized_pnl);
+                ts.monthly[yearMonth].count += 1;
             }
         }
 
-        const yearSet = new Set();
-        for (const key of Object.keys(monthlyData)) {
-            yearSet.add(key.slice(0, 4));
+        // sort trades newest-first within each ticker
+        for (const ts of Object.values(tickerSellStats)) {
+            ts.trades.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
         }
+
+        const yearSet = new Set();
+        for (const key of Object.keys(monthlyData)) yearSet.add(key.slice(0, 4));
         sortedYears = Array.from(yearSet).sort();
     }
 
     function setStatusData(statusData) {
+        _rawStatusData = statusData || null;
         currentUnrealized = { total: 0, byTicker: {} };
         if (!statusData || !statusData.positions) return;
 
@@ -105,9 +143,7 @@ window.EarningsModel = (function () {
                 }
                 tickerMap[ticker].pnl += td.pnl;
                 tickerMap[ticker].count += td.count;
-                if (!tickerMap[ticker].alias && td.alias) {
-                    tickerMap[ticker].alias = td.alias;
-                }
+                if (!tickerMap[ticker].alias && td.alias) tickerMap[ticker].alias = td.alias;
             }
         }
 
@@ -121,15 +157,65 @@ window.EarningsModel = (function () {
     function getMonthsWithData(year) {
         const set = new Set();
         for (const key of Object.keys(monthlyData)) {
-            if (!year || key.slice(0, 4) === year) {
-                set.add(key.slice(5, 7));
-            }
+            if (!year || key.slice(0, 4) === year) set.add(key.slice(5, 7));
         }
         return set;
     }
 
     function getCurrentUnrealized() {
         return currentUnrealized;
+    }
+
+    // Returns array of per-ticker comprehensive P&L (all tickers ever traded or held)
+    function getTickerSummaries() {
+        const statusData = _rawStatusData || {};
+        const realizedByTicker = statusData.realized_pnl_by_ticker || {};
+        const positions = statusData.positions || {};
+
+        // Collect all known tickers: union of positions + realized_pnl_by_ticker + history
+        const allTickers = new Set([
+            ...Object.keys(positions),
+            ...Object.keys(realizedByTicker),
+            ...Object.keys(tickerSellStats)
+        ]);
+
+        const result = [];
+        for (const ticker of allTickers) {
+            const posInfo = positions[ticker];
+            const ts = tickerSellStats[ticker] || { sell_count: 0, win_count: 0, alias: '' };
+
+            // Prefer positions.alias, then tickerSellStats.alias
+            const alias = (posInfo && posInfo.alias) || ts.alias || '';
+
+            // realized_pnl: prefer positions.realized_pnl (most accurate), fallback to realized_pnl_by_ticker
+            const realized_pnl = posInfo
+                ? Number(posInfo.realized_pnl || 0)
+                : Number(realizedByTicker[ticker] || 0);
+
+            const unrealized_pnl = posInfo ? Number(posInfo.unrealized_pnl || 0) : 0;
+            const total_pnl = realized_pnl + unrealized_pnl;
+            const status = posInfo ? '보유중' : '청산완료';
+            const win_rate = ts.sell_count > 0 ? (ts.win_count / ts.sell_count) * 100 : null;
+
+            result.push({ ticker, alias, status, realized_pnl, unrealized_pnl, total_pnl, sell_count: ts.sell_count, win_count: ts.win_count, win_rate });
+        }
+
+        return result.sort((a, b) => b.total_pnl - a.total_pnl);
+    }
+
+    // Returns sell trade history + monthly breakdown + current lots for a single ticker
+    function getTickerDetail(ticker) {
+        const ts = tickerSellStats[ticker] || { trades: [], monthly: {}, alias: '' };
+        const posInfo = (_rawStatusData && _rawStatusData.positions && _rawStatusData.positions[ticker]) || null;
+
+        const monthly = Object.entries(ts.monthly)
+            .map(([ym, d]) => ({ yearMonth: ym, pnl: d.pnl, count: d.count }))
+            .sort((a, b) => (a.yearMonth < b.yearMonth ? -1 : 1));
+
+        const lots = posInfo ? (posInfo.lots || []) : [];
+        const alias = (posInfo && posInfo.alias) || ts.alias || ticker;
+
+        return { alias, trades: ts.trades, monthly, lots };
     }
 
     return {
@@ -139,6 +225,8 @@ window.EarningsModel = (function () {
         getYearMonthly,
         getPeriodSummary,
         getMonthsWithData,
-        getCurrentUnrealized
+        getCurrentUnrealized,
+        getTickerSummaries,
+        getTickerDetail
     };
 })();

--- a/docs/js/views/earnings-view.js
+++ b/docs/js/views/earnings-view.js
@@ -8,6 +8,9 @@ window.EarningsView = (function () {
     let selectedMonth = null;      // "05" or null (all)
     let _currencyMode = 'domestic';
 
+    // Level analysis state
+    let levelMetric = 'total_pnl'; // 'total_pnl' | 'avg_profit_rate'
+
     // Ticker summary state
     let tickerSortKey = 'total_pnl';
     let tickerSortAsc = false;
@@ -42,6 +45,7 @@ window.EarningsView = (function () {
         renderBarChart();
         renderPeriodTickerTable();
         renderTickerSummarySection();
+        renderLevelAnalysisSection();
     }
 
     // ── Period filters ───────────────────────────────────────────────────────
@@ -495,6 +499,158 @@ window.EarningsView = (function () {
         });
 
         if (shouldScroll) panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+
+    // ── Level analysis section ───────────────────────────────────────────────
+
+    function renderLevelAnalysisSection() {
+        const section = document.getElementById('earnings-level-section');
+        if (!section) return;
+
+        const stats = EarningsModel.getLevelStats(selectedYear, selectedMonth);
+        const mode = _currencyMode;
+
+        if (stats.length === 0) {
+            section.innerHTML = '<p class="empty-state">해당 기간에 차수별 매도 데이터가 없습니다.</p>';
+            return;
+        }
+
+        // metric toggle
+        const toggleHtml = `
+            <div class="earnings-filter-bar" style="margin-bottom:14px">
+                <span class="earnings-filter-label">지표</span>
+                <button class="filter-chip${levelMetric === 'total_pnl' ? ' active' : ''}" data-metric="total_pnl">총 실현수익</button>
+                <button class="filter-chip${levelMetric === 'avg_profit_rate' ? ' active' : ''}" data-metric="avg_profit_rate">평균 수익률</button>
+            </div>`;
+
+        section.innerHTML = toggleHtml +
+            '<div id="level-bar-chart"></div>' +
+            '<div id="level-stats-table" style="margin-top:16px"></div>';
+
+        section.querySelectorAll('[data-metric]').forEach(btn => {
+            btn.addEventListener('click', () => {
+                levelMetric = btn.dataset.metric;
+                renderLevelAnalysisSection();
+            });
+        });
+
+        renderLevelBarChart(stats, mode);
+        renderLevelStatsTable(stats, mode);
+    }
+
+    function renderLevelBarChart(stats, mode) {
+        const container = document.getElementById('level-bar-chart');
+        if (!container) return;
+
+        const labels = stats.map(s => `Lv${s.level}`);
+        const values = levelMetric === 'total_pnl'
+            ? stats.map(s => s.total_pnl)
+            : stats.map(s => s.avg_profit_rate != null ? s.avg_profit_rate : 0);
+
+        const PAD = { top: 24, right: 12, bottom: 36, left: levelMetric === 'total_pnl' ? 64 : 44 };
+        const W = 560, H = 180;
+        const chartW = W - PAD.left - PAD.right;
+        const chartH = H - PAD.top - PAD.bottom;
+        const barW = Math.max(8, Math.floor(chartW / labels.length) - 6);
+
+        const SUCCESS = '#10b981', DANGER = '#ef4444';
+        const yMin = Math.min(0, ...values) * 1.15;
+        const yMax = Math.max(0, ...values) * 1.15;
+        const yRange = (yMax - yMin) || 1;
+
+        const yPos = v => PAD.top + chartH - ((v - yMin) / yRange) * chartH;
+        const zeroY = yPos(0).toFixed(1);
+
+        const sym = mode === 'domestic' ? '₩' : '$';
+        const fmtTick = v => {
+            if (levelMetric === 'avg_profit_rate') return (v >= 0 ? '+' : '') + v.toFixed(1) + '%';
+            const abs = Math.abs(v);
+            const sign = v < 0 ? '-' : '';
+            if (abs >= 1e9) return sign + sym + (abs / 1e9).toFixed(1) + 'B';
+            if (abs >= 1e6) return sign + sym + (abs / 1e6).toFixed(1) + 'M';
+            if (abs >= 1e3) return sign + sym + (abs / 1e3).toFixed(1) + 'K';
+            return sign + sym + abs.toFixed(0);
+        };
+
+        const fmtTooltip = (s) => levelMetric === 'total_pnl'
+            ? `총 실현수익: ${(s.total_pnl >= 0 ? '+' : '') + fmtTick(s.total_pnl)}`
+            : `평균 수익률: ${s.avg_profit_rate != null ? (s.avg_profit_rate >= 0 ? '+' : '') + s.avg_profit_rate.toFixed(2) + '%' : '-'}`;
+
+        let barsHtml = '', xLabelsHtml = '';
+        stats.forEach((s, i) => {
+            const v = values[i];
+            const x = PAD.left + i * (chartW / labels.length) + (chartW / labels.length - barW) / 2;
+            const color = v >= 0 ? SUCCESS : DANGER;
+            const barTop = Math.min(yPos(v), Number(zeroY));
+            const barH = Math.abs(yPos(v) - Number(zeroY));
+            barsHtml += `<rect x="${x.toFixed(1)}" y="${barTop.toFixed(1)}" width="${barW}" height="${Math.max(barH, 1).toFixed(1)}" fill="${color}" rx="2"><title>Lv${s.level} | ${fmtTooltip(s)} | ${s.sell_count}건 승률${s.win_rate != null ? s.win_rate.toFixed(0) + '%' : '-'}</title></rect>`;
+            xLabelsHtml += `<text x="${(x + barW / 2).toFixed(1)}" y="${(PAD.top + chartH + 14).toFixed(1)}" text-anchor="middle" class="earnings-bar-axis">Lv${escapeHtml(String(s.level))}</text>`;
+        });
+
+        const tickValues = [yMin, (yMin + yMax) / 2, yMax].filter((v, i, a) => a.indexOf(v) === i);
+        const yTicksHtml = tickValues.map(v =>
+            `<text x="${(PAD.left - 5).toFixed(1)}" y="${yPos(v).toFixed(1)}" text-anchor="end" dominant-baseline="middle" class="earnings-bar-axis">${escapeHtml(fmtTick(v))}</text>`
+        ).join('');
+
+        const ariaLabel = levelMetric === 'total_pnl' ? '차수별 총 실현수익' : '차수별 평균 수익률';
+        container.innerHTML = `<svg viewBox="0 0 ${W} ${H}" class="earnings-bar-svg" role="img" aria-label="${ariaLabel}">
+            <line x1="${PAD.left}" y1="${zeroY}" x2="${(PAD.left + chartW).toFixed(1)}" y2="${zeroY}" stroke="#d1d5db" stroke-width="1"/>
+            ${barsHtml}${yTicksHtml}${xLabelsHtml}
+        </svg>`;
+    }
+
+    function renderLevelStatsTable(stats, mode) {
+        const el = document.getElementById('level-stats-table');
+        if (!el) return;
+
+        const isDomestic = mode === 'domestic';
+
+        const rows = stats.map(s => {
+            const pnlCls = s.total_pnl >= 0 ? 'pct-positive' : 'pct-negative';
+            const pnlSign = s.total_pnl > 0 ? '+' : '';
+            const pnlStr = new Intl.NumberFormat(isDomestic ? 'ko-KR' : 'en-US', {
+                style: 'currency', currency: isDomestic ? 'KRW' : 'USD',
+                minimumFractionDigits: isDomestic ? 0 : 2, maximumFractionDigits: isDomestic ? 0 : 2
+            }).format(s.total_pnl);
+
+            const rateCls = s.avg_profit_rate != null ? (s.avg_profit_rate >= 0 ? 'pct-positive' : 'pct-negative') : '';
+            const rateStr = s.avg_profit_rate != null
+                ? `<span class="${rateCls}">${s.avg_profit_rate >= 0 ? '+' : ''}${s.avg_profit_rate.toFixed(2)}%</span>` : '-';
+
+            // win rate dot indicator (up to 5 dots)
+            const winDots = s.win_rate != null ? buildWinDots(s.win_rate) : '-';
+            const winRateStr = s.win_rate != null ? s.win_rate.toFixed(0) + '%' : '-';
+
+            return `<tr>
+                <td style="text-align:center"><span class="level-badge" data-level="${Math.min(s.level, 5)}">Lv${s.level}</span></td>
+                <td style="text-align:center;color:var(--text-muted)">${s.sell_count}건</td>
+                <td style="text-align:center"><span class="win-dots">${winDots}</span> ${winRateStr}</td>
+                <td style="text-align:right">${rateStr}</td>
+                <td class="${pnlCls}" style="text-align:right">${pnlSign}${escapeHtml(pnlStr)}</td>
+            </tr>`;
+        }).join('');
+
+        el.innerHTML = `
+            <div class="card" style="padding:0;overflow-x:auto">
+                <table class="history-table">
+                    <thead><tr>
+                        <th style="text-align:center">차수</th>
+                        <th style="text-align:center">매도건수</th>
+                        <th style="text-align:center">승률</th>
+                        <th style="text-align:right">평균 수익률</th>
+                        <th style="text-align:right">총 실현수익</th>
+                    </tr></thead>
+                    <tbody>${rows}</tbody>
+                </table>
+            </div>`;
+    }
+
+    function buildWinDots(winRate) {
+        // 5 dots: filled proportional to win rate
+        const filled = Math.round(winRate / 20); // 0-5
+        return Array.from({ length: 5 }, (_, i) =>
+            `<span class="win-dot${i < filled ? ' filled' : ''}"></span>`
+        ).join('');
     }
 
     return { render };

--- a/docs/js/views/earnings-view.js
+++ b/docs/js/views/earnings-view.js
@@ -5,8 +5,15 @@ window.EarningsView = (function () {
     const { escapeHtml, formatTickerLabel } = window.FormatUtils;
 
     let selectedYear = undefined;  // undefined=not init, null=all, "2026"=specific year
-    let selectedMonth = null; // "05" or null (all)
+    let selectedMonth = null;      // "05" or null (all)
     let _currencyMode = 'domestic';
+
+    // Ticker summary state
+    let tickerSortKey = 'total_pnl';
+    let tickerSortAsc = false;
+    let tickerStatusFilter = '';   // '' | '보유중' | '청산완료'
+    let tickerSearch = '';
+    let selectedTicker = null;
 
     function formatAmt(value, mode) {
         const isDomestic = (mode || 'domestic') === 'domestic';
@@ -33,8 +40,11 @@ window.EarningsView = (function () {
         renderMonthFilter();
         renderSummaryCards();
         renderBarChart();
-        renderTickerTable();
+        renderPeriodTickerTable();
+        renderTickerSummarySection();
     }
+
+    // ── Period filters ───────────────────────────────────────────────────────
 
     function renderYearFilter(years) {
         const container = document.getElementById('earnings-year-filter');
@@ -68,8 +78,7 @@ window.EarningsView = (function () {
             const m = String(i + 1).padStart(2, '0');
             const hasData = monthsWithData.has(m);
             const isActive = selectedMonth === m;
-            const dimClass = hasData ? '' : ' dim';
-            return `<button class="filter-chip${isActive ? ' active' : ''}${dimClass}" data-month="${m}" ${hasData ? '' : 'disabled'}>${MONTH_LABELS[i]}</button>`;
+            return `<button class="filter-chip${isActive ? ' active' : ''}${hasData ? '' : ' dim'}" data-month="${m}" ${hasData ? '' : 'disabled'}>${MONTH_LABELS[i]}</button>`;
         }).join('');
 
         container.innerHTML = `<span class="earnings-filter-label">월</span>${allBtn}${monthBtns}`;
@@ -81,6 +90,8 @@ window.EarningsView = (function () {
             });
         });
     }
+
+    // ── Summary cards ────────────────────────────────────────────────────────
 
     function renderSummaryCards() {
         const container = document.getElementById('earnings-summary-cards');
@@ -120,169 +131,82 @@ window.EarningsView = (function () {
             </div>`;
     }
 
+    // ── Bar charts ───────────────────────────────────────────────────────────
+
     function renderBarChart() {
         const container = document.getElementById('earnings-bar-chart');
         if (!container) return;
-
-        // Bar chart only makes sense for a specific year or all-time with monthly breakdown
-        const year = selectedYear;
-        if (!year) {
-            // Show all-years summary bar chart (one bar per year)
-            renderYearBarChart(container);
-            return;
-        }
-        renderMonthBarChart(container, year);
+        if (!selectedYear) { renderYearBarChart(container); return; }
+        renderMonthBarChart(container, selectedYear);
     }
 
-    function renderMonthBarChart(container, year) {
-        const months = EarningsModel.getYearMonthly(year);
-        const MONTH_SHORT = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-
-        const values = months.map(m => m.realized_pnl);
-
-        const W = 560, H = 200;
-        const PAD = { top: 24, right: 12, bottom: 36, left: 64 };
+    function buildBarSvg(labels, values, W, H, PAD, mode, highlightIdx) {
         const chartW = W - PAD.left - PAD.right;
         const chartH = H - PAD.top - PAD.bottom;
-        const barW = Math.floor(chartW / 12) - 4;
-
-        const mode = _currencyMode;
-        const SUCCESS = '#10b981';
-        const DANGER = '#ef4444';
-        const MUTED = '#6b7280';
+        const barW = Math.max(4, Math.floor(chartW / labels.length) - 4);
+        const SUCCESS = '#10b981', DANGER = '#ef4444', MUTED = '#6b7280';
 
         const yMin = Math.min(0, ...values) * 1.15;
         const yMax = Math.max(0, ...values) * 1.15;
         const yRange = (yMax - yMin) || 1;
 
-        function yPos(v) {
-            return PAD.top + chartH - ((v - yMin) / yRange) * chartH;
-        }
-
+        const yPos = v => PAD.top + chartH - ((v - yMin) / yRange) * chartH;
         const zeroY = yPos(0).toFixed(1);
 
-        const compactLabel = (v) => {
+        const sym = mode === 'domestic' ? '₩' : '$';
+        const compactLabel = v => {
             const abs = Math.abs(v);
-            const sym = mode === 'domestic' ? '₩' : '$';
-            if (abs >= 1_000_000_000) return sym + (v / 1_000_000_000).toFixed(1) + 'B';
-            if (abs >= 1_000_000) return sym + (v / 1_000_000).toFixed(1) + 'M';
-            if (abs >= 1_000) return sym + (v / 1_000).toFixed(1) + 'K';
+            if (abs >= 1e9) return sym + (v / 1e9).toFixed(1) + 'B';
+            if (abs >= 1e6) return sym + (v / 1e6).toFixed(1) + 'M';
+            if (abs >= 1e3) return sym + (v / 1e3).toFixed(1) + 'K';
             return sym + v.toFixed(0);
         };
 
-        let barsHtml = '';
-        let xLabelsHtml = '';
-
-        months.forEach((m, i) => {
-            const x = PAD.left + i * (chartW / 12) + (chartW / 12 - barW) / 2;
-            const v = m.realized_pnl;
+        let barsHtml = '', xLabelsHtml = '';
+        values.forEach((v, i) => {
+            const x = PAD.left + i * (chartW / labels.length) + (chartW / labels.length - barW) / 2;
             const color = v >= 0 ? SUCCESS : DANGER;
             const barTop = Math.min(yPos(v), Number(zeroY));
             const barH = Math.abs(yPos(v) - Number(zeroY));
-
-            const isSelected = selectedMonth === m.month;
-            const opacity = (!selectedMonth || isSelected) ? '1' : '0.35';
-
-            if (m.has_data) {
-                barsHtml += `<rect x="${x.toFixed(1)}" y="${barTop.toFixed(1)}" width="${barW}" height="${Math.max(barH, 1).toFixed(1)}" fill="${color}" opacity="${opacity}" rx="2">
-                    <title>${MONTH_SHORT[i]}: ${formatAmt(v, mode)}</title>
-                </rect>`;
+            const opacity = (highlightIdx == null || highlightIdx === i) ? '1' : '0.35';
+            if (v !== 0) {
+                barsHtml += `<rect x="${x.toFixed(1)}" y="${barTop.toFixed(1)}" width="${barW}" height="${Math.max(barH, 1).toFixed(1)}" fill="${color}" opacity="${opacity}" rx="2"><title>${escapeHtml(labels[i])}: ${formatAmt(v, mode)}</title></rect>`;
             }
-
-            const labelX = (x + barW / 2).toFixed(1);
-            const labelY = (PAD.top + chartH + 14).toFixed(1);
-            const labelFill = m.has_data ? (mode === 'domestic' ? '#374151' : MUTED) : MUTED;
-            xLabelsHtml += `<text x="${labelX}" y="${labelY}" text-anchor="middle" class="earnings-bar-axis" fill="${labelFill}">${MONTH_SHORT[i]}</text>`;
+            const labelFill = v !== 0 ? '#374151' : MUTED;
+            xLabelsHtml += `<text x="${(x + barW / 2).toFixed(1)}" y="${(PAD.top + chartH + 14).toFixed(1)}" text-anchor="middle" class="earnings-bar-axis" fill="${labelFill}">${escapeHtml(labels[i])}</text>`;
         });
 
-        // y-axis ticks
         const tickValues = [yMin, (yMin + yMax) / 2, yMax].filter((v, i, a) => a.indexOf(v) === i);
-        const yTicksHtml = tickValues.map(v => {
-            const y = yPos(v).toFixed(1);
-            return `<text x="${(PAD.left - 6).toFixed(1)}" y="${y}" text-anchor="end" dominant-baseline="middle" class="earnings-bar-axis">${compactLabel(v)}</text>`;
-        }).join('');
+        const yTicksHtml = tickValues.map(v =>
+            `<text x="${(PAD.left - 6).toFixed(1)}" y="${yPos(v).toFixed(1)}" text-anchor="end" dominant-baseline="middle" class="earnings-bar-axis">${compactLabel(v)}</text>`
+        ).join('');
 
-        container.innerHTML = `
-            <svg viewBox="0 0 ${W} ${H}" class="earnings-bar-svg" role="img" aria-label="${escapeHtml(year)} 월별 실현수익">
-                <line x1="${PAD.left}" y1="${zeroY}" x2="${(PAD.left + chartW).toFixed(1)}" y2="${zeroY}" stroke="#d1d5db" stroke-width="1"/>
-                ${barsHtml}
-                ${yTicksHtml}
-                ${xLabelsHtml}
-            </svg>`;
+        return `<line x1="${PAD.left}" y1="${zeroY}" x2="${(PAD.left + chartW).toFixed(1)}" y2="${zeroY}" stroke="#d1d5db" stroke-width="1"/>${barsHtml}${yTicksHtml}${xLabelsHtml}`;
+    }
+
+    function renderMonthBarChart(container, year) {
+        const months = EarningsModel.getYearMonthly(year);
+        const MONTH_SHORT = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+        const labels = MONTH_SHORT;
+        const values = months.map(m => m.realized_pnl);
+        const highlightIdx = selectedMonth ? (parseInt(selectedMonth, 10) - 1) : null;
+        const PAD = { top: 24, right: 12, bottom: 36, left: 64 };
+        const inner = buildBarSvg(labels, values, 560, 200, PAD, _currencyMode, highlightIdx);
+        container.innerHTML = `<svg viewBox="0 0 560 200" class="earnings-bar-svg" role="img" aria-label="${escapeHtml(year)} 월별 실현수익">${inner}</svg>`;
     }
 
     function renderYearBarChart(container) {
         const years = EarningsModel.getAvailableYears();
-        if (years.length === 0) {
-            container.innerHTML = '<p class="empty-state">데이터 없음</p>';
-            return;
-        }
-
-        const yearData = years.map(y => {
-            const s = EarningsModel.getPeriodSummary(y, null);
-            return { year: y, realized_pnl: s.realized_pnl };
-        });
-
-        const W = 560, H = 180;
+        if (years.length === 0) { container.innerHTML = '<p class="empty-state">데이터 없음</p>'; return; }
+        const values = years.map(y => EarningsModel.getPeriodSummary(y, null).realized_pnl);
         const PAD = { top: 24, right: 12, bottom: 36, left: 64 };
-        const chartW = W - PAD.left - PAD.right;
-        const chartH = H - PAD.top - PAD.bottom;
-        const barW = Math.min(60, Math.floor(chartW / yearData.length) - 8);
-        const mode = _currencyMode;
-        const SUCCESS = '#10b981';
-        const DANGER = '#ef4444';
-
-        const values = yearData.map(d => d.realized_pnl);
-        const yMin = Math.min(0, ...values) * 1.15;
-        const yMax = Math.max(0, ...values) * 1.15 || 1;
-        const yRange = (yMax - yMin) || 1;
-
-        function yPos(v) {
-            return PAD.top + chartH - ((v - yMin) / yRange) * chartH;
-        }
-        const zeroY = yPos(0).toFixed(1);
-
-        const compactLabel = (v) => {
-            const abs = Math.abs(v);
-            const sym = mode === 'domestic' ? '₩' : '$';
-            if (abs >= 1_000_000_000) return sym + (v / 1_000_000_000).toFixed(1) + 'B';
-            if (abs >= 1_000_000) return sym + (v / 1_000_000).toFixed(1) + 'M';
-            if (abs >= 1_000) return sym + (v / 1_000).toFixed(1) + 'K';
-            return sym + v.toFixed(0);
-        };
-
-        let barsHtml = '';
-        let xLabelsHtml = '';
-
-        yearData.forEach((d, i) => {
-            const x = PAD.left + i * (chartW / yearData.length) + (chartW / yearData.length - barW) / 2;
-            const v = d.realized_pnl;
-            const color = v >= 0 ? SUCCESS : DANGER;
-            const barTop = Math.min(yPos(v), Number(zeroY));
-            const barH = Math.abs(yPos(v) - Number(zeroY));
-            barsHtml += `<rect x="${x.toFixed(1)}" y="${barTop.toFixed(1)}" width="${barW}" height="${Math.max(barH, 1).toFixed(1)}" fill="${color}" rx="2">
-                <title>${escapeHtml(d.year)}: ${formatAmt(v, mode)}</title>
-            </rect>`;
-            const labelX = (x + barW / 2).toFixed(1);
-            xLabelsHtml += `<text x="${labelX}" y="${(PAD.top + chartH + 14).toFixed(1)}" text-anchor="middle" class="earnings-bar-axis">${escapeHtml(d.year)}</text>`;
-        });
-
-        const tickValues = [yMin, (yMin + yMax) / 2, yMax].filter((v, i, a) => a.indexOf(v) === i);
-        const yTicksHtml = tickValues.map(v => {
-            const y = yPos(v).toFixed(1);
-            return `<text x="${(PAD.left - 6).toFixed(1)}" y="${y}" text-anchor="end" dominant-baseline="middle" class="earnings-bar-axis">${compactLabel(v)}</text>`;
-        }).join('');
-
-        container.innerHTML = `
-            <svg viewBox="0 0 ${W} ${H}" class="earnings-bar-svg" role="img" aria-label="연도별 실현수익">
-                <line x1="${PAD.left}" y1="${zeroY}" x2="${(PAD.left + chartW).toFixed(1)}" y2="${zeroY}" stroke="#d1d5db" stroke-width="1"/>
-                ${barsHtml}
-                ${yTicksHtml}
-                ${xLabelsHtml}
-            </svg>`;
+        const inner = buildBarSvg(years, values, 560, 180, PAD, _currencyMode, null);
+        container.innerHTML = `<svg viewBox="0 0 560 180" class="earnings-bar-svg" role="img" aria-label="연도별 실현수익">${inner}</svg>`;
     }
 
-    function renderTickerTable(container) {
+    // ── Period ticker breakdown (existing, period-filtered) ──────────────────
+
+    function renderPeriodTickerTable() {
         const el = document.getElementById('earnings-ticker-table');
         if (!el) return;
 
@@ -310,16 +234,266 @@ window.EarningsView = (function () {
         el.innerHTML = `
             <div class="card" style="padding:0;overflow-x:auto">
                 <table class="history-table">
-                    <thead>
-                        <tr>
-                            <th>종목</th>
-                            <th style="text-align:right">실현수익</th>
-                            <th style="text-align:center">매도건수</th>
-                        </tr>
-                    </thead>
+                    <thead><tr>
+                        <th>종목</th>
+                        <th style="text-align:right">실현수익</th>
+                        <th style="text-align:center">매도건수</th>
+                    </tr></thead>
                     <tbody>${rows}</tbody>
                 </table>
             </div>`;
+    }
+
+    // ── Ticker comprehensive summary (all-time, from status.json) ────────────
+
+    function renderTickerSummarySection() {
+        const section = document.getElementById('earnings-ticker-summary-section');
+        if (!section) return;
+
+        const summaries = EarningsModel.getTickerSummaries();
+        const mode = _currencyMode;
+
+        // search + status filter controls
+        section.innerHTML = `
+            <div class="ticker-summary-controls">
+                <input id="ticker-summary-search" class="ticker-search-input" type="text" placeholder="종목명/코드 검색..." value="${escapeHtml(tickerSearch)}">
+                <div class="filter-chips" role="group">
+                    <button class="filter-chip${tickerStatusFilter === '' ? ' active' : ''}" data-status="">전체</button>
+                    <button class="filter-chip${tickerStatusFilter === '보유중' ? ' active' : ''}" data-status="보유중">보유중</button>
+                    <button class="filter-chip${tickerStatusFilter === '청산완료' ? ' active' : ''}" data-status="청산완료">청산완료</button>
+                </div>
+            </div>
+            <div id="ticker-summary-table-wrap"></div>
+            <div id="ticker-detail-panel" class="ticker-detail-panel" style="display:none"></div>`;
+
+        // search input event
+        const searchInput = section.querySelector('#ticker-summary-search');
+        searchInput.addEventListener('input', () => {
+            tickerSearch = searchInput.value;
+            renderTickerSummaryTable(summaries, mode);
+        });
+
+        // status filter events
+        section.querySelectorAll('.filter-chips .filter-chip').forEach(btn => {
+            btn.addEventListener('click', () => {
+                tickerStatusFilter = btn.dataset.status;
+                section.querySelectorAll('.filter-chips .filter-chip').forEach(b => b.classList.toggle('active', b.dataset.status === tickerStatusFilter));
+                renderTickerSummaryTable(summaries, mode);
+            });
+        });
+
+        renderTickerSummaryTable(summaries, mode);
+
+        if (selectedTicker) {
+            renderTickerDetailPanel(selectedTicker, mode);
+        }
+    }
+
+    function getFilteredSummaries(summaries) {
+        return summaries
+            .filter(s => {
+                if (tickerStatusFilter && s.status !== tickerStatusFilter) return false;
+                if (tickerSearch) {
+                    const q = tickerSearch.toLowerCase();
+                    if (!s.ticker.toLowerCase().includes(q) && !s.alias.toLowerCase().includes(q)) return false;
+                }
+                return true;
+            })
+            .sort((a, b) => {
+                const va = a[tickerSortKey];
+                const vb = b[tickerSortKey];
+                const dir = tickerSortAsc ? 1 : -1;
+                if (va == null && vb == null) return 0;
+                if (va == null) return 1;
+                if (vb == null) return -1;
+                return va < vb ? -dir : va > vb ? dir : 0;
+            });
+    }
+
+    function renderTickerSummaryTable(summaries, mode) {
+        const wrap = document.getElementById('ticker-summary-table-wrap');
+        if (!wrap) return;
+
+        const filtered = getFilteredSummaries(summaries);
+
+        if (filtered.length === 0) {
+            wrap.innerHTML = '<p class="empty-state">해당 조건의 종목이 없습니다.</p>';
+            return;
+        }
+
+        const COLS = [
+            { key: 'alias',         label: '종목',     align: 'left'  },
+            { key: 'total_pnl',     label: '총손익',    align: 'right' },
+            { key: 'realized_pnl',  label: '실현손익',  align: 'right' },
+            { key: 'unrealized_pnl',label: '평가손익',  align: 'right' },
+            { key: 'sell_count',    label: '매도건수',  align: 'center'},
+            { key: 'win_rate',      label: '승률',      align: 'center'},
+            { key: 'status',        label: '상태',      align: 'center'},
+        ];
+
+        const headerCells = COLS.map(c => {
+            const isActive = tickerSortKey === c.key;
+            const arrow = isActive ? (tickerSortAsc ? ' ▲' : ' ▼') : '';
+            return `<th class="ts-th${isActive ? ' ts-th-active' : ''}" data-sort-key="${c.key}" style="text-align:${c.align};cursor:pointer">${c.label}${arrow}</th>`;
+        }).join('');
+
+        const rows = filtered.map(s => {
+            const isSelected = selectedTicker === s.ticker;
+            const totalCls = s.total_pnl >= 0 ? 'pct-positive' : 'pct-negative';
+            const totalSign = s.total_pnl > 0 ? '+' : '';
+            const realCls = s.realized_pnl >= 0 ? 'pct-positive' : 'pct-negative';
+            const realSign = s.realized_pnl > 0 ? '+' : '';
+            const unrCls = s.unrealized_pnl >= 0 ? 'pct-positive' : 'pct-negative';
+            const unrSign = s.unrealized_pnl > 0 ? '+' : '';
+            const winRateStr = s.win_rate != null ? s.win_rate.toFixed(0) + '%' : '-';
+            const statusBadge = s.status === '보유중'
+                ? `<span class="ts-status-badge ts-status-held">보유중</span>`
+                : `<span class="ts-status-badge ts-status-closed">청산</span>`;
+            const label = escapeHtml(formatTickerLabel(s.ticker, s.alias));
+            return `<tr class="ts-row${isSelected ? ' ts-row-selected' : ''}" data-ticker="${escapeHtml(s.ticker)}" style="cursor:pointer">
+                <td><strong>${label}</strong></td>
+                <td class="${totalCls}" style="text-align:right">${totalSign}${escapeHtml(formatAmt(s.total_pnl, mode))}</td>
+                <td class="${realCls}" style="text-align:right">${realSign}${escapeHtml(formatAmt(s.realized_pnl, mode))}</td>
+                <td class="${s.unrealized_pnl !== 0 ? unrCls : ''}" style="text-align:right">${s.unrealized_pnl !== 0 ? unrSign + escapeHtml(formatAmt(s.unrealized_pnl, mode)) : '-'}</td>
+                <td style="text-align:center;color:var(--text-muted)">${s.sell_count}건</td>
+                <td style="text-align:center">${winRateStr}</td>
+                <td style="text-align:center">${statusBadge}</td>
+            </tr>`;
+        }).join('');
+
+        wrap.innerHTML = `
+            <div class="card" style="padding:0;overflow-x:auto">
+                <table class="history-table ts-table">
+                    <thead><tr>${headerCells}</tr></thead>
+                    <tbody>${rows}</tbody>
+                </table>
+                <div class="ts-note">* 전체 기간 기준 (상단 연도/월 필터 미적용)</div>
+            </div>`;
+
+        // sort header click
+        wrap.querySelectorAll('.ts-th').forEach(th => {
+            th.addEventListener('click', () => {
+                const key = th.dataset.sortKey;
+                if (tickerSortKey === key) {
+                    tickerSortAsc = !tickerSortAsc;
+                } else {
+                    tickerSortKey = key;
+                    tickerSortAsc = key === 'alias';
+                }
+                renderTickerSummaryTable(summaries, mode);
+            });
+        });
+
+        // row click -> detail panel
+        wrap.querySelectorAll('.ts-row').forEach(row => {
+            row.addEventListener('click', () => {
+                const ticker = row.dataset.ticker;
+                if (selectedTicker === ticker) {
+                    selectedTicker = null;
+                    const panel = document.getElementById('ticker-detail-panel');
+                    if (panel) panel.style.display = 'none';
+                    row.classList.remove('ts-row-selected');
+                } else {
+                    selectedTicker = ticker;
+                    wrap.querySelectorAll('.ts-row').forEach(r => r.classList.toggle('ts-row-selected', r.dataset.ticker === ticker));
+                    renderTickerDetailPanel(ticker, mode);
+                }
+            });
+        });
+    }
+
+    function renderTickerDetailPanel(ticker, mode) {
+        const panel = document.getElementById('ticker-detail-panel');
+        if (!panel) return;
+
+        const detail = EarningsModel.getTickerDetail(ticker);
+        panel.style.display = '';
+
+        // mini monthly bar chart for this ticker
+        let chartHtml = '';
+        if (detail.monthly.length > 0) {
+            const labels = detail.monthly.map(m => m.yearMonth.slice(2)); // "26-05"
+            const values = detail.monthly.map(m => m.pnl);
+            const PAD = { top: 16, right: 8, bottom: 28, left: 56 };
+            const inner = buildBarSvg(labels, values, 480, 140, PAD, mode, null);
+            chartHtml = `
+                <div class="ticker-detail-chart">
+                    <div class="ticker-detail-section-title">월별 실현수익</div>
+                    <svg viewBox="0 0 480 140" class="earnings-bar-svg" role="img" aria-label="${escapeHtml(detail.alias)} 월별 실현수익">${inner}</svg>
+                </div>`;
+        }
+
+        // lots (current holdings)
+        let lotsHtml = '';
+        if (detail.lots.length > 0) {
+            const lotRows = detail.lots.map(lot => {
+                const pct = lot.pct_change != null ? Number(lot.pct_change) : null;
+                const pctStr = pct != null ? `<span class="${pct >= 0 ? 'pct-positive' : 'pct-negative'}">${pct >= 0 ? '+' : ''}${pct.toFixed(1)}%</span>` : '-';
+                return `<tr>
+                    <td>${escapeHtml(lot.buy_date || '')}</td>
+                    <td style="text-align:center">${lot.level != null ? `Lv${lot.level}` : '-'}</td>
+                    <td style="text-align:right">${lot.quantity}주 @${escapeHtml(formatAmt(lot.buy_price, mode))}</td>
+                    <td style="text-align:right">${pctStr}</td>
+                </tr>`;
+            }).join('');
+            lotsHtml = `
+                <div class="ticker-detail-section-title" style="margin-top:12px">현재 보유 Lot</div>
+                <div style="overflow-x:auto">
+                    <table class="history-table">
+                        <thead><tr><th>매수일</th><th style="text-align:center">차수</th><th style="text-align:right">수량/단가</th><th style="text-align:right">수익률</th></tr></thead>
+                        <tbody>${lotRows}</tbody>
+                    </table>
+                </div>`;
+        }
+
+        // trade history
+        let tradesHtml = '';
+        if (detail.trades.length > 0) {
+            const tradeRows = detail.trades.map(t => {
+                const pnlCls = t.realized_pnl >= 0 ? 'pct-positive' : 'pct-negative';
+                const pnlSign = t.realized_pnl > 0 ? '+' : '';
+                const rateStr = t.profit_rate != null
+                    ? `<span class="${t.profit_rate >= 0 ? 'pct-positive' : 'pct-negative'}">${t.profit_rate >= 0 ? '+' : ''}${t.profit_rate.toFixed(2)}%</span>`
+                    : '-';
+                const lvDisplay = t.level !== '' ? `Lv${t.level}` : '-';
+                return `<tr>
+                    <td>${escapeHtml(t.date)}</td>
+                    <td style="text-align:center">${lvDisplay}</td>
+                    <td style="text-align:right">${t.qty}주 @${escapeHtml(formatAmt(t.sell_price, mode))}</td>
+                    <td style="text-align:right">${t.buy_price != null ? escapeHtml(formatAmt(t.buy_price, mode)) : '-'}</td>
+                    <td class="${pnlCls}" style="text-align:right">${pnlSign}${escapeHtml(formatAmt(t.realized_pnl, mode))}</td>
+                    <td style="text-align:right">${rateStr}</td>
+                </tr>`;
+            }).join('');
+            tradesHtml = `
+                <div class="ticker-detail-section-title" style="margin-top:12px">매도 내역</div>
+                <div style="overflow-x:auto">
+                    <table class="history-table">
+                        <thead><tr><th>날짜</th><th style="text-align:center">차수</th><th style="text-align:right">수량/매도가</th><th style="text-align:right">매수가</th><th style="text-align:right">수익금</th><th style="text-align:right">수익률</th></tr></thead>
+                        <tbody>${tradeRows}</tbody>
+                    </table>
+                </div>`;
+        } else {
+            tradesHtml = '<p class="empty-state" style="margin-top:8px">매도 내역 없음</p>';
+        }
+
+        panel.innerHTML = `
+            <div class="ticker-detail-header">
+                <span class="ticker-detail-title">${escapeHtml(formatTickerLabel(ticker, detail.alias))}</span>
+                <button class="ticker-detail-close" id="ticker-detail-close-btn">✕ 닫기</button>
+            </div>
+            ${chartHtml}
+            ${lotsHtml}
+            ${tradesHtml}`;
+
+        panel.querySelector('#ticker-detail-close-btn').addEventListener('click', () => {
+            selectedTicker = null;
+            panel.style.display = 'none';
+            const wrap = document.getElementById('ticker-summary-table-wrap');
+            if (wrap) wrap.querySelectorAll('.ts-row').forEach(r => r.classList.remove('ts-row-selected'));
+        });
+
+        panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     }
 
     return { render };

--- a/docs/js/views/earnings-view.js
+++ b/docs/js/views/earnings-view.js
@@ -156,10 +156,11 @@ window.EarningsView = (function () {
         const sym = mode === 'domestic' ? '₩' : '$';
         const compactLabel = v => {
             const abs = Math.abs(v);
-            if (abs >= 1e9) return sym + (v / 1e9).toFixed(1) + 'B';
-            if (abs >= 1e6) return sym + (v / 1e6).toFixed(1) + 'M';
-            if (abs >= 1e3) return sym + (v / 1e3).toFixed(1) + 'K';
-            return sym + v.toFixed(0);
+            const sign = v < 0 ? '-' : '';
+            if (abs >= 1e9) return sign + sym + (abs / 1e9).toFixed(1) + 'B';
+            if (abs >= 1e6) return sign + sym + (abs / 1e6).toFixed(1) + 'M';
+            if (abs >= 1e3) return sign + sym + (abs / 1e3).toFixed(1) + 'K';
+            return sign + sym + abs.toFixed(0);
         };
 
         let barsHtml = '', xLabelsHtml = '';
@@ -396,13 +397,13 @@ window.EarningsView = (function () {
                 } else {
                     selectedTicker = ticker;
                     wrap.querySelectorAll('.ts-row').forEach(r => r.classList.toggle('ts-row-selected', r.dataset.ticker === ticker));
-                    renderTickerDetailPanel(ticker, mode);
+                    renderTickerDetailPanel(ticker, mode, true);
                 }
             });
         });
     }
 
-    function renderTickerDetailPanel(ticker, mode) {
+    function renderTickerDetailPanel(ticker, mode, shouldScroll = false) {
         const panel = document.getElementById('ticker-detail-panel');
         if (!panel) return;
 
@@ -493,7 +494,7 @@ window.EarningsView = (function () {
             if (wrap) wrap.querySelectorAll('.ts-row').forEach(r => r.classList.remove('ts-row-selected'));
         });
 
-        panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        if (shouldScroll) panel.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     }
 
     return { render };


### PR DESCRIPTION
## Summary

- **EarningsModel** 확장: `getTickerSummaries()`, `getTickerDetail()` 추가
- **EarningsView** 확장: 종목별 종합수익 테이블 + 상세 패널 추가
- **bar chart 공통 헬퍼** `buildBarSvg()` 로 기존 월별/연도별 차트 코드 통합(DRY)

## 화면 구성

### 종목별 종합수익 테이블 (상단 기간 필터 미적용, 전체 기간)

| 컬럼 | 설명 |
|------|------|
| 종목 | ticker + alias |
| 총손익 | 실현손익 + 현재 평가손익 |
| 실현손익 | `realized_pnl_by_ticker` 또는 `positions.realized_pnl` |
| 평가손익 | `positions.unrealized_pnl` (보유 중인 경우만) |
| 매도건수 | history.json SELL 집계 |
| 승률 | 수익 거래 / 전체 매도 건수 |
| 상태 | 보유중 / 청산완료 |

- **컬럼 클릭** → 정렬 (asc/desc 토글)
- **텍스트 검색** → 종목코드·종목명 부분 일치 실시간 필터
- **상태 필터** → 전체 / 보유중 / 청산완료
- **청산 종목도 표시** (`realized_pnl_by_ticker` 활용)

### 종목 상세 패널 (행 클릭 시 인라인 표시)

- 월별 실현수익 미니 바 차트 (해당 종목만)
- 현재 보유 Lot 테이블 (보유 중인 경우)
- 전체 매도 내역 테이블 (날짜·차수·매도가·매수가·수익금·수익률)

## Test plan

- [ ] Earnings 탭 → 종목별 종합수익 테이블 표시 확인
- [ ] 컬럼 헤더 클릭 → 정렬 동작 확인 (총손익·승률 등)
- [ ] 검색창에 종목명 입력 → 실시간 필터 확인
- [ ] 보유중/청산완료 필터 확인
- [ ] 행 클릭 → 상세 패널 (차트·lots·매도내역) 표시 확인
- [ ] 상세 패널 "닫기" 클릭 → 패널 닫힘 + 행 선택 해제 확인
- [ ] domestic/overseas/backtest 모드 전환 후 정상 표시 확인
- [ ] pytest 381 passed (JS 변경이므로 Python 테스트 영향 없음)

https://claude.ai/code/session_011r9Wf1PXaqnLS5d2jC6TpU

---
_Generated by [Claude Code](https://claude.ai/code/session_011r9Wf1PXaqnLS5d2jC6TpU)_