### PR TITLE
fix: manual-trade.yml 로그 타임스탬프 UTC->KST 수정

### DIFF
--- a/.github/workflows/manual-trade.yml
+++ b/.github/workflows/manual-trade.yml
@@ -33,6 +33,8 @@ permissions:
 jobs:
   trade:
     runs-on: ubuntu-latest
+    env:
+      TZ: Asia/Seoul
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary

- `manual-trade.yml` job 레벨에 `TZ: Asia/Seoul` 추가
- 자동매매 워크플로우(`trading-bot-domestic.yml`, `trading-bot-overseas.yml`)에는 이미 설정되어 있었으나 수동매매 워크플로우에만 누락되어 있었음
- `datetime.now()`와 `logging.Formatter`의 `%(asctime)s`가 시스템 TZ를 따르므로, GitHub Actions 기본값인 UTC로 로그가 찍히던 문제 해결

## Test plan

- [ ] `pytest` 391 passed, 17 skipped 확인
- [ ] `manual-trade.yml` 실행 후 로그 타임스탬프가 KST(UTC+9)로 기록되는지 확인


---
_Generated by [Claude Code](https://claude.ai/code/session_01NpX62SGSq7uAZVLkfhQJi7)_