### PR TITLE
security: StockAsset PR #279과 동일한 5가지 보안 수정 적용

### DIFF
--- a/.github/workflows/copy-ticker-files.yml
+++ b/.github/workflows/copy-ticker-files.yml
@@ -29,24 +29,34 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    # 입력값은 셸 인젝션 방지를 위해 env 경유로만 전달한다 (run 내 직접 보간 금지)
     - name: Create destination directories
+      env:
+        SKILL_DEST: ${{ inputs.skill_dest }}
+        UTILS_DEST: ${{ inputs.utils_dest }}
       run: |
-        mkdir -p "${{ inputs.skill_dest }}"
-        mkdir -p "${{ inputs.utils_dest }}"
+        mkdir -p "$SKILL_DEST"
+        mkdir -p "$UTILS_DEST"
 
     - name: Download ticker-reader skill files
+      env:
+        TICKER_MAP_REF: ${{ inputs.ticker_map_ref }}
+        SKILL_DEST: ${{ inputs.skill_dest }}
       run: |
-        BASE="https://raw.githubusercontent.com/junghyun99/ticker-map/${{ inputs.ticker_map_ref }}"
+        BASE="https://raw.githubusercontent.com/junghyun99/ticker-map/$TICKER_MAP_REF"
         curl -fsSL "$BASE/.claude/skills/ticker-reader/SKILL.md" \
-          -o "${{ inputs.skill_dest }}/SKILL.md"
+          -o "$SKILL_DEST/SKILL.md"
 
     - name: Download utils files
+      env:
+        TICKER_MAP_REF: ${{ inputs.ticker_map_ref }}
+        UTILS_DEST: ${{ inputs.utils_dest }}
       run: |
-        BASE="https://raw.githubusercontent.com/junghyun99/ticker-map/${{ inputs.ticker_map_ref }}"
+        BASE="https://raw.githubusercontent.com/junghyun99/ticker-map/$TICKER_MAP_REF"
         curl -fsSL "$BASE/src/utils/ticker_reader.py" \
-          -o "${{ inputs.utils_dest }}/ticker_reader_base.py"
+          -o "$UTILS_DEST/ticker_reader_base.py"
         curl -fsSL "$BASE/src/utils/tickers.db" \
-          -o "${{ inputs.utils_dest }}/tickers.db"
+          -o "$UTILS_DEST/tickers.db"
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
@@ -60,16 +70,20 @@ jobs:
         python scripts/export_tickers.py
 
     - name: Commit and Push
+      env:
+        TICKER_MAP_REF: ${{ inputs.ticker_map_ref }}
+        SKILL_DEST: ${{ inputs.skill_dest }}
+        UTILS_DEST: ${{ inputs.utils_dest }}
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add "${{ inputs.skill_dest }}/SKILL.md"
-        git add "${{ inputs.utils_dest }}/ticker_reader_base.py"
-        git add "${{ inputs.utils_dest }}/tickers.db"
+        git add "$SKILL_DEST/SKILL.md"
+        git add "$UTILS_DEST/ticker_reader_base.py"
+        git add "$UTILS_DEST/tickers.db"
         git add "docs/data/tickers.json"
         if git diff --cached --quiet; then
           echo "변경 사항 없음 - 커밋 생략"
         else
-          git commit -m "feat: sync ticker files from ticker-map@${{ inputs.ticker_map_ref }} [skip ci]"
+          git commit -m "feat: sync ticker files from ticker-map@$TICKER_MAP_REF [skip ci]"
           git push
         fi

--- a/.github/workflows/download-market-data.yml
+++ b/.github/workflows/download-market-data.yml
@@ -33,14 +33,19 @@ jobs:
         pip install -r requirements.txt
 
     - name: Download market data
+      env:
+        # 입력값은 코드 인젝션 방지를 위해 env 경유로만 전달한다 (스크립트 내 직접 보간 금지)
+        START_DATE: ${{ inputs.start_date }}
+        END_DATE: ${{ inputs.end_date }}
       run: |
         python -c "
+        import os
         from src.backtest.cache import BacktestDataCache
         from src.utils.logger import TradeLogger
         from datetime import datetime, timedelta
 
-        start_date = '${{ inputs.start_date }}'
-        end_date = '${{ inputs.end_date }}'
+        start_date = os.environ['START_DATE']
+        end_date = os.environ['END_DATE']
 
         # 지표 계산용 500일 여유분 포함
         real_start = datetime.strptime(start_date, '%Y-%m-%d') - timedelta(days=500)
@@ -75,7 +80,7 @@ jobs:
         "
 
     - name: Commit and Push Cache
-      uses: stefanzweifel/git-auto-commit-action@v5
+      uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
       with:
         commit_message: "data: download market data (${{ inputs.start_date }} ~ ${{ inputs.end_date }}) [skip ci]"
         file_pattern: "src/backtest/cache/**"

