### PR TITLE
fix: KIS 500 에러 시 잔고 조회 재시도 및 수동매매 주문 폴백 처리

### DIFF
--- a/src/infra/broker/kis_base.py
+++ b/src/infra/broker/kis_base.py
@@ -180,6 +180,21 @@ class KisBrokerCommon(IBrokerAdapter):
                 current_cash = pf.total_cash
                 self.logger.info(f"[KisBroker] Available Cash for BUY: {current_cash:,.0f}")
 
+                # 포트폴리오 조회 실패(cash=0) 시 예산 체크 없이 원래 수량으로 주문
+                # 자금 부족이면 브로커가 REJECTED 처리하므로 안전
+                if current_cash <= 0:
+                    disp = display_ticker(order.ticker)
+                    self.logger.warning(
+                        f"[KisBroker] Portfolio cash=0 (잔고 조회 실패). "
+                        f"{disp} {order.quantity}주 원래 수량으로 주문 진행 "
+                        f"(자금 부족 시 브로커 거절)"
+                    )
+                    res = self._send_order_and_wait(order, timeout=30)
+                    if res:
+                        executions.append(res)
+                    time.sleep(0.2)
+                    continue
+
                 # 안전 마진 (98%)
                 SAFE_MARGIN = 0.98
                 budget = current_cash * SAFE_MARGIN

--- a/src/infra/broker/kis_domestic.py
+++ b/src/infra/broker/kis_domestic.py
@@ -86,41 +86,54 @@ class KisDomesticBrokerBase(KisBrokerCommon):
             "CTX_AREA_FK100": "",
             "CTX_AREA_NK100": ""
         }
-        headers = self._get_header(tr_id)
-        total_cash = 0.0
-        all_holdings: Dict[str, int] = {}
-        all_prices: Dict[str, float] = {}
 
-        time.sleep(0.2)
-        try:
-            res = self._request('GET', url, headers=headers, params=params, timeout=DEFAULT_HTTP_TIMEOUT)
-            res.raise_for_status()
-            data = res.json()
+        retry_delays = [2, 4, 8]
+        last_error = None
 
-            if data.get('rt_cd') != '0':
-                self.logger.warning(f"[KisDomestic] Get Portfolio Failed: {data.get('msg1')}")
-                return Portfolio(total_cash=0.0, holdings={}, current_prices={})
+        for attempt in range(len(retry_delays) + 1):
+            headers = self._get_header(tr_id)
+            time.sleep(0.2)
+            try:
+                res = self._request('GET', url, headers=headers, params=params, timeout=DEFAULT_HTTP_TIMEOUT)
+                res.raise_for_status()
+                data = res.json()
 
-            output2_list = data.get('output2', [])
-            summary = output2_list[0] if output2_list else {}
-            
-            total_cash = float(summary.get('prvs_rcdl_excc_amt', 0) or 0)
+                if data.get('rt_cd') != '0':
+                    self.logger.warning(f"[KisDomestic] Get Portfolio Failed: {data.get('msg1')}")
+                    return Portfolio(total_cash=0.0, holdings={}, current_prices={})
 
-            for item in data.get('output1', []):
-                qty = int(item.get('hldg_qty', 0) or 0)
-                if qty > 0:
-                    ticker = item.get('pdno', '').zfill(6)
-                    all_holdings[ticker] = qty
-                    all_prices[ticker] = float(item.get('prpr', 0) or 0)
+                output2_list = data.get('output2', [])
+                summary = output2_list[0] if output2_list else {}
+                total_cash = float(summary.get('prvs_rcdl_excc_amt', 0) or 0)
 
-        except Exception as e:
-            self.logger.error(f"[KisDomestic] Error getting portfolio: {e}")
+                all_holdings: Dict[str, int] = {}
+                all_prices: Dict[str, float] = {}
+                for item in data.get('output1', []):
+                    qty = int(item.get('hldg_qty', 0) or 0)
+                    if qty > 0:
+                        ticker = item.get('pdno', '').zfill(6)
+                        all_holdings[ticker] = qty
+                        all_prices[ticker] = float(item.get('prpr', 0) or 0)
 
