### PR TITLE
feat: 수동매매에서 비활성 종목 매수 허용 (force=True)

### DIFF
--- a/scripts/manual_trade.py
+++ b/scripts/manual_trade.py
@@ -58,13 +58,6 @@ def main():
             f"'{args.ticker}' 종목이 없습니다."
         )
         sys.exit(1)
-    # 매수만 비활성 종목 차단. 매도는 청산 목적으로 허용 (엔진과 동일 정책).
-    if args.action == "buy" and not target_rule.enabled:
-        print(
-            f"에러: '{args.ticker}'는 비활성화 상태입니다. "
-            f"매수하려면 설정 파일에서 enabled=true 로 변경하세요."
-        )
-        sys.exit(1)
     market_type = target_rule.market_type
 
     log_dir = os.path.join(config.LOG_PATH, market_type)
@@ -108,6 +101,7 @@ def main():
             ticker=args.ticker,
             action=action,
             override_amount=args.amount,
+            force=True,
         )
     except Exception as e:
         logger.error(f"수동매매 중단: {e}")

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -325,6 +325,7 @@ class MagicSplitEngine:
         action: OrderAction,
         sim_date: Optional[str] = None,
         override_amount: Optional[float] = None,
+        force: bool = False,
     ) -> DayResult:
         """수동매매 1건을 실행한다.
 
@@ -353,7 +354,8 @@ class MagicSplitEngine:
         if target_rule is None:
             raise ValueError(f"설정에 등록되지 않은 종목입니다: {ticker}")
         # 비활성 종목은 매수만 차단. 매도는 잔여 포지션 청산을 위해 허용.
-        if not target_rule.enabled and action == OrderAction.BUY:
+        # force=True(수동매매 전용)이면 enabled 여부 무관하게 허용.
+        if not force and not target_rule.enabled and action == OrderAction.BUY:
             raise ValueError(
                 f"비활성화된 종목 매수 불가: {ticker}. "
                 f"config에서 enabled=true 설정 후 매수하세요. (매도는 청산 목적으로 허용됨)"

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -1050,6 +1050,50 @@ class TestRunManualTrade:
                 sim_date="2026-04-10",
             )
 
+    def test_force_buy_disabled_ticker_succeeds(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """force=True 이면 비활성 ticker BUY도 허용된다."""
+        rules = [
+            StockRule("MSFT", -5.0, 10.0, 500, 10, enabled=False),
+        ]
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={}, current_prices={"MSFT": 100.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"MSFT": 100.0}
+        mock_repo.load_positions.return_value = []
+        mock_repo.load_last_sell_prices.return_value = {}
+        mock_repo.get_realized_pnl_by_ticker.return_value = {}
+        mock_repo.get_last_trade_dates.return_value = {}
+        mock_broker.execute_orders.return_value = [
+            TradeExecution("MSFT", OrderAction.BUY, 5, 100.0, 0.5,
+                           "2026-06-18", ExecutionStatus.FILLED),
+        ]
+
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        result = eng.run_manual_trade(
+            ticker="MSFT", action=OrderAction.BUY,
+            sim_date="2026-06-18", force=True,
+        )
+
+        assert result.has_orders is True
+        saved = mock_repo.save_positions.call_args[0][0]
+        assert any(lot.ticker == "MSFT" for lot in saved)
+
+    def test_force_false_disabled_ticker_buy_still_raises(
+        self, mock_broker, mock_repo, mock_logger,
+    ):
+        """force=False(기본값)이면 비활성 ticker BUY는 여전히 ValueError."""
+        rules = [
+            StockRule("MSFT", -5.0, 10.0, 500, 10, enabled=False),
+        ]
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        with pytest.raises(ValueError, match="비활성화된 종목 매수 불가"):
+            eng.run_manual_trade(
+                ticker="MSFT", action=OrderAction.BUY,
+                sim_date="2026-06-18", force=False,
+            )
+
     def test_disabled_ticker_sell_allowed_for_liquidation(
         self, mock_broker, mock_repo, mock_logger,
     ):


### PR DESCRIPTION
## Summary

- `run_manual_trade()`에 `force: bool = False` 파라미터 추가
- `force=True`이면 `enabled:false` 종목도 매수/매도 허용 (수동매매 전용)
- `scripts/manual_trade.py`는 항상 `force=True`로 호출 → CLI/Actions에서 비활성 종목 매매 가능
- 자동매매 경로(`run_cycle`)는 `run_manual_trade()`를 호출하지 않으므로 영향 없음

## Changes

| 파일 | 변경 내용 |
|------|-----------|
| `src/core/engine/base.py` | `run_manual_trade()` 시그니처에 `force` 추가, enabled 체크에 `not force` 조건 삽입 |
| `scripts/manual_trade.py` | CLI 레벨 enabled 체크 블록 삭제, `force=True` 전달 |
| `tests/test_core_engine.py` | `force=True` 허용 / `force=False` 차단 테스트 2개 추가 |

## Test plan

- [x] `test_force_buy_disabled_ticker_succeeds` - force=True 이면 비활성 종목 BUY 성공
- [x] `test_force_false_disabled_ticker_buy_still_raises` - force=False(기본값)이면 여전히 ValueError
- [x] 기존 14개 TestRunManualTrade 테스트 전부 통과
- [x] 전체 391개 테스트 통과, 커버리지 90% (기준 80% 초과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1HAzXfZdjhn8uK67KceBB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1HAzXfZdjhn8uK67KceBB)_