### PR TITLE
feat: 수동매매 UI에 종목별 일괄매도 버튼 추가

### DIFF
--- a/.github/workflows/manual-trade.yml
+++ b/.github/workflows/manual-trade.yml
@@ -15,12 +15,13 @@ on:
         required: true
         type: string
       action:
-        description: 'Order Action (qty is auto-derived: BUY=rule.buy_amount, SELL=highest-level lot full)'
+        description: 'Order Action (qty is auto-derived: BUY=rule.buy_amount, SELL=highest-level lot, SELL_ALL=all lots at once)'
         required: true
         type: choice
         options:
           - buy
           - sell
+          - sell_all
       amount:
         description: 'Buy amount override (KRW or USD). Leave empty to use config buy_amount.'
         required: false

--- a/docs/js/manual-trade.js
+++ b/docs/js/manual-trade.js
@@ -373,7 +373,7 @@
         if (isSellAll) {
             confirmMsg += `\n총 ${activeOrderParams.totalQty}주 전량 청산`;
         }
-        if (!isSellAll) {
+        if (isBuy) {
             confirmMsg += '\n(수량은 [금액 / 현재가]로 엔진이 자동 계산합니다)';
         }
         if (!confirm(confirmMsg)) {

--- a/docs/js/manual-trade.js
+++ b/docs/js/manual-trade.js
@@ -24,7 +24,7 @@
     const cancelTradeBtn = document.getElementById('cancel-trade-btn');
     const statusFeedback = document.getElementById('status-feedback');
 
-    let activeOrderParams = null; // { ticker, alias, action, marketType, configAmount }
+    let activeOrderParams = null; // { ticker, alias, action, marketType, configAmount, totalQty }
 
     /** market_type에 맞춰 통화 단위와 함께 금액을 포매팅한다. */
     function formatAmount(value, marketType) {
@@ -157,22 +157,23 @@
             if (!Array.isArray(posData)) {
                 Object.entries(posData).forEach(([ticker, info]) => {
                     const lots = info.lots || [];
-                    const maxLevel = lots.length > 0 
-                        ? Math.max(...lots.map(l => l.level || 0)) 
+                    const maxLevel = lots.length > 0
+                        ? Math.max(...lots.map(l => l.level || 0))
                         : 0;
                     const highestLot = lots.find(l => (l.level || 0) === maxLevel);
-                    statusMap[ticker] = { 
-                        level: maxLevel, 
+                    statusMap[ticker] = {
+                        level: maxLevel,
                         quantity: info.total_qty || 0,
-                        highestLvQty: highestLot ? highestLot.quantity : 0
+                        highestLvQty: highestLot ? highestLot.quantity : 0,
+                        lotsCount: lots.length,
                     };
                 });
             } else {
                 // Legacy: positions is a flat array of lots
                 posData.forEach(pos => {
                     const t = pos.ticker;
-                    if (!statusMap[t]) statusMap[t] = { level: 0, quantity: 0, highestLvQty: 0 };
-                    
+                    if (!statusMap[t]) statusMap[t] = { level: 0, quantity: 0, highestLvQty: 0, lotsCount: 0 };
+
                     if ((pos.level || 0) > statusMap[t].level) {
                         statusMap[t].level = pos.level || 0;
                         statusMap[t].highestLvQty = pos.quantity || 0;
@@ -180,14 +181,15 @@
                         statusMap[t].highestLvQty += (pos.quantity || 0);
                     }
                     statusMap[t].quantity += (pos.quantity || 0);
+                    statusMap[t].lotsCount += 1;
                 });
             }
         }
 
         tickers = stocks.map(rule => {
-            const status = statusMap[rule.ticker] || { level: 0, quantity: 0, highestLvQty: 0 };
+            const status = statusMap[rule.ticker] || { level: 0, quantity: 0, highestLvQty: 0, lotsCount: 0 };
             const resolvedAlias = rule.alias || tickerMap[rule.ticker] || rule.ticker;
-            
+
             return {
                 ticker: rule.ticker,
                 alias: resolvedAlias,
@@ -195,6 +197,7 @@
                 currentLevel: status.level,
                 currentQty: status.quantity,
                 highestLvQty: status.highestLvQty,
+                lotsCount: status.lotsCount,
                 config: rule
             };
         });
@@ -251,8 +254,19 @@
                 sellBtn.onclick = () => openOrderModal(t, 'sell');
             }
 
+            const sellAllBtn = document.createElement('button');
+            sellAllBtn.className = 'btn btn-sm btn-sell-all';
+            sellAllBtn.textContent = '일괄매도';
+            if (t.currentQty <= 0) {
+                sellAllBtn.style.opacity = '0.5';
+                sellAllBtn.style.cursor = 'not-allowed';
+            } else {
+                sellAllBtn.onclick = () => openOrderModal(t, 'sell_all');
+            }
+
             actionsTd.appendChild(buyBtn);
             actionsTd.appendChild(sellBtn);
+            actionsTd.appendChild(sellAllBtn);
 
             tr.appendChild(infoTd);
             tr.appendChild(statusTd);
@@ -267,7 +281,8 @@
             ? `${tickerObj.alias} (${tickerObj.ticker})`
             : tickerObj.ticker;
 
-        modalTitle.textContent = `${displayName} ${action === 'buy' ? '매수' : '매도'}`;
+        const actionLabel = action === 'buy' ? '매수' : action === 'sell_all' ? '일괄매도' : '매도';
+        modalTitle.textContent = `${displayName} ${actionLabel}`;
         statusFeedback.style.display = 'none';
         confirmTradeBtn.disabled = false;
         confirmTradeBtn.textContent = '실행';
@@ -302,6 +317,13 @@
                     설정값: ${formatAmount(configAmount, currentMarket)} — 변경하면 해당 금액으로 주문합니다.
                 </small>`;
             inputHint.parentNode.insertBefore(amountGroup, inputHint);
+        } else if (action === 'sell_all') {
+            const totalQty = tickerObj.currentQty || 0;
+            const lotsCount = tickerObj.lotsCount || 0;
+            orderSummary.innerHTML =
+                `보유 <b>${lotsCount}개 lot</b> (<b>총 ${totalQty}주</b>) 전량 일괄매도`;
+            inputHint.textContent =
+                '고차수부터 순차로 모든 lot을 한 번의 주문으로 청산합니다. 히스토리에 lot별 손익이 기록됩니다.';
         } else {
             const sellQty = tickerObj.highestLvQty || 0;
             orderSummary.innerHTML =
@@ -316,6 +338,7 @@
             action: action,
             marketType: currentMarket,
             configAmount: configAmount,
+            totalQty: tickerObj.currentQty,
         };
 
         orderModal.style.display = 'flex';
@@ -325,7 +348,8 @@
         if (!activeOrderParams || !githubApi) return;
 
         const isBuy = activeOrderParams.action === 'buy';
-        const actionLabel = isBuy ? '매수' : '매도';
+        const isSellAll = activeOrderParams.action === 'sell_all';
+        const actionLabel = isBuy ? '매수' : isSellAll ? '일괄매도' : '매도';
 
         const inputs = {
             market_type: activeOrderParams.marketType,
@@ -346,7 +370,12 @@
         if (isBuy && inputs.amount) {
             confirmMsg += `\n매수 금액: ${formatAmount(parseFloat(inputs.amount), activeOrderParams.marketType)}`;
         }
-        confirmMsg += '\n(수량은 [금액 / 현재가]로 엔진이 자동 계산합니다)';
+        if (isSellAll) {
+            confirmMsg += `\n총 ${activeOrderParams.totalQty}주 전량 청산`;
+        }
+        if (!isSellAll) {
+            confirmMsg += '\n(수량은 [금액 / 현재가]로 엔진이 자동 계산합니다)';
+        }
         if (!confirm(confirmMsg)) {
             return;
         }

--- a/docs/manual-trade.html
+++ b/docs/manual-trade.html
@@ -116,6 +116,11 @@
             color: white;
         }
 
+        .btn-sell-all {
+            background: #7c3aed;
+            color: white;
+        }
+
         /* Modal styling */
         .modal-overlay {
             position: fixed;
@@ -255,7 +260,7 @@
 
     <script src="js/services/data-repository.js?v=20260512-2"></script>
     <script src="js/services/github-api.js?v=20260512-2"></script>
-    <script src="js/manual-trade.js?v=20260602-2"></script>
+    <script src="js/manual-trade.js?v=20260619-1"></script>
 </body>
 
 </html>

--- a/scripts/manual_trade.py
+++ b/scripts/manual_trade.py
@@ -33,8 +33,8 @@ def parse_args():
     parser = argparse.ArgumentParser(description="수동 매매 스크립트")
     parser.add_argument("--ticker", required=True, help="종목 코드 (예: 005930, TSLA)")
     parser.add_argument(
-        "--action", required=True, choices=["buy", "sell"],
-        help="매수(buy) 또는 매도(sell). 수량은 자동 도출됨.",
+        "--action", required=True, choices=["buy", "sell", "sell_all"],
+        help="매수(buy), 매도(sell), 일괄매도(sell_all). 수량은 자동 도출됨.",
     )
     parser.add_argument(
         "--amount", type=float, default=None,
@@ -95,6 +95,7 @@ def main():
     )
 
     action = OrderAction.BUY if args.action == "buy" else OrderAction.SELL
+    is_sell_all = args.action == "sell_all"
 
     try:
         result = engine.run_manual_trade(
@@ -102,6 +103,7 @@ def main():
             action=action,
             override_amount=args.amount,
             force=True,
+            sell_all=is_sell_all,
         )
     except Exception as e:
         logger.error(f"수동매매 중단: {e}")

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -364,15 +364,20 @@ class MagicSplitEngine:
                 f"config에서 enabled=true 설정 후 매수하세요. (매도는 청산 목적으로 허용됨)"
             )
 
+        if sell_all and action != OrderAction.SELL:
+            raise ValueError("일괄매도(sell_all)는 매도(SELL) 작업에만 사용할 수 있습니다.")
+
         all_signals: List[SplitSignal] = []
         all_executions: List[TradeExecution] = []
         portfolio: Optional[Portfolio] = None
         positions: Optional[List[PositionLot]] = None
         last_sell_prices: dict = {}
+        regime_state: dict = {}
 
         try:
             # Step 1+2: 자동 사이클과 동일한 상태 로드 (공유 헬퍼)
             portfolio, positions, last_sell_prices = self._load_initial_state()
+            regime_state = self._load_regime_state()
             current_price = self._ensure_current_price(portfolio, ticker)
             if current_price <= 0:
                 raise RuntimeError(f"{disp} 현재가 조회 실패")
@@ -464,6 +469,7 @@ class MagicSplitEngine:
                     positions = self._update_positions(
                         positions, [signal], executions, today,
                         last_sell_prices=last_sell_prices,
+                        regime_state=regime_state,
                     )
                     portfolio = self._refresh_portfolio(portfolio)
                 except Exception as e:
@@ -484,6 +490,7 @@ class MagicSplitEngine:
                 self._persist(
                     portfolio, all_signals, all_executions, positions,
                     sim_date=sim_date, last_sell_prices=last_sell_prices,
+                    regime_state=regime_state,
                 )
 
         self.logger.set_ticker_context(None)

--- a/src/core/engine/base.py
+++ b/src/core/engine/base.py
@@ -326,12 +326,14 @@ class MagicSplitEngine:
         sim_date: Optional[str] = None,
         override_amount: Optional[float] = None,
         force: bool = False,
+        sell_all: bool = False,
     ) -> DayResult:
         """수동매매 1건을 실행한다.
 
         evaluate_stock 단계만 우회하고, 자동매매와 동일한 방식으로 모든 수량을 도출한다.
         - BUY: override_amount 지정 시 해당 금액, 없으면 rule.buy_amount_at(next_level) / 현재가
         - SELL: 최고 차수 lot.quantity 전량 매도 (사용자 입력 없음)
+        - SELL (sell_all=True): 보유 lot 전체 수량을 한 번에 일괄 청산
 
         후반부 파이프라인(주문 실행 -> 포지션 반영 -> 저장)은 자동매매와 100% 동일.
         max_lots 같은 안전 한도도 동일하게 적용된다.
@@ -342,6 +344,7 @@ class MagicSplitEngine:
             action: OrderAction.BUY 또는 OrderAction.SELL
             sim_date: 시뮬레이션 날짜 ("YYYY-MM-DD")
             override_amount: 매수 금액 직접 지정 (None이면 config buy_amount 사용)
+            sell_all: True이면 보유 lot 전체를 일괄 청산 (regime_liquidation 경로)
         """
         today = sim_date or datetime.now().strftime("%Y-%m-%d")
         disp = display_ticker(ticker)
@@ -378,6 +381,7 @@ class MagicSplitEngine:
             highest_level = max((lot.level for lot in ticker_lots), default=0)
             target_lot_id: Optional[str] = None
             target_buy_price: float = 0.0
+            is_bulk_sell: bool = False
 
             if action == OrderAction.BUY:
                 level = highest_level + 1
@@ -405,6 +409,18 @@ class MagicSplitEngine:
                     f"{format_money(buy_amount, self.market_type)} / 현재가="
                     f"{format_money(current_price, self.market_type)} = {order_qty}주"
                 )
+            elif sell_all:
+                # 일괄매도: 보유 lot 전체 수량 합산 -> regime_liquidation 경로로 전량 청산
+                if not ticker_lots:
+                    raise RuntimeError(
+                        f"{disp} 매도할 포지션이 존재하지 않습니다."
+                    )
+                order_qty = sum(lot.quantity for lot in ticker_lots)
+                level = highest_level
+                is_bulk_sell = True
+                self.logger.info(
+                    f"일괄매도 수량 도출: {len(ticker_lots)}개 lot 합산 {order_qty}주 전량"
+                )
             else:
                 # 매도: 자동매매와 동일하게 최고 차수 lot 전량 매도. 수량은 자동 도출.
                 if not ticker_lots:
@@ -426,10 +442,11 @@ class MagicSplitEngine:
                 action=action,
                 quantity=order_qty,
                 price=current_price,
-                reason="수동 매매(Manual Trade)",
+                reason="수동 일괄매도(Manual Bulk Sell)" if is_bulk_sell else "수동 매매(Manual Trade)",
                 pct_change=0.0,
                 level=level,
                 buy_price=target_buy_price,
+                regime_liquidation=is_bulk_sell,
             )
             all_signals.append(signal)
             self.logger.info(

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -1192,6 +1192,169 @@ class TestRunManualTrade:
         alert_msgs = [c.args[0] for c in notifier.send_alert.call_args_list]
         assert any("수동매매" in m and "체결 실패 또는 거절" in m for m in alert_msgs)
 
+    # ── sell_all 관련 테스트 ────────────────────────────────────────
+
+    def test_sell_all_drains_all_lots(self, mock_broker, mock_repo, mock_logger):
+        """sell_all=True: 전체 lot 수량 합산해 regime_liquidation 신호 생성, 전량 청산."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={"AAPL": 10},
+            current_prices={"AAPL": 110.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 110.0}
+        mock_repo.load_positions.return_value = [
+            PositionLot("lot_lv1", "AAPL", 100.0, 5, "2026-04-01", level=1),
+            PositionLot("lot_lv2", "AAPL", 95.0, 3, "2026-04-05", level=2),
+            PositionLot("lot_lv3", "AAPL", 90.0, 2, "2026-04-08", level=3),
+        ]
+        mock_repo.load_last_sell_prices.return_value = {}
+        mock_repo.load_status.return_value = {}
+        mock_broker.execute_orders.return_value = [
+            TradeExecution("AAPL", OrderAction.SELL, 10, 110.0, 0.5,
+                           "2026-04-10", ExecutionStatus.FILLED),
+        ]
+        mock_repo.get_realized_pnl_by_ticker.return_value = {}
+        mock_repo.get_last_trade_dates.return_value = {}
+
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        result = eng.run_manual_trade(
+            ticker="AAPL", action=OrderAction.SELL,
+            sim_date="2026-04-10", sell_all=True,
+        )
+
+        # 신호: regime_liquidation=True, lot_id=None, 수량=전체 합산
+        assert len(result.signals) == 1
+        sig = result.signals[0]
+        assert sig.regime_liquidation is True
+        assert sig.lot_id is None
+        assert sig.quantity == 10  # 5+3+2
+        assert sig.level == 3     # 최고 차수
+        assert sig.reason == "수동 일괄매도(Manual Bulk Sell)"
+
+        # 브로커 주문: 합산 수량 전달
+        sent = mock_broker.execute_orders.call_args[0][0]
+        assert sent[0].quantity == 10
+
+        # 포지션: 전량 제거
+        saved = mock_repo.save_positions.call_args[0][0]
+        assert all(l.ticker != "AAPL" for l in saved)
+
+        # last_sell_prices 갱신
+        lsp = mock_repo.save_last_sell_prices.call_args[0][0]
+        assert lsp["AAPL"] == 110.0
+
+    def test_sell_all_no_positions_raises(self, mock_broker, mock_repo, mock_logger):
+        """sell_all=True + 보유 없음 -> RuntimeError."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={}, current_prices={"AAPL": 100.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 100.0}
+        mock_repo.load_positions.return_value = []
+        mock_repo.load_last_sell_prices.return_value = {}
+        mock_repo.load_status.return_value = {}
+
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        with pytest.raises(RuntimeError, match="매도할 포지션"):
+            eng.run_manual_trade(
+                ticker="AAPL", action=OrderAction.SELL,
+                sim_date="2026-04-10", sell_all=True,
+            )
+
+    def test_sell_all_with_buy_action_raises(self, mock_broker, mock_repo, mock_logger):
+        """sell_all=True + action=BUY -> ValueError (방어 검증)."""
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        with pytest.raises(ValueError, match="일괄매도"):
+            eng.run_manual_trade(
+                ticker="AAPL", action=OrderAction.BUY,
+                sim_date="2026-04-10", sell_all=True,
+            )
+
+    def test_sell_all_clears_ticker_regime_state_on_full_liquidation(
+        self, mock_broker, mock_repo, mock_logger
+    ):
+        """sell_all 전량 체결 후 해당 종목 regime_state가 pop되고
+        다른 종목(MSFT) 상태는 그대로 build_dashboard_status에 전달된다."""
+        from unittest.mock import patch
+        rules = [
+            StockRule("AAPL", -5.0, 10.0, 500, 10),
+            StockRule("MSFT", -5.0, 10.0, 500, 10),
+        ]
+        existing_regime = {
+            "AAPL": {"regime": "uptrend", "adds": 2},
+            "MSFT": {"regime": "uptrend", "adds": 1},
+        }
+        mock_repo.load_status.return_value = {"regime_state_by_ticker": existing_regime}
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={"AAPL": 8},
+            current_prices={"AAPL": 110.0, "MSFT": 200.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 110.0}
+        mock_repo.load_positions.return_value = [
+            PositionLot("lot_lv1", "AAPL", 100.0, 5, "2026-04-01", level=1),
+            PositionLot("lot_lv2", "AAPL", 95.0, 3, "2026-04-05", level=2),
+        ]
+        mock_repo.load_last_sell_prices.return_value = {}
+        mock_broker.execute_orders.return_value = [
+            TradeExecution("AAPL", OrderAction.SELL, 8, 110.0, 0.5,
+                           "2026-04-10", ExecutionStatus.FILLED),
+        ]
+        mock_repo.get_realized_pnl_by_ticker.return_value = {}
+        mock_repo.get_last_trade_dates.return_value = {}
+
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        with patch("src.core.engine.base.build_dashboard_status") as mock_build:
+            mock_build.return_value = {}
+            eng.run_manual_trade(
+                ticker="AAPL", action=OrderAction.SELL,
+                sim_date="2026-04-10", sell_all=True,
+            )
+
+        _, kwargs = mock_build.call_args
+        passed_regime = kwargs.get("regime_state_by_ticker")
+        # AAPL은 전량 청산 후 pop
+        assert "AAPL" not in passed_regime
+        # MSFT는 건드리지 않음
+        assert passed_regime.get("MSFT", {}).get("adds") == 1
+
+    def test_regime_state_preserved_for_other_tickers_on_regular_sell(
+        self, mock_broker, mock_repo, mock_logger
+    ):
+        """일반 매도(sell)도 regime_state를 로드해 다른 종목 상태가 보존된다 (버그 수정 검증)."""
+        from unittest.mock import patch
+        rules = [StockRule("AAPL", -5.0, 10.0, 500, 10)]
+        existing_regime = {"TSLA": {"regime": "uptrend", "adds": 3}}
+        mock_repo.load_status.return_value = {"regime_state_by_ticker": existing_regime}
+        mock_broker.get_portfolio.return_value = Portfolio(
+            total_cash=10000.0, holdings={"AAPL": 5},
+            current_prices={"AAPL": 110.0},
+        )
+        mock_broker.fetch_current_prices.return_value = {"AAPL": 110.0}
+        mock_repo.load_positions.return_value = [
+            PositionLot("lot_lv1", "AAPL", 100.0, 5, "2026-04-01", level=1),
+        ]
+        mock_repo.load_last_sell_prices.return_value = {}
+        mock_broker.execute_orders.return_value = [
+            TradeExecution("AAPL", OrderAction.SELL, 5, 110.0, 0.5,
+                           "2026-04-10", ExecutionStatus.FILLED),
+        ]
+        mock_repo.get_realized_pnl_by_ticker.return_value = {}
+        mock_repo.get_last_trade_dates.return_value = {}
+
+        eng = self._make_engine(mock_broker, mock_repo, mock_logger, rules)
+        with patch("src.core.engine.base.build_dashboard_status") as mock_build:
+            mock_build.return_value = {}
+            eng.run_manual_trade(
+                ticker="AAPL", action=OrderAction.SELL,
+                sim_date="2026-04-10",
+            )
+
+        _, kwargs = mock_build.call_args
+        passed_regime = kwargs.get("regime_state_by_ticker")
+        # TSLA regime_state가 status.json에 그대로 보존되어야 함
+        assert passed_regime.get("TSLA", {}).get("adds") == 3
+
 
 class TestRegimeAddCommitOnFill:
     """상승 add는 매수 체결이 확정될 때만 regime_state를 갱신한다 (백테스트/라이브 동일)."""


### PR DESCRIPTION
## Summary

- 수동매매 페이지(`manual-trade.html`) 각 종목 행에 **일괄매도** 버튼 추가
- 클릭 시 "N개 lot / 총 X주 전량 청산" 확인 모달 표시 후 `sell_all` 액션으로 workflow dispatch
- 백엔드: `run_manual_trade(sell_all=True)` → 보유 lot 전체 합산 → `regime_liquidation=True` 신호 → 기존 `_apply_bulk_liquidation()` 경로 (단일 주문 + lot별 손익 분해 기록)

## Changes

| 파일 | 변경 |
|------|------|
| `src/core/engine/base.py` | `run_manual_trade`에 `sell_all` 파라미터 추가, lot 합산 → `regime_liquidation` 신호 생성 |
| `scripts/manual_trade.py` | `--action sell_all` 지원 추가 |
| `.github/workflows/manual-trade.yml` | action choices에 `sell_all` 추가 |
| `docs/js/manual-trade.js` | 일괄매도 버튼 렌더링, 모달 내용, workflow dispatch |
| `docs/manual-trade.html` | `.btn-sell-all` 스타일(보라색), 캐시 버스터 갱신 |

## Test plan

- [x] `pytest` 398 tests passed
- [ ] UI: 종목 행에 보라색 "일괄매도" 버튼 표시 확인
- [ ] UI: 포지션 없는 종목은 버튼 비활성화(opacity) 확인
- [ ] UI: 확인 모달에 "N개 lot / 총 X주 전량 일괄매도" 문구 표시 확인
- [ ] Actions: `sell_all` 선택지 노출 확인
- [ ] 실거래: `run_manual_trade(sell_all=True)` → 단일 주문으로 전량 청산, history에 lot별 손익 기록 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011f8835hbkPUZamC8C7vwHU

---
_Generated by [Claude Code](https://claude.ai/code/session_011f8835hbkPUZamC8C7vwHU)_