-        return Portfolio(
-            total_cash=total_cash,
-            holdings=all_holdings,
-            current_prices=all_prices
-        )
+                return Portfolio(
+                    total_cash=total_cash,
+                    holdings=all_holdings,
+                    current_prices=all_prices
+                )
+
+            except Exception as e:
+                last_error = e
+                if attempt < len(retry_delays):
+                    delay = retry_delays[attempt]
+                    self.logger.warning(
+                        f"[KisDomestic] Portfolio fetch failed (attempt {attempt + 1}/{len(retry_delays) + 1}): {e}. "
+                        f"Retrying in {delay}s..."
+                    )
+                    time.sleep(delay)
+                else:
+                    self.logger.error(f"[KisDomestic] Error getting portfolio: {last_error}")
+
+        return Portfolio(total_cash=0.0, holdings={}, current_prices={})
 
     def _send_order_and_wait(self, order: Order, timeout: int = 30) -> Optional[TradeExecution]:
         """국내주식 주문 전송 후 체결 대기."""

--- a/tests/test_infra_broker_kis_domestic_live.py
+++ b/tests/test_infra_broker_kis_domestic_live.py
@@ -37,16 +37,15 @@ pytestmark = pytest.mark.skipif(
 
 # --- 상수 ---
 DEFAULT_TEST_TICKER = "069500"           # KODEX 200 ETF (~35,000원, 매우 유동성 높음)
-READONLY_PRICE_TICKERS = ["005930.KS", "069500.KS"]  # 삼성전자 + KODEX 200
+READONLY_PRICE_TICKERS = ["005930", "069500"]  # 삼성전자 + KODEX 200
 LIMIT_DROP_PCT = 0.95                    # 현재가 대비 -5% 지정가 (체결 안 되도록)
 ORDER_TIMEOUT_SHORT = 5                  # S8 타임아웃 시나리오용
 
 
 def _normalize_ticker(raw: str) -> str:
-    """입력이 6자리 코드든 yfinance 티커든 .KS suffix 형태로 통일."""
-    if "." in raw:
-        return raw
-    return f"{raw.zfill(6)}.KS"
+    """입력 티커를 KIS 6자리 코드로 정규화. .KS/.KQ suffix가 있으면 제거."""
+    code = raw.split(".")[0]
+    return code.zfill(6)
 
 
 def _floor_to_tick(price: int) -> int:
@@ -102,7 +101,6 @@ def broker(logger, test_ticker):
         app_secret=app_secret,
         acc_no=acc_no,
         logger=logger,
-        known_tickers=[test_ticker, "005930.KS", "069500.KS"],
     )
 
 


### PR DESCRIPTION
$(cat <<'EOF'
## 문제

수동 매매 워크플로우 실행 시 KIS `inquire-balance` API가 500 Server Error를 반환하여 주문이 실행되지 않는 오류 발생.

**실패 흐름:**
1. `get_portfolio()` → KIS 500 에러 → 빈 Portfolio(cash=0) 반환
2. `execute_orders()` 내 예산 체크에서 `get_portfolio()` 재호출 → 또 500, cash=0
3. `budget=0` → 수량 3주 → 0주로 조정 → 주문 미실행

## 원인

KIS OpenAPI 서버의 간헐적 500 에러. 재시도 로직이 없어 단 1회 실패로 전체 주문이 차단됨.

## 변경 사항

### `kis_domestic.py` - `get_portfolio()` 재시도 로직 추가
- 5xx 에러 발생 시 최대 3회 재시도 (2s → 4s → 8s 지연)
- 모든 재시도 실패 시 기존과 동일하게 빈 Portfolio 반환

### `kis_base.py` - `execute_orders()` 폴백 처리 추가
- 잔고 조회 실패로 cash=0이 되면 원래 주문 수량으로 그대로 주문 진행
- 실제 자금이 부족하면 KIS 브로커가 REJECTED 처리하므로 안전

## 테스트 계획

- [ ] 단위 테스트(`pytest`) 통과 확인
- [ ] KIS 500 에러 mock 시나리오에서 재시도 후 성공하는지 확인
- [ ] 재시도 모두 실패 시 cash=0 폴백으로 주문 진행되는지 확인

https://claude.ai/code/session_01K8qo7wdGAKWeMcF5UY72No
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8qo7wdGAKWeMcF5UY72No)_