### PR TITLE
fix(ci): Google Drive 백업 - 고정 커밋 액션을 Python API 클라이언트로 교체

### DIFF
--- a/.github/workflows/gdrive-sync.yml
+++ b/.github/workflows/gdrive-sync.yml
@@ -10,19 +10,52 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: 저장소 코드 불러오기
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
     - name: 코드를 ZIP 파일로 압축하기
-      # 파일명 자체를 업로드할 이름으로 지정하여 압축합니다.
       run: zip -r repo-MagicSplit-latest-backup.zip . -x "*.git/*"
 
+    - name: Google Drive API 클라이언트 설치
+      run: pip install -q google-auth google-auth-httplib2 google-api-python-client
+
     - name: 구글 드라이브에 업로드하기 (OAuth 방식)
-      uses: logickoder/google-drive-upload@80e9dbe39d1136b6b0758781de3797364dc7135b # 1.0.1
-      with:
-        filename: repo-MagicSplit-latest-backup.zip
-        folderId: ${{ secrets.GDRIVE_FOLDER_ID }}
-        clientId: ${{ secrets.GDRIVE_CLIENT_ID }}
-        clientSecret: ${{ secrets.GDRIVE_CLIENT_SECRET }}
-        refreshToken: ${{ secrets.GDRIVE_REFRESH_TOKEN }}
-        authType: oauth
-        overwrite: true
+      env:
+        GDRIVE_CLIENT_ID: ${{ secrets.GDRIVE_CLIENT_ID }}
+        GDRIVE_CLIENT_SECRET: ${{ secrets.GDRIVE_CLIENT_SECRET }}
+        GDRIVE_REFRESH_TOKEN: ${{ secrets.GDRIVE_REFRESH_TOKEN }}
+        GDRIVE_FOLDER_ID: ${{ secrets.GDRIVE_FOLDER_ID }}
+      run: |
+        python3 << 'PYTHON'
+        import os
+        from google.oauth2.credentials import Credentials
+        from googleapiclient.discovery import build
+        from googleapiclient.http import MediaFileUpload
+
+        creds = Credentials(
+            token=None,
+            refresh_token=os.environ['GDRIVE_REFRESH_TOKEN'],
+            token_uri='https://oauth2.googleapis.com/token',
+            client_id=os.environ['GDRIVE_CLIENT_ID'],
+            client_secret=os.environ['GDRIVE_CLIENT_SECRET']
+        )
+
+        service = build('drive', 'v3', credentials=creds)
+        folder_id = os.environ['GDRIVE_FOLDER_ID']
+        filename = 'repo-MagicSplit-latest-backup.zip'
+
+        results = service.files().list(
+            q=f"name='{filename}' and '{folder_id}' in parents and trashed=false",
+            fields='files(id, name)'
+        ).execute()
+
+        existing = results.get('files', [])
+        media = MediaFileUpload(filename, mimetype='application/zip', resumable=True)
+
+        if existing:
+            service.files().update(fileId=existing[0]['id'], media_body=media).execute()
+            print(f'File updated: {filename}')
+        else:
+            metadata = {'name': filename, 'parents': [folder_id]}
+            service.files().create(body=metadata, media_body=media, fields='id').execute()
+            print(f'File created: {filename}')
+        PYTHON


### PR DESCRIPTION
## 문제

`logickoder/google-drive-upload@80e9dbe` 고정 커밋 액션이 OAuth2 `refresh_token`을 정상적으로 인식하지 못해 백업 워크플로우가 실패.

## 해결

StockAsset/pull/282 에서 동일하게 적용한 방식을 반영:

- `logickoder/google-drive-upload` 액션 제거
- `pip install google-auth google-auth-httplib2 google-api-python-client` 설치 단계 추가
- `google.oauth2.credentials.Credentials`로 refresh_token 기반 인증 직접 처리
- 기존 파일 존재 시 `files.update()`, 없으면 `files.create()` 실행

기존 시크릿(GDRIVE_CLIENT_ID, GDRIVE_CLIENT_SECRET, GDRIVE_REFRESH_TOKEN, GDRIVE_FOLDER_ID)은 변경 없이 그대로 사용.

https://claude.ai/code/session_014MpEiDu5TN1ULTRg4qEHQc

---
_Generated by [Claude Code](https://claude.ai/code/session_014MpEiDu5TN1ULTRg4qEHQc)_