### PR TITLE
Add concurrency group to trading bot workflows (prevent simultaneous runs)

### DIFF
--- a/.github/workflows/trading-bot-domestic.yml
+++ b/.github/workflows/trading-bot-domestic.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: trading-domestic
+  cancel-in-progress: false
+
 jobs:
   trade-domestic:
     runs-on: ubuntu-latest

--- a/.github/workflows/trading-bot-overseas.yml
+++ b/.github/workflows/trading-bot-overseas.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: trading-overseas
+  cancel-in-progress: false
+
 jobs:
   trade-overseas:
     runs-on: ubuntu-latest


### PR DESCRIPTION
$(cat <<'EOF'
## 검토 결과 요약

`trading-bot-domestic.yml` 워크플로우를 하루 여러 번 호출해도 되는지 분석한 결과, **순차 실행은 안전하지만 동시 실행 시 상태 불일치 위험**이 있어 `concurrency` 그룹을 추가합니다.

## 분석 결과

### ✅ 안전한 부분 (하루 여러 번 실행 가능)

- **상태 영속성**: 각 실행 후 positions.json/history.json 등이 git 커밋되므로, 다음 실행의 `checkout`이 최신 상태를 가져옴
- **비즈니스 로직 멱등성**: 가격이 임계치를 넘지 않으면 중복 신호 없음. 가격이 추가 하락하면 다음 차수 매수가 발동하는 것은 의도된 동작
- **트레일링 스톱**: `trailing_highest_price`가 positions.json에 저장·복원되어 실행 간 고점 추적 정확히 이어짐

### ⚠️ 문제: 동시 실행 시 상태 불일치

`concurrency` 그룹이 없으면 두 실행이 동시에 진행될 수 있음:

```
Run A: checkout (상태 S0) → KIS 매수 주문 실행 → 커밋/푸시 성공 (S1)
Run B: checkout (상태 S0) → KIS 매수 주문 실행 → 커밋/푸시 실패! (non-fast-forward)
```

- Run B의 **KIS 주문은 이미 전달**됐지만 positions.json 업데이트는 저장되지 않음
- 결과: 실제 보유 수량 ≠ positions.json → 다음 실행에서 reconcile 경고 + 해당 종목 매매 중단

## 변경 사항

`trading-bot-domestic.yml`, `trading-bot-overseas.yml` 모두에 concurrency 그룹 추가:

```yaml
concurrency:
  group: trading-domestic   # or trading-overseas
  cancel-in-progress: false
```

- `cancel-in-progress: false`: 실행 중인 작업이 있으면 새 실행을 **대기** (취소하지 않음)
  - 의도한 모든 매매 사이클이 실행됨을 보장
  - domestic/overseas는 별도 그룹이므로 서로 독립적으로 실행 가능

https://claude.ai/code/session_019Ubgqr1GUvzhCsoymVUsPU
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Ubgqr1GUvzhCsoymVUsPU)_