--- a/.github/workflows/gdrive-sync.yml
+++ b/.github/workflows/gdrive-sync.yml
@@ -17,7 +17,7 @@ jobs:
       run: zip -r repo-MagicSplit-latest-backup.zip . -x "*.git/*"
 
     - name: 구글 드라이브에 업로드하기 (OAuth 방식)
-      uses: logickoder/google-drive-upload@main
+      uses: logickoder/google-drive-upload@80e9dbe39d1136b6b0758781de3797364dc7135b # 1.0.1
       with:
         filename: repo-MagicSplit-latest-backup.zip
         folderId: ${{ secrets.GDRIVE_FOLDER_ID }}

--- a/.github/workflows/kis-domestic-broker-test.yml
+++ b/.github/workflows/kis-domestic-broker-test.yml
@@ -46,10 +46,30 @@ jobs:
       id: token-cache-restore
       uses: actions/cache/restore@v4
       with:
-        path: .kis_token_cache.json
+        # 캐시에는 암호문(.enc)만 저장한다. 평문 토큰을 캐시에 두면
+        # 다른 브랜치/포크 PR이 접두사로 복원해 탈취할 수 있다.
+        path: .kis_token_cache.enc
         key: kis-token-shared-${{ github.run_id }}
         restore-keys: |
           kis-token-shared-
+
+    - name: Decrypt KIS token cache
+      if: ${{ hashFiles('.kis_token_cache.enc') != '' }}
+      env:
+        KIS_TOKEN_CACHE_KEY: ${{ secrets.KIS_TOKEN_CACHE_KEY }}
+      run: |
+        if [ -z "${KIS_TOKEN_CACHE_KEY:-}" ]; then
+          echo "::warning::KIS_TOKEN_CACHE_KEY 미설정 - 캐시 복호화를 건너뜁니다."
+          exit 0
+        fi
+        if openssl enc -d -aes-256-cbc -pbkdf2 -salt \
+        -in .kis_token_cache.enc -out .kis_token_cache.json \
+        -pass env:KIS_TOKEN_CACHE_KEY; then
+          echo "토큰 캐시 복호화 성공 - 유효기간 내 기존 토큰을 재사용합니다."
+        else
+          echo "::warning::토큰 캐시 복호화 실패 - 손상/위조 캐시 제거 후 새 토큰을 발급합니다."
+          rm -f .kis_token_cache.json
+        fi
 
     - name: Run broker live tests
       env:
@@ -58,21 +78,35 @@ jobs:
         KIS_ACC_NO: ${{ secrets.KIS_ACC_NO }}
         IS_LIVE: 'true'
         RUN_ORDER_TESTS: ${{ inputs.test_level == 'full' && 'true' || 'false' }}
+        TEST_LEVEL: ${{ inputs.test_level }}
         TEST_TICKER: ${{ inputs.test_ticker }}
         PYTHONUTF8: '1'
         PYTHONUNBUFFERED: '1'
       run: |
         echo "=== KIS Domestic Broker Live Test ==="
-        echo "Test level   : ${{ inputs.test_level }}"
+        echo "Test level   : $TEST_LEVEL"
         echo "Order tests  : $RUN_ORDER_TESTS"
         echo "Test ticker  : $TEST_TICKER"
         echo "Broker       : KisDomesticLiveBroker (실거래 서버)"
         echo "======================================"
         pytest tests/test_infra_broker_kis_domestic_live.py -v -s
 
+    - name: Encrypt KIS token cache
+      if: ${{ always() && hashFiles('.kis_token_cache.json') != '' }}
+      env:
+        KIS_TOKEN_CACHE_KEY: ${{ secrets.KIS_TOKEN_CACHE_KEY }}
+      run: |
+        if [ -z "${KIS_TOKEN_CACHE_KEY:-}" ]; then
+          echo "::warning::KIS_TOKEN_CACHE_KEY 미설정 - 토큰을 캐시에 저장하지 않습니다."
+          exit 0
+        fi
+        openssl enc -aes-256-cbc -pbkdf2 -salt \
+        -in .kis_token_cache.json -out .kis_token_cache.enc \
+        -pass env:KIS_TOKEN_CACHE_KEY
+
     - name: Save KIS token cache
-      if: always()
+      if: ${{ always() && hashFiles('.kis_token_cache.enc') != '' }}
       uses: actions/cache/save@v4
       with:
-        path: .kis_token_cache.json
+        path: .kis_token_cache.enc
         key: kis-token-shared-${{ github.run_id }}

--- a/.github/workflows/kis-overseas-broker-test.yml
+++ b/.github/workflows/kis-overseas-broker-test.yml
@@ -48,10 +48,30 @@ jobs:
       id: token-cache-restore
       uses: actions/cache/restore@v4
       with:
-        path: .kis_token_cache.json
+        # 캐시에는 암호문(.enc)만 저장한다. 평문 토큰을 캐시에 두면
+        # 다른 브랜치/포크 PR이 접두사로 복원해 탈취할 수 있다.
+        path: .kis_token_cache.enc
         key: kis-token-shared-${{ github.run_id }}
         restore-keys: |
           kis-token-shared-
+
+    - name: Decrypt KIS token cache
+      if: ${{ hashFiles('.kis_token_cache.enc') != '' }}
+      env:
+        KIS_TOKEN_CACHE_KEY: ${{ secrets.KIS_TOKEN_CACHE_KEY }}
+      run: |
+        if [ -z "${KIS_TOKEN_CACHE_KEY:-}" ]; then
+          echo "::warning::KIS_TOKEN_CACHE_KEY 미설정 - 캐시 복호화를 건너뜁니다."
+          exit 0
+        fi
+        if openssl enc -d -aes-256-cbc -pbkdf2 -salt \
+        -in .kis_token_cache.enc -out .kis_token_cache.json \
+        -pass env:KIS_TOKEN_CACHE_KEY; then
+          echo "토큰 캐시 복호화 성공 - 유효기간 내 기존 토큰을 재사용합니다."
+        else
+          echo "::warning::토큰 캐시 복호화 실패 - 손상/위조 캐시 제거 후 새 토큰을 발급합니다."
+          rm -f .kis_token_cache.json
+        fi
 
     - name: Run broker live tests
       env:
@@ -60,21 +80,35 @@ jobs:
         KIS_ACC_NO: ${{ secrets.KIS_ACC_NO }}
         IS_LIVE: 'true'
         RUN_ORDER_TESTS: ${{ inputs.test_level == 'full' && 'true' || 'false' }}
+        TEST_LEVEL: ${{ inputs.test_level }}
         TEST_TICKER: ${{ inputs.test_ticker }}
         PYTHONUTF8: '1'
         PYTHONUNBUFFERED: '1'
       run: |
         echo "=== KIS Overseas Broker Live Test ==="
-        echo "Test level   : ${{ inputs.test_level }}"
+        echo "Test level   : $TEST_LEVEL"
         echo "Order tests  : $RUN_ORDER_TESTS"
         echo "Test ticker  : $TEST_TICKER"
         echo "Broker       : KisOverseasLiveBroker (실거래 서버)"
         echo "======================================"
         pytest tests/test_infra_broker_kis_overseas_live.py -v -s
 
+    - name: Encrypt KIS token cache
+      if: ${{ always() && hashFiles('.kis_token_cache.json') != '' }}
+      env:
+        KIS_TOKEN_CACHE_KEY: ${{ secrets.KIS_TOKEN_CACHE_KEY }}
+      run: |
+        if [ -z "${KIS_TOKEN_CACHE_KEY:-}" ]; then
+          echo "::warning::KIS_TOKEN_CACHE_KEY 미설정 - 토큰을 캐시에 저장하지 않습니다."
+          exit 0
+        fi
+        openssl enc -aes-256-cbc -pbkdf2 -salt \
+        -in .kis_token_cache.json -out .kis_token_cache.enc \
+        -pass env:KIS_TOKEN_CACHE_KEY
+
     - name: Save KIS token cache
-      if: always()
+      if: ${{ always() && hashFiles('.kis_token_cache.enc') != '' }}
       uses: actions/cache/save@v4
       with:
-        path: .kis_token_cache.json
+        path: .kis_token_cache.enc
         key: kis-token-shared-${{ github.run_id }}

--- a/.github/workflows/manual-trade.yml
+++ b/.github/workflows/manual-trade.yml
@@ -51,10 +51,30 @@ jobs:
       id: token-cache-restore
       uses: actions/cache/restore@v4
       with:
-        path: .kis_token_cache.json
+        # 캐시에는 암호문(.enc)만 저장한다. 평문 토큰을 캐시에 두면
+        # 다른 브랜치/포크 PR이 접두사로 복원해 탈취할 수 있다.
+        path: .kis_token_cache.enc
         key: kis-token-shared-${{ github.run_id }}
         restore-keys: |
           kis-token-shared-
+
+    - name: Decrypt KIS token cache
+      if: ${{ hashFiles('.kis_token_cache.enc') != '' }}
+      env:
+        KIS_TOKEN_CACHE_KEY: ${{ secrets.KIS_TOKEN_CACHE_KEY }}
+      run: |
+        if [ -z "${KIS_TOKEN_CACHE_KEY:-}" ]; then
+          echo "::warning::KIS_TOKEN_CACHE_KEY 미설정 - 캐시 복호화를 건너뜁니다."
+          exit 0
+        fi
+        if openssl enc -d -aes-256-cbc -pbkdf2 -salt \
+        -in .kis_token_cache.enc -out .kis_token_cache.json \
+        -pass env:KIS_TOKEN_CACHE_KEY; then
+          echo "토큰 캐시 복호화 성공 - 유효기간 내 기존 토큰을 재사용합니다."
+        else
+          echo "::warning::토큰 캐시 복호화 실패 - 손상/위조 캐시 제거 후 새 토큰을 발급합니다."
+          rm -f .kis_token_cache.json
+        fi
 
     - name: Execute Manual Trade
       env:
@@ -66,41 +86,61 @@ jobs:
         KIS_APP_SECRET: ${{ secrets.KIS_APP_SECRET }}
         KIS_ACC_NO: ${{ secrets.KIS_ACC_NO }}
         IS_LIVE: 'true'
+        # 입력값은 셸 인젝션 방지를 위해 env 경유로만 전달한다 (run 내 직접 보간 금지)
+        TICKER: ${{ github.event.inputs.ticker }}
+        ORDER_ACTION: ${{ github.event.inputs.action }}
+        AMOUNT: ${{ github.event.inputs.amount }}
       run: |
-        AMOUNT="${{ github.event.inputs.amount }}"
         if [ -n "$AMOUNT" ]; then
           python scripts/manual_trade.py \
-            --ticker "${{ github.event.inputs.ticker }}" \
-            --action "${{ github.event.inputs.action }}" \
+            --ticker "$TICKER" \
+            --action "$ORDER_ACTION" \
             --amount "$AMOUNT"
         else
           python scripts/manual_trade.py \
-            --ticker "${{ github.event.inputs.ticker }}" \
-            --action "${{ github.event.inputs.action }}"
+            --ticker "$TICKER" \
+            --action "$ORDER_ACTION"
         fi
 
+    - name: Encrypt KIS token cache
+      if: ${{ always() && hashFiles('.kis_token_cache.json') != '' }}
+      env:
+        KIS_TOKEN_CACHE_KEY: ${{ secrets.KIS_TOKEN_CACHE_KEY }}
+      run: |
+        if [ -z "${KIS_TOKEN_CACHE_KEY:-}" ]; then
+          echo "::warning::KIS_TOKEN_CACHE_KEY 미설정 - 토큰을 캐시에 저장하지 않습니다."
+          exit 0
+        fi
+        openssl enc -aes-256-cbc -pbkdf2 -salt \
+        -in .kis_token_cache.json -out .kis_token_cache.enc \
+        -pass env:KIS_TOKEN_CACHE_KEY
+
     - name: Save KIS token cache
-      if: always()
+      if: ${{ always() && hashFiles('.kis_token_cache.enc') != '' }}
       uses: actions/cache/save@v4
       with:
-        path: .kis_token_cache.json
+        path: .kis_token_cache.enc
         key: kis-token-shared-${{ github.run_id }}
 
     - name: Debug - List data and logs
       if: always()
+      env:
+        MARKET_TYPE: ${{ github.event.inputs.market_type }}
       run: |
-        echo "=== docs/data/${{ github.event.inputs.market_type }}/ ==="
-        ls -R docs/data/${{ github.event.inputs.market_type }}/ || echo "Not found"
-        echo "=== logs/${{ github.event.inputs.market_type }}/ ==="
-        ls -R logs/${{ github.event.inputs.market_type }}/ || echo "Not found"
+        echo "=== docs/data/$MARKET_TYPE/ ==="
+        ls -R "docs/data/$MARKET_TYPE/" || echo "Not found"
+        echo "=== logs/$MARKET_TYPE/ ==="
+        ls -R "logs/$MARKET_TYPE/" || echo "Not found"
 
     - name: Commit updated data and logs
+      env:
+        MARKET_TYPE: ${{ github.event.inputs.market_type }}
       run: |
-        git add --force docs/data/${{ github.event.inputs.market_type }}/*.json || true
-        git add --force logs/${{ github.event.inputs.market_type }}/*.log || true
+        git add --force docs/data/"$MARKET_TYPE"/*.json || true
+        git add --force logs/"$MARKET_TYPE"/*.log || true
 
     - name: Push updated data and logs
-      uses: stefanzweifel/git-auto-commit-action@v5
+      uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
       with:
         commit_message: "Manual trade update: ${{ github.event.inputs.ticker }} ${{ github.event.inputs.action }} [skip ci]"
         file_pattern: "docs/data/${{ github.event.inputs.market_type }}/*.json logs/${{ github.event.inputs.market_type }}/*.log"

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -28,7 +28,7 @@ jobs:
         pytest --cov=src --cov-report=xml --cov-report=term-missing --cov-fail-under=80 tests/
 
     - name: Slack Notification on Failure
-      uses: 8398a7/action-slack@v3
+      uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
       with:
         status: ${{ job.status }}
         fields: repo,message,commit,author,action,eventName,ref,workflow,job,took

--- a/.github/workflows/run-backtest.yml
+++ b/.github/workflows/run-backtest.yml
@@ -46,8 +46,10 @@ jobs:
         pip install -r requirements.txt
 
     - name: Set Environment Variables
+      env:
+        MARKET_TYPE: ${{ inputs.market_type }}
       run: |
-        if [ "${{ inputs.market_type }}" == "국내" ]; then
+        if [ "$MARKET_TYPE" == "국내" ]; then
           echo "CONFIG_PATH=config_test_domestic.json" >> $GITHUB_ENV
           echo "MARKET_VAL=domestic" >> $GITHUB_ENV
         else
@@ -57,17 +59,23 @@ jobs:
       shell: bash
 
     - name: Run backtest
+      env:
+        # 입력값은 코드 인젝션 방지를 위해 env 경유로만 전달한다 (스크립트 내 직접 보간 금지)
+        START_DATE: ${{ inputs.start }}
+        END_DATE: ${{ inputs.end }}
+        INITIAL_CASH: ${{ inputs.initial_cash }}
+        RUN_NUMBER: ${{ github.run_number }}
       run: |
         python -c "
         import os
         from src.backtest.runner import run_backtest
         result = run_backtest(
             config_path=os.environ.get('CONFIG_PATH'),
-            start_date='${{ inputs.start }}',
-            end_date='${{ inputs.end }}',
-            initial_cash=float('${{ inputs.initial_cash }}'),
+            start_date=os.environ['START_DATE'],
+            end_date=os.environ['END_DATE'],
+            initial_cash=float(os.environ['INITIAL_CASH']),
             market_type=os.environ.get('MARKET_VAL'),
-            run_number='${{ github.run_number }}_' + os.environ.get('MARKET_VAL'),
+            run_number=os.environ['RUN_NUMBER'] + '_' + os.environ.get('MARKET_VAL'),
         )
         if result:
             pf = result.final_portfolio
@@ -77,7 +85,7 @@ jobs:
         "
 
     - name: Commit and Push Results
-      uses: stefanzweifel/git-auto-commit-action@v5
+      uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
       with:
         commit_message: "backtest result update (${{ inputs.start }} ~ ${{ inputs.end }}) [skip ci]"
         file_pattern: "docs/data/backtest/** logs/backtest/*"

--- a/.github/workflows/trading-bot-domestic.yml
+++ b/.github/workflows/trading-bot-domestic.yml
@@ -73,10 +73,30 @@ jobs:
       id: token-cache-restore
       uses: actions/cache/restore@v4
       with:
-        path: .kis_token_cache.json
+        # 캐시에는 암호문(.enc)만 저장한다. 평문 토큰을 캐시에 두면
+        # 다른 브랜치/포크 PR이 접두사로 복원해 탈취할 수 있다.
+        path: .kis_token_cache.enc
         key: kis-token-shared-${{ github.run_id }}
         restore-keys: |
           kis-token-shared-
+
+    - name: Decrypt KIS token cache
+      if: ${{ steps.holiday.outputs.is_holiday != 'true' && hashFiles('.kis_token_cache.enc') != '' }}
+      env:
+        KIS_TOKEN_CACHE_KEY: ${{ secrets.KIS_TOKEN_CACHE_KEY }}
+      run: |
+        if [ -z "${KIS_TOKEN_CACHE_KEY:-}" ]; then
+          echo "::warning::KIS_TOKEN_CACHE_KEY 미설정 - 캐시 복호화를 건너뜁니다."
+          exit 0
+        fi
+        if openssl enc -d -aes-256-cbc -pbkdf2 -salt \
+        -in .kis_token_cache.enc -out .kis_token_cache.json \
+        -pass env:KIS_TOKEN_CACHE_KEY; then
+          echo "토큰 캐시 복호화 성공 - 유효기간 내 기존 토큰을 재사용합니다."
+        else
+          echo "::warning::토큰 캐시 복호화 실패 - 손상/위조 캐시 제거 후 새 토큰을 발급합니다."
+          rm -f .kis_token_cache.json
+        fi
 
     - name: Run MagicSplit Bot (Domestic)
       if: ${{ steps.holiday.outputs.is_holiday != 'true' }}
@@ -92,11 +112,24 @@ jobs:
         PYTHONUNBUFFERED: "1"
       run: python -m src.main
 
+    - name: Encrypt KIS token cache
+      if: ${{ always() && steps.holiday.outputs.is_holiday != 'true' && hashFiles('.kis_token_cache.json') != '' }}
+      env:
+        KIS_TOKEN_CACHE_KEY: ${{ secrets.KIS_TOKEN_CACHE_KEY }}
+      run: |
+        if [ -z "${KIS_TOKEN_CACHE_KEY:-}" ]; then
+          echo "::warning::KIS_TOKEN_CACHE_KEY 미설정 - 토큰을 캐시에 저장하지 않습니다."
+          exit 0
+        fi
+        openssl enc -aes-256-cbc -pbkdf2 -salt \
+        -in .kis_token_cache.json -out .kis_token_cache.enc \
+        -pass env:KIS_TOKEN_CACHE_KEY
+
     - name: Save KIS token cache
-      if: ${{ always() && steps.holiday.outputs.is_holiday != 'true' }}
+      if: ${{ always() && steps.holiday.outputs.is_holiday != 'true' && hashFiles('.kis_token_cache.enc') != '' }}
       uses: actions/cache/save@v4
       with:
-        path: .kis_token_cache.json
+        path: .kis_token_cache.enc
         key: kis-token-shared-${{ github.run_id }}
 
     - name: Debug - List data and logs
@@ -115,7 +148,7 @@ jobs:
         
     - name: Push updated data and logs
       if: ${{ success() && steps.holiday.outputs.is_holiday != 'true' }}
-      uses: stefanzweifel/git-auto-commit-action@v5
+      uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
       with:
         commit_message: "Auto-update domestic trading data and logs [skip ci]"
         file_pattern: "docs/data/domestic/*.json logs/domestic/*.log"

--- a/.github/workflows/trading-bot-overseas.yml
+++ b/.github/workflows/trading-bot-overseas.yml
@@ -73,10 +73,30 @@ jobs:
       id: token-cache-restore
       uses: actions/cache/restore@v4
       with:
-        path: .kis_token_cache.json
+        # 캐시에는 암호문(.enc)만 저장한다. 평문 토큰을 캐시에 두면
+        # 다른 브랜치/포크 PR이 접두사로 복원해 탈취할 수 있다.
+        path: .kis_token_cache.enc
         key: kis-token-shared-${{ github.run_id }}
         restore-keys: |
           kis-token-shared-
+
+    - name: Decrypt KIS token cache
+      if: ${{ steps.holiday.outputs.is_holiday != 'true' && hashFiles('.kis_token_cache.enc') != '' }}
+      env:
+        KIS_TOKEN_CACHE_KEY: ${{ secrets.KIS_TOKEN_CACHE_KEY }}
+      run: |
+        if [ -z "${KIS_TOKEN_CACHE_KEY:-}" ]; then
+          echo "::warning::KIS_TOKEN_CACHE_KEY 미설정 - 캐시 복호화를 건너뜁니다."
+          exit 0
+        fi
+        if openssl enc -d -aes-256-cbc -pbkdf2 -salt \
+        -in .kis_token_cache.enc -out .kis_token_cache.json \
+        -pass env:KIS_TOKEN_CACHE_KEY; then
+          echo "토큰 캐시 복호화 성공 - 유효기간 내 기존 토큰을 재사용합니다."
+        else
+          echo "::warning::토큰 캐시 복호화 실패 - 손상/위조 캐시 제거 후 새 토큰을 발급합니다."
+          rm -f .kis_token_cache.json
+        fi
 
     - name: Run MagicSplit Bot (Overseas)
       if: ${{ steps.holiday.outputs.is_holiday != 'true' }}
@@ -92,11 +112,24 @@ jobs:
         PYTHONUNBUFFERED: "1"
       run: python -m src.main
 
+    - name: Encrypt KIS token cache
+      if: ${{ always() && steps.holiday.outputs.is_holiday != 'true' && hashFiles('.kis_token_cache.json') != '' }}
+      env:
+        KIS_TOKEN_CACHE_KEY: ${{ secrets.KIS_TOKEN_CACHE_KEY }}
+      run: |
+        if [ -z "${KIS_TOKEN_CACHE_KEY:-}" ]; then
+          echo "::warning::KIS_TOKEN_CACHE_KEY 미설정 - 토큰을 캐시에 저장하지 않습니다."
+          exit 0
+        fi
+        openssl enc -aes-256-cbc -pbkdf2 -salt \
+        -in .kis_token_cache.json -out .kis_token_cache.enc \
+        -pass env:KIS_TOKEN_CACHE_KEY
+
     - name: Save KIS token cache
-      if: ${{ always() && steps.holiday.outputs.is_holiday != 'true' }}
+      if: ${{ always() && steps.holiday.outputs.is_holiday != 'true' && hashFiles('.kis_token_cache.enc') != '' }}
       uses: actions/cache/save@v4
       with:
-        path: .kis_token_cache.json
+        path: .kis_token_cache.enc
         key: kis-token-shared-${{ github.run_id }}
 
     - name: Debug - List data and logs
@@ -115,7 +148,7 @@ jobs:
 
     - name: Push updated data and logs
       if: ${{ success() && steps.holiday.outputs.is_holiday != 'true' }}
-      uses: stefanzweifel/git-auto-commit-action@v5
+      uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
       with:
         commit_message: "Auto-update overseas trading data and logs [skip ci]"
         file_pattern: "docs/data/overseas/*.json logs/overseas/*.log"

--- a/.gitignore
+++ b/.gitignore
@@ -213,8 +213,13 @@ __marimo__/
 .claude/settings.local.json
 CLAUDE.local.md
 
+# 인증서 / 개인키 파일 (민감 정보)
+*.pem
+*.key
+
 # KIS API 토큰 캐시 (민감 정보)
 .kis_token_cache.json
+.kis_token_cache.enc
 
 # Project Data & Logs (Keep directory structure, ignore data files)
 logs/**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ src/
 ??  ?��??� broker/          # KIS domestic/overseas/mock 브로�?
 ??  ?��??� data.py          # YFinanceLoader (?�택??
 ??  ?��??� repo.py          # JsonRepository (positions.json, status.json, history.json)
-??  ?��??� notifier.py      # SlackNotifier, TelegramNotifier
+??  ?��??� notifier.py      # SlackNotifier
 ?��??� backtest/            # runner, cache (parquet), fetcher (yfinance), components
 ?��??� utils/               # TradeLogger
 scripts/
@@ -94,6 +94,7 @@ presets.json             # 차수�?배열 공유 ?�리??(?�택)
 - `config_overseas.json_PATH` - 매매 규칙 ?�일 경로 (기본�? `config_overseas.json`. �?��??`config_domestic.json` 지??
 - `PRESETS_JSON_PATH` - ?�리???�일 경로 (?�택, 기본?� config ?�일�?같�? ?�렉?�리??`presets.json`)
 - `PYTHONUTF8` - Windows ?�경?�서 ?��? 로그 ?�코???�류 방�???(?�수: `1` ?�정)
+- `KIS_HTTP_TIMEOUT` - KIS REST 호출 타임아웃 초 (기본값: `10`)
 
 ## 로컬 ?�경 ?�정
 1. `.env.example` ?�일??`.env`�?복사

--- a/src/config.py
+++ b/src/config.py
@@ -11,7 +11,8 @@ EXCHANGE_CODE_SHORT_TO_FULL: dict[str, str] = {
     'AMS': 'AMEX',
 }
 
-DEFAULT_HTTP_TIMEOUT = 10
+# KIS REST 호출 타임아웃 (초). 미설정 시 무한 대기 방지를 위해 항상 적용된다.
+DEFAULT_HTTP_TIMEOUT = float(os.getenv("KIS_HTTP_TIMEOUT", "10"))
 
 
 class Config:

--- a/src/config.py
+++ b/src/config.py
@@ -11,8 +11,17 @@ EXCHANGE_CODE_SHORT_TO_FULL: dict[str, str] = {
     'AMS': 'AMEX',
 }
 
+def _parse_http_timeout(raw, default: float = 10.0) -> float:
+    """KIS_HTTP_TIMEOUT 환경변수 값을 검증한다. 숫자가 아니거나 0 이하면 기본값으로 폴백."""
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
 # KIS REST 호출 타임아웃 (초). 미설정 시 무한 대기 방지를 위해 항상 적용된다.
-DEFAULT_HTTP_TIMEOUT = float(os.getenv("KIS_HTTP_TIMEOUT", "10"))
+DEFAULT_HTTP_TIMEOUT = _parse_http_timeout(os.getenv("KIS_HTTP_TIMEOUT", "10"))
 
 
 class Config:

--- a/src/infra/notifier.py
+++ b/src/infra/notifier.py
@@ -4,36 +4,6 @@ from typing import Optional
 from src.core.interfaces import INotifier
 
 
-class TelegramNotifier(INotifier):
-    def __init__(self, token: str, chat_id: str, logger):
-        self.token = token
-        self.chat_id = chat_id
-        self.logger = logger
-        self.base_url = f"https://api.telegram.org/bot{token}/sendMessage"
-
-    def send_message(self, message: str, detail: Optional[str] = None) -> None:
-        text = f"[MagicSplit]\n{message}"
-        if detail:
-            text += f"\n\n[Details]\n{detail}"
-        self._send(text)
-
-    def send_alert(self, message: str, detail: Optional[str] = None) -> None:
-        text = f"[WARNING]\n{message}"
-        if detail:
-            text += f"\n\n[Details]\n{detail}"
-        self._send(text)
-
-    def _send(self, text: str):
-        if not self.token or not self.chat_id:
-            self.logger.info(f"[Telegram Mock] {text}")
-            return
-        try:
-            payload = {"chat_id": self.chat_id, "text": text}
-            requests.post(self.base_url, json=payload, timeout=5)
-        except Exception as e:
-            self.logger.error(f"[Telegram Error] Failed to send: {e}")
-
-
 class SlackNotifier(INotifier):
     def __init__(self, webhook_url: str, logger, bot_token: str = "", channel_id: str = ""):
         self.webhook_url = webhook_url

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 # tests/test_config.py
 import pytest
-from src.config import Config, EXCHANGE_CODE_SHORT_TO_FULL
+from src.config import Config, EXCHANGE_CODE_SHORT_TO_FULL, _parse_http_timeout
 
 
 class TestConfig:
@@ -18,3 +18,18 @@ class TestConfig:
         assert EXCHANGE_CODE_SHORT_TO_FULL["NAS"] == "NASD"
         assert EXCHANGE_CODE_SHORT_TO_FULL["NYS"] == "NYSE"
         assert EXCHANGE_CODE_SHORT_TO_FULL["AMS"] == "AMEX"
+
+
+class TestParseHttpTimeout:
+    def test_valid_value(self):
+        assert _parse_http_timeout("30") == 30.0
+        assert _parse_http_timeout("2.5") == 2.5
+
+    def test_invalid_string_falls_back_to_default(self):
+        assert _parse_http_timeout("abc") == 10.0
+        assert _parse_http_timeout("") == 10.0
+        assert _parse_http_timeout(None) == 10.0
+
+    def test_non_positive_falls_back_to_default(self):
+        assert _parse_http_timeout("0") == 10.0
+        assert _parse_http_timeout("-5") == 10.0

--- a/tests/test_infra_notifier.py
+++ b/tests/test_infra_notifier.py
@@ -1,7 +1,7 @@
 # tests/test_infra_notifier.py
 import pytest
 from unittest.mock import patch, MagicMock
-from src.infra.notifier import SlackNotifier, TelegramNotifier
+from src.infra.notifier import SlackNotifier
 
 
 @pytest.fixture
@@ -75,18 +75,3 @@ class TestSlackNotifier:
         second_call_args = mock_post.call_args_list[1]
         assert "Detail Log" in second_call_args.kwargs["json"]["text"]
         assert second_call_args.kwargs["json"]["thread_ts"] == "12345.6789"
-
-
-class TestTelegramNotifier:
-    def test_send_no_token(self, mock_logger):
-        """토큰 없으면 로거로만 출력"""
-        notifier = TelegramNotifier("", "", mock_logger)
-        notifier.send_message("test")
-        mock_logger.info.assert_called_once()
-
-    @patch("src.infra.notifier.requests.post")
-    def test_send_with_token(self, mock_post, mock_logger):
-        mock_post.return_value = MagicMock(status_code=200)
-        notifier = TelegramNotifier("token123", "chat456", mock_logger)
-        notifier.send_message("hello")
-        mock_post.assert_called_once()


### PR DESCRIPTION
## 개요
StockAsset [PR #279](https://github.com/junghyun99/StockAsset/pull/279)에 적용된 5가지 보안 수정을 MagicSplit에 동일하게 적용합니다.

## 변경 내용

### 1. 서드파티 액션 커밋 SHA 고정 (공급망 공격 방지)
가변 태그(`@v5`, `@v3`, `@main`)는 액션 저장소가 탈취되면 악성 커밋으로 재지정될 수 있어, 불변 커밋 SHA로 고정했습니다. (SHA는 각 저장소 태그와 대조하여 검증함)
- `stefanzweifel/git-auto-commit-action@v5` -> `b863ae19...` (v5.2.0) — 워크플로우 5개
- `8398a7/action-slack@v3` -> `77eaa4f1...` (v3.19.0) — python-test.yml
- `logickoder/google-drive-upload@main` -> `80e9dbe3...` (1.0.1) — gdrive-sync.yml

### 2. KIS 토큰 캐시 암호화
Actions 캐시의 평문 토큰은 `restore-keys` 접두사 매칭으로 다른 브랜치/포크 PR에서 복원·탈취될 수 있습니다. 토큰 캐시 사용 워크플로우 5개(trading-bot-domestic/overseas, manual-trade, kis-domestic/overseas-broker-test)에 적용:
- 캐시 경로를 `.kis_token_cache.json` -> `.kis_token_cache.enc`로 변경
- 복원 후 복호화 / 저장 전 암호화 스텝 추가 (`openssl aes-256-cbc -pbkdf2`, `KIS_TOKEN_CACHE_KEY` 시크릿 사용)
- 키 미설정 시 경고 후 새 토큰 발급으로 폴백 (동작 중단 없음)

### 3. 워크플로우 셸/코드 인젝션 방지
`run:` 스크립트에 `${{ inputs.* }}`를 직접 보간하면 입력값이 코드로 실행될 수 있어, 모두 `env:` 변수 경유로 변경했습니다.
- manual-trade.yml (ticker/action/amount/market_type), kis-*-broker-test.yml (test_level), run-backtest.yml·download-market-data.yml (인라인 Python의 날짜/금액 입력), copy-ticker-files.yml (ref/경로 입력)

### 4. 미사용 TelegramNotifier 제거
URL에 봇 토큰이 포함되어 예외 로깅 시 유출 위험이 있던 미사용 `TelegramNotifier`를 코드·테스트·문서에서 제거했습니다. `SlackNotifier`만 유지합니다.

### 5. HTTP 타임아웃 환경변수화 + .gitignore 강화
- `DEFAULT_HTTP_TIMEOUT`을 `KIS_HTTP_TIMEOUT` 환경변수로 설정 가능하게 변경 (기본값 10초, 기존 동작 동일)
- `.gitignore`에 `*.pem`, `*.key`, `.kis_token_cache.enc` 추가

## 필요한 후속 조치
- [ ] 저장소 Settings > Secrets에 **`KIS_TOKEN_CACHE_KEY`** 시크릿 등록 (임의의 강력한 문자열, 예: `openssl rand -base64 32` 출력값). 미등록 시 토큰 캐시만 비활성화되고 매 실행마다 새 토큰을 발급합니다.

## 테스트
- `pytest --cov=src tests/`: **379 passed, 17 skipped**, 커버리지 **89.10%** (기준 80% 충족)
- 워크플로우 10개 전체 YAML 문법 검증 통과

https://claude.ai/code/session_01DQqS5BCrZovZBVs9cMk84U

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQqS5BCrZovZBVs9cMk84U)_